### PR TITLE
Add basic P2P wireless capabilities and a remote player discovery

### DIFF
--- a/include/wireless/esp-now-comms.hpp
+++ b/include/wireless/esp-now-comms.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <vector>
+#include <queue>
+#include <unordered_map>
+#include <esp_now.h>
+
+//Change to 1 to enable tracking rssi for peers
+//This works, but requires wifi to be in promiscuous mode
+//which likely prevents connecting to access points and
+//requires an unknown but likely high amount of processing
+//power
+#define PDN_ENABLE_RSSI_TRACKING 0
+
+//Use this mac address in order to reach all nearby devices
+const uint8_t ESP_NOW_BROADCAST_ADDR[ESP_NOW_ETH_ALEN] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
+//PktType determines which callback will handle the packet on the receiving end
+enum class PktType : uint8_t
+{
+    kPlayerInfoBroadcast = 0,
+    kNumPacketTypes //Not a real packet type, DO NOT USE
+};
+
+
+//Singleton class that handles communication over ESP-NOW protocol.
+class EspNowManager
+{
+public:
+    static EspNowManager* GetInstance();
+
+    void Update();
+
+    //Queues up data for sending, may not send right away
+    int SendData(const uint8_t* dstMac, const PktType packetType, const uint8_t* data, size_t len);
+
+    //Type for packet handler callbacks (as function pointers)
+    typedef void(*PktHandler)(const uint8_t* srcMacAddr, const uint8_t* data, const size_t len, void* userArg);
+
+    //Set the packet handler for a particular packet type
+    //Only one handler can be registered per packet type at a time, so if a new
+    //packet handler is registered for a packet type that has an existing handler,
+    //the existing handler is automatically unregistered
+    //userArg will be saved per packet type and will be passed in unmodified to
+    //packet handler for that packet type (when a packet of that type is receieved)
+    void SetPacketHandler(const PktType packetType, PktHandler callback, void* userArg);
+
+    //Unregister packet handler for specified packet type
+    void ClearPacketHandler(const PktType packetType);
+
+#if PDN_ENABLE_RSSI_TRACKING
+    int GetRssiForPeer(const uint8_t* macAddr);
+#endif
+
+private:
+    EspNowManager();
+
+#if PDN_ENABLE_RSSI_TRACKING
+    //Callback for receiving raw Wifi packets, used for rssi tracking
+    static void WifiPromiscuousRecvCallback(void *buf, wifi_promiscuous_pkt_type_t type);
+#endif
+
+    //ESP-NOW callbacks
+    static void EspNowRecvCallback(const uint8_t *mac_addr, const uint8_t *data, int data_len);
+    static void EspNowSendCallback(const uint8_t *mac_addr, esp_now_send_status_t status);
+
+    //Attempt to send the next packet in send queue
+    int SendFrontPkt();
+
+    //Free front packet in send queue and pop it from queue
+    void MoveToNextSendPkt();
+
+    //ESP-NOW requires peers to be registered but there's a limit,
+    //so we'll need to unregister least recently used peer if we
+    //hit the limit. This function will ensure a peer is registered.
+    int EnsurePeerIsRegistered(const uint8_t* mac_addr);
+
+    //Storage for packet handler callbacks and their user args
+    std::vector<std::pair<PktHandler, void*> > m_pktHandlerCallbacks;
+
+    //Handle received packet of a certain type
+    void HandlePktCallback(const PktType packetType, const uint8_t* srcMacAddr, const uint8_t* pktData, const size_t pktLen);
+
+    //Storage for retry handling
+    uint8_t m_maxRetries;
+    uint8_t m_curRetries;
+
+    //Send queue stores packets to send using DataSendBuffer
+    struct DataSendBuffer
+    {
+        uint8_t dstMac[6];
+        uint8_t* ptr;
+        size_t len;
+    };
+
+    //Packet send queue
+    std::queue<DataSendBuffer> m_sendQueue;
+
+    //When receiving a buffer that's split across multiple packets,
+    //this struct will track the data while it's being received
+    struct DataRecvBuffer
+    {
+        uint8_t* data;
+        unsigned long mostRecentRecvPktTime;
+        uint8_t expectedNextIdx;
+    };
+    std::unordered_map<uint64_t, DataRecvBuffer> m_recvBuffers;
+
+#if PDN_ENABLE_RSSI_TRACKING
+    //Storage for rssi, which is captured by wifi promiscuous callback
+    std::unordered_map<uint64_t, int> m_rssiTracker;
+#endif
+};

--- a/include/wireless/remote-player-manager.hpp
+++ b/include/wireless/remote-player-manager.hpp
@@ -1,5 +1,6 @@
 #include <vector>
 #include <esp_now.h>
+#include <cstring>  // For memcpy
 
 #include "player.hpp"
 
@@ -10,7 +11,7 @@ struct RemotePlayer
     unsigned long lastSeenTime;
     signed rssi;
 
-    RemotePlayer(const uint8_t* macAddr, String id, Allegiance allegiance, bool isHunter,
+    RemotePlayer(const uint8_t* macAddr, string id, Allegiance allegiance, bool isHunter,
                  unsigned long lastSeen, signed rssiDb) :
                  playerInfo(id, allegiance, isHunter),
                  lastSeenTime(lastSeen),

--- a/include/wireless/remote-player-manager.hpp
+++ b/include/wireless/remote-player-manager.hpp
@@ -1,0 +1,46 @@
+#include <vector>
+#include <esp_now.h>
+
+#include "player.hpp"
+
+struct RemotePlayer
+{
+    uint8_t wifiMacAddr[ESP_NOW_ETH_ALEN];
+    Player playerInfo;
+    unsigned long lastSeenTime;
+    signed rssi;
+
+    RemotePlayer(const uint8_t* macAddr, String id, Allegiance allegiance, bool isHunter,
+                 unsigned long lastSeen, signed rssiDb) :
+                 playerInfo(id, allegiance, isHunter),
+                 lastSeenTime(lastSeen),
+                 rssi(rssiDb)
+    {
+        memcpy(wifiMacAddr, macAddr, ESP_NOW_ETH_ALEN);
+    }
+};
+
+class RemotePlayerManager
+{
+public:
+    RemotePlayerManager();
+
+    void Update();
+
+    void StartBroadcastingPlayerInfo(Player* playerInfo, unsigned long broadcastIntervalMillis);
+    
+    void SetRemotePlayerTTL(unsigned long ttl);
+    unsigned long GetRemotePlayerTTL();
+
+    int ProcessPlayerInfoPkt(const uint8_t* srcMacAddr, const uint8_t* data, const size_t dataLen);
+
+protected:
+    int BroadcastPlayerInfo();
+
+    Player* m_localPlayerInfo;
+    std::vector<RemotePlayer> m_remotePlayers;
+    unsigned long m_remotePlayerTTL;
+    unsigned long m_broadcastInterval;
+    unsigned long m_lastBroadcastTime;
+
+};

--- a/lib/pdn-libs/player.hpp
+++ b/lib/pdn-libs/player.hpp
@@ -15,6 +15,10 @@ enum class Allegiance {
 
 class Player {
 public:
+    Player() = default;
+    
+    Player(const string id0, const Allegiance allegiance0, const bool isHunter0);
+    
     string toJson() const;
 
     void fromJson(const string &json);

--- a/src/device/pdn.cpp
+++ b/src/device/pdn.cpp
@@ -26,6 +26,14 @@ int PDN::begin() {
     FastLED.clear();
     FastLED.show();
 
+    //Initialize PSRAM which can be used as
+    //extra heap space by allocating using
+    //ps_malloc instead of malloc
+    if(psramInit())
+    {
+        Serial.println("PSRAM initialized");
+    }
+
     return 1;
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2,6 +2,12 @@
 #include <memory>
 #include <ArduinoJson.h>
 
+Player::Player(const string id0, const Allegiance allegiance0, const bool isHunter0) :
+  id(id0),
+  allegiance(allegiance0),
+  hunter(isHunter0)
+{
+}
 
 
 string Player::toJson() const {

--- a/src/wireless/esp-now-comms.cpp
+++ b/src/wireless/esp-now-comms.cpp
@@ -3,8 +3,7 @@
 #include <esp_now.h>
 #include <esp_wifi.h>
 
-#include "../include/esp-now-comms.hpp"
-#include "esp-now-comms.hpp"
+#include "wireless/esp-now-comms.hpp"
 
 #define DEBUG_PRINT_ESP_NOW 0
 

--- a/src/wireless/esp-now-comms.cpp
+++ b/src/wireless/esp-now-comms.cpp
@@ -1,0 +1,427 @@
+#include <algorithm>
+#include <Arduino.h> //For Serial, may be replaced with more specific header?
+#include <esp_now.h>
+#include <esp_wifi.h>
+
+#include "../include/esp-now-comms.hpp"
+#include "esp-now-comms.hpp"
+
+#define DEBUG_PRINT_ESP_NOW 0
+
+
+struct DataPktHdr
+{
+    //Total packet length including header
+    uint8_t pktLen;
+    PktType packetType;
+    uint8_t numPktsInCluster;
+    uint8_t idxInCluster;
+} __attribute__((packed));
+
+constexpr size_t MAX_PKT_DATA_SIZE = ESP_NOW_MAX_DATA_LEN - sizeof(DataPktHdr);
+
+static uint64_t MacToUInt64(const uint8_t* macAddr)
+{
+    uint64_t tmp = 0;
+    for(int i = 0; i < ESP_NOW_ETH_ALEN; ++i)
+        tmp = (tmp << 8) + macAddr[i];
+
+    return tmp;
+}
+
+static const char* MacToString(const uint8_t* macAddr)
+{
+    static char macStr[18];
+    snprintf(macStr, 18, "%X:%X:%X:%X:%X:%X",
+        macAddr[0], macAddr[1], macAddr[2],
+        macAddr[3], macAddr[4], macAddr[5]);
+        macStr[17] = '\0';
+    return macStr;
+}
+
+EspNowManager *EspNowManager::GetInstance()
+{
+    static EspNowManager instance;
+    return &instance;
+}
+
+void EspNowManager::Update()
+{
+    //TODO: Is this actually needed anymore?
+}
+
+EspNowManager::EspNowManager() :
+    m_pktHandlerCallbacks((int)PktType::kNumPacketTypes, std::pair<PktHandler, void*>(nullptr, nullptr)),
+    m_maxRetries(5),
+    m_curRetries(0)
+{
+#if PDN_ENABLE_RSSI_TRACKING
+    wifi_promiscuous_filter_t filter = {
+		.filter_mask = WIFI_PROMIS_FILTER_MASK_MGMT};
+	esp_wifi_set_promiscuous_filter(&filter);
+    esp_wifi_set_promiscuous_rx_cb(EspNowManager::WifiPromiscuousRecvCallback);
+    esp_wifi_set_promiscuous(true);
+#endif
+
+    //Initialize Wifi + ESP-NOW
+    esp_err_t err = esp_now_init();
+    if(err != ESP_OK)
+    {
+        Serial.printf("ESPNOW failed to init: 0x%X\n", err);
+    }
+    else
+    {
+        //Register callbacks
+        esp_err_t err = esp_now_register_recv_cb(EspNowManager::EspNowRecvCallback);
+        if(err != ESP_OK)
+            Serial.printf("ESPNOW Error registering recv cb: 0x%X\n", err);
+        err = esp_now_register_send_cb(EspNowManager::EspNowSendCallback);
+        if(err != ESP_OK)
+            Serial.printf("ESPNOW Error registering send cb: 0x%X\n", err);
+
+        //Register broadcast peer
+        esp_now_peer_info_t broadcastPeer = {};
+        memcpy(broadcastPeer.peer_addr, ESP_NOW_BROADCAST_ADDR, ESP_NOW_ETH_ALEN);
+        err = esp_now_add_peer(&broadcastPeer);
+        if(err != ESP_OK)
+            Serial.printf("ESPNOW Error registering broadcast peer: 0x%X\n", err);
+
+        Serial.println("ESPNOW Comms initialized");
+    }
+}
+
+#if PDN_ENABLE_RSSI_TRACKING
+void EspNowManager::WifiPromiscuousRecvCallback(void *buf, wifi_promiscuous_pkt_type_t type)
+{
+    const wifi_promiscuous_pkt_t* pkt = (wifi_promiscuous_pkt_t*)buf;
+
+    //TODO: Filter to make sure it's an Action frame
+    
+    //ESP-NOW uses category type 127 in vendor specific action frames (a type of mgmt frame)
+    if(pkt->payload[24] != 127)
+        return;
+    
+    int rssi = pkt->rx_ctrl.rssi;
+    //2 bytes for frame control
+    //2 bytes for duration id
+    //6 bytes for first mac addr (which is receiver)
+    //=10 byte offset to get to sender
+    const uint8_t* srcMac = (pkt->payload) + 10;
+    uint64_t srcMac64 = MacToUInt64(srcMac);
+
+    EspNowManager::GetInstance()->m_rssiTracker[srcMac64] = rssi;
+    
+}
+#endif
+
+int EspNowManager::SendData(const uint8_t* dstMac, const PktType packetType, const uint8_t *data, size_t len)
+{
+    if(len > (255 * MAX_PKT_DATA_SIZE))
+    {
+        Serial.printf("ESP-NOW Error: Tried to send too large of buffer: %u of max %u\n",
+            len, 
+            255 * MAX_PKT_DATA_SIZE);
+        return -1;
+    }
+
+    //Calculate the total number of ESP_NOW_MAX_DATA_LEN (250) byte packets we'll 
+    //need to send the whole buffer
+    uint8_t numInCluster = len / MAX_PKT_DATA_SIZE + 
+                           (len % MAX_PKT_DATA_SIZE == 0 ? 0 : 1);
+    
+    //Allocate entire send buffer up front so we don't fail an allocation part way through
+    //the cluster
+    //We'll use alloca for tracking the buffers while we set them up since this should
+    //require a very small amount of memory making the risk of stack overflow very small
+    //This will also be much faster than malloc/free which would be wasteful for such a
+    //small allocation
+    uint8_t** sendBuffers = (uint8_t**)alloca(sizeof(uint8_t*) * numInCluster);
+    size_t bytesLeft = len;
+    for(int i = 0; i < numInCluster; ++i)
+    {
+        size_t thisBuffer = std::min(bytesLeft, MAX_PKT_DATA_SIZE);
+        sendBuffers[i] = (uint8_t*)ps_malloc(sizeof(DataPktHdr) + thisBuffer);
+        if(!sendBuffers[i])
+        {
+            //free anything we already allocated
+            for(int j = 0; j < i; ++j)
+                free(sendBuffers[j]);
+
+            //TODO: Change to use error logging and return better error code once we have them
+            Serial.println("Failed to allocate buffers for ESP-NOW send queue");
+            Serial.printf("Needed to allocate a total of %lu bytes\n", len);
+            return -1;
+        }
+        bytesLeft -= thisBuffer;
+    }
+
+    //Before we start filling the send queue, see if we'll need to start
+    //sending afterwards
+    bool willNeedToStartSend = m_sendQueue.empty();
+
+    //Build up each packet
+    bytesLeft = len;
+    for(int pktIdx = 0; pktIdx < numInCluster; ++pktIdx)
+    {
+        size_t thisBuffer = std::min(bytesLeft, MAX_PKT_DATA_SIZE);
+#if DEBUG_PRINT_ESP_NOW
+        Serial.printf("ESPNOW SendData pktIdx: %i thisBuffer: %u\n", pktIdx, thisBuffer);
+#endif
+
+        //Each packet needs a header, build it directly in the send buffer
+        DataPktHdr* hdr = (DataPktHdr*)sendBuffers[pktIdx];
+        hdr->idxInCluster = pktIdx;
+        hdr->numPktsInCluster = numInCluster;
+        hdr->pktLen = sizeof(DataPktHdr) + thisBuffer;
+        hdr->packetType = packetType;
+
+        //Copy the actual data into the send buffer following the header
+        size_t dataOffset = pktIdx * MAX_PKT_DATA_SIZE;
+        memcpy(sendBuffers[pktIdx] + sizeof(DataPktHdr), data + dataOffset, thisBuffer);
+
+        //Now add it to the send queue
+        DataSendBuffer buffer;
+        memcpy(buffer.dstMac, dstMac, ESP_NOW_ETH_ALEN);
+        buffer.ptr = sendBuffers[pktIdx];
+        buffer.len = hdr->pktLen;
+        m_sendQueue.push(buffer);
+
+        bytesLeft -= thisBuffer;
+    }
+
+    //Check if this is the first packet in the queue
+    if(willNeedToStartSend)
+    {
+        SendFrontPkt();
+    }
+    return 0;
+}
+
+void EspNowManager::SetPacketHandler(const PktType packetType, PktHandler callback, void* userArg)
+{
+    m_pktHandlerCallbacks[(int)packetType].first = callback;
+    m_pktHandlerCallbacks[(int)packetType].second = userArg;
+}
+
+void EspNowManager::ClearPacketHandler(const PktType packetType)
+{
+    m_pktHandlerCallbacks[(int)packetType].first = nullptr;
+}
+
+#if PDN_ENABLE_RSSI_TRACKING
+int EspNowManager::GetRssiForPeer(const uint8_t *macAddr)
+{
+    uint64_t macAddr64 = MacToUInt64(macAddr);
+    if(m_rssiTracker.count(macAddr64) > 0)
+        return m_rssiTracker[macAddr64];
+    return -1;
+}
+#endif
+
+void EspNowManager::EspNowRecvCallback(const uint8_t *mac_addr, const uint8_t *data, int data_len)
+{
+    EspNowManager* manager = EspNowManager::GetInstance();
+
+#if DEBUG_PRINT_ESP_NOW
+    Serial.printf("ESPNOW Recv Callback len %i from %X:%X:%X:%X:%X:%X\n", data_len,
+        mac_addr[0], mac_addr[1], mac_addr[2],
+        mac_addr[3], mac_addr[4], mac_addr[5]);
+
+    for(int i = 36; i < 41; ++i)
+         Serial.printf("0x%X ", data[i]);
+    Serial.printf("\n");
+#endif
+
+    //Make sure received packet is at least min length
+    if(data_len < sizeof(DataPktHdr))
+    {
+        Serial.printf("[ESPNOW] Recieved buffer (%i bytes) was smaller than header (%u)\n", data_len, sizeof(DataPktHdr));
+        return;
+    }
+
+    const DataPktHdr* pktHdr = (const DataPktHdr*)data;
+    //auto rssi = esp_now_info->rx_ctrl->rssi;
+
+#if DEBUG_PRINT_ESP_NOW
+    //Serial.printf("Packet Type: %i\n", pktHdr->packetType);
+#endif
+
+    //Check for multipacket cluster
+    if(pktHdr->numPktsInCluster > 1)
+    {
+        //Need a static array to use as map key
+        //TODO: Is there a way to just cast mac_addr?
+        uint64_t tmpMacAddr = MacToUInt64(mac_addr);
+        //If this is the first packet, we'll need some special handling
+        if(pktHdr->idxInCluster == 0)
+        {
+            //If there's an existing cluster for this mac address, release it
+            //as that means we lost a packet somewhere
+            auto existingBuffer = manager->m_recvBuffers.find(tmpMacAddr);
+            if(existingBuffer != manager->m_recvBuffers.end())
+            {
+                free(existingBuffer->second.data);
+                manager->m_recvBuffers.erase(existingBuffer);
+            }
+
+            DataRecvBuffer newBuffer;
+            newBuffer.data = (uint8_t*)ps_malloc(pktHdr->numPktsInCluster * MAX_PKT_DATA_SIZE);
+            newBuffer.expectedNextIdx = 1;
+        }
+        {
+            auto existingBuffer = manager->m_recvBuffers.find(tmpMacAddr);
+            //At this point, we should have a recv buffer for this mac address
+            //if we don't, we missed the start packet in this cluster
+            if(existingBuffer != manager->m_recvBuffers.end())
+            {
+                DataRecvBuffer recvBuffer = existingBuffer->second;
+                if(pktHdr->idxInCluster != recvBuffer.expectedNextIdx)
+                {
+                    Serial.printf("Received pkt %u when expecting %u. Must have missed a packet in cluster.\n",
+                                  recvBuffer.expectedNextIdx,
+                                  pktHdr->idxInCluster);
+                    free(recvBuffer.data);
+                    manager->m_recvBuffers.erase(existingBuffer);
+                    return;
+                }
+
+                //Copy data into our recv buffer
+                size_t bufferOffset = pktHdr->idxInCluster * MAX_PKT_DATA_SIZE;
+                memcpy(recvBuffer.data + bufferOffset, data + sizeof(DataPktHdr), pktHdr->pktLen - sizeof(DataPktHdr));
+                ++existingBuffer->second.expectedNextIdx;
+                
+                //Check for this being the last packet in cluster
+                if(existingBuffer->second.expectedNextIdx == pktHdr->numPktsInCluster)
+                {
+                    size_t totalClusterSize = (pktHdr->numPktsInCluster - 1) * MAX_PKT_DATA_SIZE;
+                    totalClusterSize += pktHdr->pktLen - sizeof(DataPktHdr);
+                    manager->HandlePktCallback(pktHdr->packetType, mac_addr, recvBuffer.data, totalClusterSize);
+                    free(recvBuffer.data);
+                    manager->m_recvBuffers.erase(existingBuffer);
+                    return;
+                }
+            }
+            else
+            {
+                Serial.println("No recv buffer for mid cluster pkt. We must have missed first pkt.");
+                return;
+            }
+        }
+    }
+    else
+    {
+        //Single packet cluster
+        manager->HandlePktCallback(pktHdr->packetType, mac_addr, data + sizeof(DataPktHdr), pktHdr->pktLen - sizeof(DataPktHdr));
+    }
+}
+
+void EspNowManager::EspNowSendCallback(const uint8_t *mac_addr, esp_now_send_status_t status)
+{
+    EspNowManager* manager = EspNowManager::GetInstance();
+
+#if DEBUG_PRINT_ESP_NOW
+    Serial.println("ESPNOW Send Callback");
+#endif
+
+    if(status == ESP_NOW_SEND_SUCCESS)
+    {
+        manager->MoveToNextSendPkt();
+    }
+    else
+    {
+        if(manager->m_curRetries < manager->m_maxRetries)
+        {
+            Serial.println("ESPNOW Failed send, retrying");
+            ++manager->m_curRetries;
+        }
+        else
+        {
+            Serial.println("ESPNOW Failed send, giving up");
+            manager->MoveToNextSendPkt();
+        }
+    }
+
+    if(!manager->m_sendQueue.empty())
+    {
+        //TODO: Catch error and do reporting and push to next pkt
+        manager->SendFrontPkt();
+    }
+}
+
+int EspNowManager::SendFrontPkt()
+{
+    DataSendBuffer buffer = m_sendQueue.front();
+    
+    //If this is the first packet in cluster, make sure the peer is registered
+    DataPktHdr* hdr = (DataPktHdr*)buffer.ptr;
+    if(hdr->idxInCluster == 0 && (memcmp(buffer.dstMac, ESP_NOW_BROADCAST_ADDR, ESP_NOW_ETH_ALEN) != 0))
+        EnsurePeerIsRegistered(buffer.dstMac);
+
+    esp_err_t err;
+    do
+    {
+        err = esp_now_send(buffer.dstMac, buffer.ptr, buffer.len);
+        if(err != ESP_OK)
+        {
+            ++m_curRetries;
+            if(m_curRetries >= m_maxRetries)
+            {
+                Serial.printf("ESPNOW Failed after max retries. Err: %i\n", err);
+                //TODO: Pop all packets in the current cluster?
+                MoveToNextSendPkt();
+                if(!m_sendQueue.empty())
+                    SendFrontPkt();
+                //TODO: Return correct error code
+                return -1;
+            }
+        }
+    } while (err != ESP_OK);
+    
+    return 0;
+}
+
+void EspNowManager::MoveToNextSendPkt()
+{
+        free(m_sendQueue.front().ptr);
+        m_sendQueue.pop();
+        m_curRetries = 0;
+}
+
+int EspNowManager::EnsurePeerIsRegistered(const uint8_t *mac_addr)
+{
+    //Peer already registered
+    if(esp_now_is_peer_exist(mac_addr))
+        return 0;
+
+    esp_now_peer_num_t num_peers;
+    esp_now_get_peer_num(&num_peers);
+    if(num_peers.total_num > 19)
+    {
+        //We need to remove one, for now just remove a random peer
+        esp_now_peer_info_t rand_peer;
+        esp_now_fetch_peer(false, &rand_peer);
+
+        esp_now_del_peer(rand_peer.peer_addr);
+    }
+
+    esp_now_peer_info_t new_peer = {};
+    memcpy(new_peer.peer_addr, mac_addr, ESP_NOW_ETH_ALEN);
+    esp_now_add_peer(&new_peer);
+
+    return 0;
+}
+
+void EspNowManager::HandlePktCallback(const PktType packetType, const uint8_t *srcMacAddr, const uint8_t *pktData, const size_t pktLen)
+{
+    if((int)packetType >= (int)PktType::kNumPacketTypes)
+    {
+        Serial.printf("Recv invalid packet type: %u\n", (int)packetType);
+        return;
+    }
+
+    PktHandler callback = m_pktHandlerCallbacks[(int)packetType].first;
+    if(callback)
+    {
+        callback(srcMacAddr, pktData, pktLen, m_pktHandlerCallbacks[(int)packetType].second);
+    }
+}

--- a/src/wireless/remote-player-manager.cpp
+++ b/src/wireless/remote-player-manager.cpp
@@ -1,0 +1,126 @@
+#include "../include/remote-player-manager.hpp"
+#include "../include/esp-now-comms.hpp"
+
+#define DEBUG_REMOTE_PLAYER_MANAGER 0
+
+struct PlayerInfoPkt
+{
+    char id[32];
+    Allegiance allegiance;
+    uint8_t hunter;
+} __attribute__((packed));
+
+
+RemotePlayerManager::RemotePlayerManager() :
+    m_remotePlayerTTL(5000),
+    m_broadcastInterval(1000),
+    m_lastBroadcastTime(0)
+{
+}
+
+void RemotePlayerManager::Update()
+{
+    unsigned long now = millis();
+
+    //Remove players not seen in a long time
+    //Single pass removal using Erase-move idiom
+    m_remotePlayers.erase(
+        std::remove_if(m_remotePlayers.begin(), m_remotePlayers.end(),
+            [&now,this](RemotePlayer p){ return now - p.lastSeenTime > m_remotePlayerTTL; }),
+        m_remotePlayers.end());
+
+    //Broadcast if we need to
+    if( (m_lastBroadcastTime != 0) && (now - m_lastBroadcastTime >= m_broadcastInterval))
+    {
+        BroadcastPlayerInfo();
+    }
+}
+
+int RemotePlayerManager::BroadcastPlayerInfo()
+{
+    PlayerInfoPkt broadcastPkt;
+    strncpy(broadcastPkt.id, m_localPlayerInfo->getUserID().c_str(), 32);
+    broadcastPkt.id[31] = '\0'; //TODO: Should be 33 bytes since ID could be 32 chars
+    broadcastPkt.allegiance = m_localPlayerInfo->getAllegiance();
+    broadcastPkt.hunter = m_localPlayerInfo->isHunter();
+
+#if DEBUG_REMOTE_PLAYER_MANAGER
+    Serial.printf("Broadcasting player info. ID: %s Allegiance: %u %s (pktsize: %lu)\n",
+                  broadcastPkt.id,
+                  broadcastPkt.allegiance,
+                  broadcastPkt.hunter ? "Hunter" : "Not Hunter",
+                  sizeof(broadcastPkt));
+#endif
+
+    int ret = EspNowManager::GetInstance()->SendData(ESP_NOW_BROADCAST_ADDR,
+                                                     PktType::kPlayerInfoBroadcast,
+                                                     (uint8_t*)&broadcastPkt,
+                                                     sizeof(broadcastPkt));
+    m_lastBroadcastTime = millis();
+    return ret;
+}
+
+void RemotePlayerManager::StartBroadcastingPlayerInfo(Player *playerInfo, unsigned long broadcastIntervalMillis)
+{
+    m_localPlayerInfo = playerInfo;
+    m_broadcastInterval = broadcastIntervalMillis;
+    BroadcastPlayerInfo();
+}
+
+void RemotePlayerManager::SetRemotePlayerTTL(unsigned long ttl)
+{
+    m_remotePlayerTTL = ttl;
+}
+
+unsigned long RemotePlayerManager::GetRemotePlayerTTL()
+{
+    return m_remotePlayerTTL;
+}
+
+int RemotePlayerManager::ProcessPlayerInfoPkt(const uint8_t* srcMacAddr, const uint8_t *data, const size_t dataLen)
+{
+    if(dataLen != sizeof(PlayerInfoPkt))
+    {
+        Serial.printf("Unexpected packet len for PlayerInfoPkt. Got %lu but expected %lu\n",
+                      dataLen,
+                      sizeof(PlayerInfoPkt));
+        //TODO: Return correct error code
+        return -1;
+    }
+
+    const PlayerInfoPkt* pkt = (const PlayerInfoPkt*)data;
+
+    //Find our remote player record in local list
+    auto remotePlayer = std::find_if(m_remotePlayers.begin(), m_remotePlayers.end(),
+        [srcMacAddr](RemotePlayer rp) { return memcmp(srcMacAddr, rp.wifiMacAddr, ESP_NOW_ETH_ALEN) == 0;});
+
+    //If we don't currently have a record for them, add them
+    if(remotePlayer == m_remotePlayers.end())
+    {
+
+#if DEBUG_REMOTE_PLAYER_MANAGER
+        Serial.printf("Discovered player %s Allegiance: %u IsHunter: %u\n", pkt->id, pkt->allegiance, pkt->hunter);
+#endif
+
+        m_remotePlayers.emplace_back(srcMacAddr, pkt->id, pkt->allegiance, pkt->hunter,
+            millis(), 0);
+        remotePlayer = m_remotePlayers.end() - 1;
+        Serial.printf("Added discovered player %s (Allegiance: %u, %s) at addr %X:%X:%X:%X:%X:%X\n", 
+            remotePlayer->playerInfo.getUserID().c_str(),
+            remotePlayer->playerInfo.getAllegiance(),
+            remotePlayer->playerInfo.isHunter() ? "Hunter" : "Not Hunter",
+            srcMacAddr[0], srcMacAddr[1], srcMacAddr[2],
+            srcMacAddr[3], srcMacAddr[4], srcMacAddr[5]);
+    }
+
+    //If we have a local record of this player, update their last seen time, regardless of packet type
+    if(remotePlayer != m_remotePlayers.end())
+    {
+        remotePlayer->lastSeenTime = millis();
+#if PDN_ENABLE_RSSI_TRACKING
+        remotePlayer->rssi = EspNowManager::GetInstance()->GetRssiForPeer(srcMacAddr);
+        //Serial.printf("Updated peer rssi to %i\n", remotePlayer->rssi);
+#endif
+    }
+    return 0;
+}

--- a/src/wireless/remote-player-manager.cpp
+++ b/src/wireless/remote-player-manager.cpp
@@ -1,5 +1,6 @@
-#include "../include/remote-player-manager.hpp"
-#include "../include/esp-now-comms.hpp"
+#include <Arduino.h>
+#include "wireless/remote-player-manager.hpp"
+#include "wireless/esp-now-comms.hpp"
 
 #define DEBUG_REMOTE_PLAYER_MANAGER 0
 


### PR DESCRIPTION
This adds a system for sending and receiving data to other nearby PDN devices using ESP-NOW protocol. While ESP-NOW only supports packets up to 250 bytes, this change also adds a lightweight higher level protocol on top of ESP-NOW to allow for much larger packets. Note that this currently uses a system where if any part of a larger packet is dropped, the entire packet is dropped, so its still best to keep packets as small as possible. A further improvement would be to implement optional packet acknowledgement.

Services can use this protocol by adding a new packet type to the esp-now-comms.hpp header and then registering a handler to receive packets of that type. RemotePlayerManager serves as an example of how to create and register a service.

This change also supports tracking RSSI for other devices, which is the wireless signal strength between them. This can be roughly used as distance between players, though normal radio interference such as walls applies, so it's not exact. This adds a lot of extra compute required, so has been disabled by default. To enable it, set PDN_ENABLE_RSSI_TRACKING to 1 in platformio.ini

This has not been tested with recent changes due to hardware issues on my side and the large packet support has never been tested. 