### PR TITLE
CLI Display Mirror with Braille Rendering

### DIFF
--- a/src/cli-main.cpp
+++ b/src/cli-main.cpp
@@ -235,7 +235,7 @@ int main(int argc, char** argv) {
                 }
             } else if (key == '\n' || key == '\r') {
                 // Execute command on Enter
-                auto result = commandProcessor.execute(g_commandBuffer, devices, g_selectedDevice);
+                auto result = commandProcessor.execute(g_commandBuffer, devices, g_selectedDevice, renderer);
                 g_commandResult = result.message;
                 if (result.shouldQuit) {
                     g_running = false;

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -200,6 +200,190 @@ TEST_F(NativeLightStripDriverTestSuite, GlobalBrightness) {
 }
 
 // ============================================
+// NATIVE DISPLAY DRIVER TESTS - Old Behavior
+// ============================================
+
+TEST_F(NativeDisplayDriverTestSuite, DrawTextAddsToHistory) {
+    displayDriverDrawTextAddsToHistory(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, DrawTextPositionedAddsToHistory) {
+    displayDriverDrawTextPositionedAddsToHistory(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, DrawButtonAddsToHistory) {
+    displayDriverDrawButtonAddsToHistory(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, InvalidateScreenClearsBuffer) {
+    displayDriverInvalidateScreenClearsBuffer(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, TextHistoryMaxSize) {
+    displayDriverTextHistoryMaxSize(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, TextHistoryNoDuplicates) {
+    displayDriverTextHistoryNoDuplicates(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, DrawTextRendersToBuffer) {
+    displayDriverDrawTextRendersToBuffer(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, MethodChainingWorks) {
+    displayDriverMethodChainingWorks(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, FontModeTracking) {
+    displayDriverFontModeTracking(this);
+}
+
+// ============================================
+// NATIVE DISPLAY DRIVER TESTS - XBM & Mirror
+// ============================================
+
+TEST_F(NativeDisplayDriverTestSuite, XBMDecoding) {
+    displayDriverXBMDecoding(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, FullWhiteImage) {
+    displayDriverFullWhiteImage(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, ImageOffset) {
+    displayDriverImageOffset(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, ImageSentinelPosition) {
+    displayDriverImageSentinelPosition(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, ImageExplicitPosition) {
+    displayDriverImageExplicitPosition(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, NullImageSafety) {
+    displayDriverNullImageSafety(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, DoubleDrawImage) {
+    displayDriverDoubleDrawImage(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, DrawImageThenText) {
+    displayDriverDrawImageThenText(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, RenderToAsciiDimensions) {
+    displayDriverRenderToAsciiDimensions(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, RenderToAsciiContent) {
+    displayDriverRenderToAsciiContent(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, RenderToAsciiFullBlock) {
+    displayDriverRenderToAsciiFullBlock(this);
+}
+
+// ============================================
+// NATIVE DISPLAY DRIVER TESTS - Braille
+// ============================================
+
+TEST_F(NativeDisplayDriverTestSuite, RenderToBrailleDimensions) {
+    displayDriverRenderToBrailleDimensions(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, RenderToBrailleBlank) {
+    displayDriverRenderToBrailleBlank(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, RenderToBrailleContent) {
+    displayDriverRenderToBrailleContent(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, RenderToBrailleFullBlock) {
+    displayDriverRenderToBrailleFullBlock(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, RenderToBrailleDotMapping) {
+    displayDriverRenderToBrailleDotMapping(this);
+}
+
+// ============================================
+// CLI DISPLAY COMMAND TESTS
+// ============================================
+
+TEST_F(CliDisplayCommandTestSuite, MirrorToggle) {
+    cliCommandMirrorToggle(this);
+}
+
+TEST_F(CliDisplayCommandTestSuite, MirrorOnOff) {
+    cliCommandMirrorOnOff(this);
+}
+
+TEST_F(CliDisplayCommandTestSuite, CaptionsToggle) {
+    cliCommandCaptionsToggle(this);
+}
+
+TEST_F(CliDisplayCommandTestSuite, CaptionsOnOff) {
+    cliCommandCaptionsOnOff(this);
+}
+
+TEST_F(CliDisplayCommandTestSuite, CaptionsAlias) {
+    cliCommandCaptionsAlias(this);
+}
+
+TEST_F(CliDisplayCommandTestSuite, DisplayOn) {
+    cliCommandDisplayOn(this);
+}
+
+TEST_F(CliDisplayCommandTestSuite, DisplayOff) {
+    cliCommandDisplayOff(this);
+}
+
+TEST_F(CliDisplayCommandTestSuite, DisplayToggleBothOff) {
+    cliCommandDisplayToggleBothOff(this);
+}
+
+TEST_F(CliDisplayCommandTestSuite, DisplayToggleBothOn) {
+    cliCommandDisplayToggleBothOn(this);
+}
+
+TEST_F(CliDisplayCommandTestSuite, DisplayToggleDisagree) {
+    cliCommandDisplayToggleDisagree(this);
+}
+
+TEST_F(CliDisplayCommandTestSuite, DisplayToggleDisagreeReverse) {
+    cliCommandDisplayToggleDisagreeReverse(this);
+}
+
+TEST_F(CliDisplayCommandTestSuite, DisplayAlias) {
+    cliCommandDisplayAlias(this);
+}
+
+// ============================================
+// CLI COMMAND / REBOOT TESTS
+// ============================================
+
+TEST_F(CliCommandTestSuite, MockHttpFetchTransitions) {
+    cliDeviceMockHttpFetchTransitions(this);
+}
+
+TEST_F(CliCommandTestSuite, RebootResetsState) {
+    cliCommandRebootResetsState(this);
+}
+
+TEST_F(CliCommandTestSuite, RebootFromLaterState) {
+    cliCommandRebootFromLaterState(this);
+}
+
+TEST_F(CliCommandTestSuite, RebootClearsHistory) {
+    cliCommandRebootClearsHistory(this);
+}
+
+// ============================================
 // MAIN
 // ============================================
 

--- a/test/test_cli/native-driver-tests.hpp
+++ b/test/test_cli/native-driver-tests.hpp
@@ -5,10 +5,14 @@
 #pragma once
 
 #include <gtest/gtest.h>
+#include "device/drivers/native/native-display-driver.hpp"
 #include "device/drivers/native/native-serial-driver.hpp"
 #include "device/drivers/native/native-peer-comms-driver.hpp"
 #include "device/drivers/native/native-button-driver.hpp"
 #include "device/drivers/native/native-light-strip-driver.hpp"
+#include "cli/cli-device.hpp"
+#include "cli/cli-commands.hpp"
+#include "game/quickdraw-states.hpp"
 
 // ============================================
 // NATIVE SERIAL DRIVER TEST SUITE
@@ -346,4 +350,666 @@ void lightStripGlobalBrightness(NativeLightStripDriverTestSuite* suite) {
     
     // Note: Global brightness affects the lights but may not change stored values
     // This is just a smoke test that the method exists and doesn't crash
+}
+
+// ============================================
+// NATIVE DISPLAY DRIVER TEST SUITE
+// ============================================
+
+class NativeDisplayDriverTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        driver_ = new NativeDisplayDriver("TestDisplay");
+    }
+
+    void TearDown() override {
+        delete driver_;
+    }
+
+    NativeDisplayDriver* driver_;
+};
+
+// --- Old behavior tests: text history, buffer, method chaining ---
+
+// Test: drawText adds to text history
+void displayDriverDrawTextAddsToHistory(NativeDisplayDriverTestSuite* suite) {
+    suite->driver_->drawText("Hello");
+    suite->driver_->drawText("World");
+
+    const auto& history = suite->driver_->getTextHistory();
+    ASSERT_EQ(history.size(), 2u);
+    ASSERT_EQ(history[0], "World");  // Most recent first
+    ASSERT_EQ(history[1], "Hello");
+}
+
+// Test: drawText with position also adds to text history
+void displayDriverDrawTextPositionedAddsToHistory(NativeDisplayDriverTestSuite* suite) {
+    suite->driver_->drawText("Positioned", 10, 20);
+
+    const auto& history = suite->driver_->getTextHistory();
+    ASSERT_EQ(history.size(), 1u);
+    ASSERT_EQ(history[0], "Positioned");
+}
+
+// Test: drawButton adds bracketed text to history
+void displayDriverDrawButtonAddsToHistory(NativeDisplayDriverTestSuite* suite) {
+    suite->driver_->drawButton("OK", 64, 32);
+
+    const auto& history = suite->driver_->getTextHistory();
+    ASSERT_EQ(history.size(), 1u);
+    ASSERT_EQ(history[0], "[OK]");
+}
+
+// Test: invalidateScreen clears the entire buffer
+void displayDriverInvalidateScreenClearsBuffer(NativeDisplayDriverTestSuite* suite) {
+    // Draw something first
+    suite->driver_->drawText("Fill");
+    ASSERT_TRUE(suite->driver_->getPixel(0, 0));  // 'F' sets pixels at (0,0)
+
+    suite->driver_->invalidateScreen();
+
+    // All pixels should be off
+    for (int y = 0; y < NativeDisplayDriver::HEIGHT; y += 16) {
+        for (int x = 0; x < NativeDisplayDriver::WIDTH; x += 16) {
+            ASSERT_FALSE(suite->driver_->getPixel(x, y));
+        }
+    }
+}
+
+// Test: text history is capped at 4 entries
+void displayDriverTextHistoryMaxSize(NativeDisplayDriverTestSuite* suite) {
+    suite->driver_->drawText("One");
+    suite->driver_->drawText("Two");
+    suite->driver_->drawText("Three");
+    suite->driver_->drawText("Four");
+    suite->driver_->drawText("Five");
+
+    const auto& history = suite->driver_->getTextHistory();
+    ASSERT_EQ(history.size(), 4u);
+    ASSERT_EQ(history[0], "Five");   // Most recent
+    ASSERT_EQ(history[3], "Two");    // Oldest kept
+}
+
+// Test: duplicate consecutive text entries are not added
+void displayDriverTextHistoryNoDuplicates(NativeDisplayDriverTestSuite* suite) {
+    suite->driver_->drawText("Same");
+    suite->driver_->drawText("Same");
+    suite->driver_->drawText("Same");
+
+    const auto& history = suite->driver_->getTextHistory();
+    ASSERT_EQ(history.size(), 1u);
+}
+
+// Test: drawText renders pixels to the buffer
+void displayDriverDrawTextRendersToBuffer(NativeDisplayDriverTestSuite* suite) {
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawText("A", 0, 0);
+
+    // 'A' in 5x7 font: column 0 is 0x7E = 01111110
+    // Bits 1-6 should be on at x=0
+    ASSERT_FALSE(suite->driver_->getPixel(0, 0));  // bit 0 off
+    ASSERT_TRUE(suite->driver_->getPixel(0, 1));   // bit 1 on
+    ASSERT_TRUE(suite->driver_->getPixel(0, 2));   // bit 2 on
+}
+
+// Test: method chaining works (invalidateScreen->drawText->render)
+void displayDriverMethodChainingWorks(NativeDisplayDriverTestSuite* suite) {
+    // This mimics how game states use the display
+    Display* result = suite->driver_->invalidateScreen()->drawText("Chain")->drawText("Test", 0, 10);
+
+    // Should return this pointer for chaining
+    ASSERT_EQ(result, static_cast<Display*>(suite->driver_));
+
+    // Both texts should be in history
+    const auto& history = suite->driver_->getTextHistory();
+    ASSERT_GE(history.size(), 2u);
+}
+
+// Test: font mode tracking
+void displayDriverFontModeTracking(NativeDisplayDriverTestSuite* suite) {
+    ASSERT_EQ(suite->driver_->getFontModeName(), "TEXT");
+
+    suite->driver_->setGlyphMode(FontMode::NUMBER_GLYPH);
+    ASSERT_EQ(suite->driver_->getFontModeName(), "NUMBER");
+
+    suite->driver_->setGlyphMode(FontMode::TEXT_INVERTED_SMALL);
+    ASSERT_EQ(suite->driver_->getFontModeName(), "INV_SM");
+}
+
+// --- New behavior tests: XBM decoding, mirror rendering ---
+
+// Test: XBM byte decoding sets correct pixels (LSB-first)
+void displayDriverXBMDecoding(NativeDisplayDriverTestSuite* suite) {
+    const unsigned char xbmData[] = {
+        0xA5, // row 0: pixels 0,2,5,7 on (LSB-first: 10100101)
+        0xFF, // row 1: all 8 pixels on
+    };
+    Image img(xbmData, 8, 2, 0, 0);
+
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawImage(img);
+
+    ASSERT_TRUE(suite->driver_->getPixel(0, 0));
+    ASSERT_FALSE(suite->driver_->getPixel(1, 0));
+    ASSERT_TRUE(suite->driver_->getPixel(2, 0));
+    ASSERT_FALSE(suite->driver_->getPixel(3, 0));
+    ASSERT_FALSE(suite->driver_->getPixel(4, 0));
+    ASSERT_TRUE(suite->driver_->getPixel(5, 0));
+    ASSERT_FALSE(suite->driver_->getPixel(6, 0));
+    ASSERT_TRUE(suite->driver_->getPixel(7, 0));
+
+    for (int x = 0; x < 8; x++) {
+        ASSERT_TRUE(suite->driver_->getPixel(x, 1));
+    }
+}
+
+// Test: Full 128x64 all-white image decodes correctly
+void displayDriverFullWhiteImage(NativeDisplayDriverTestSuite* suite) {
+    unsigned char whiteData[1024];
+    memset(whiteData, 0xFF, sizeof(whiteData));
+    Image img(whiteData, 128, 64, 0, 0);
+
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawImage(img);
+
+    ASSERT_TRUE(suite->driver_->getPixel(0, 0));
+    ASSERT_TRUE(suite->driver_->getPixel(127, 0));
+    ASSERT_TRUE(suite->driver_->getPixel(0, 63));
+    ASSERT_TRUE(suite->driver_->getPixel(127, 63));
+    ASSERT_TRUE(suite->driver_->getPixel(64, 32));
+}
+
+// Test: drawImage(img) uses Image's default position
+void displayDriverImageOffset(NativeDisplayDriverTestSuite* suite) {
+    const unsigned char xbmData[] = { 0xFF };
+    Image img(xbmData, 8, 1, 64, 0);
+
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawImage(img);
+
+    ASSERT_FALSE(suite->driver_->getPixel(0, 0));
+    ASSERT_TRUE(suite->driver_->getPixel(64, 0));
+    ASSERT_TRUE(suite->driver_->getPixel(71, 0));
+}
+
+// Test: drawImage(img, -1, -1) uses Image's default position (sentinel values)
+void displayDriverImageSentinelPosition(NativeDisplayDriverTestSuite* suite) {
+    const unsigned char xbmData[] = { 0xFF };
+    Image img(xbmData, 8, 1, 32, 10);  // default at (32, 10)
+
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawImage(img, -1, -1);
+
+    ASSERT_FALSE(suite->driver_->getPixel(0, 0));
+    ASSERT_TRUE(suite->driver_->getPixel(32, 10));
+    ASSERT_TRUE(suite->driver_->getPixel(39, 10));
+}
+
+// Test: drawImage(img, x, y) overrides Image's default position
+void displayDriverImageExplicitPosition(NativeDisplayDriverTestSuite* suite) {
+    const unsigned char xbmData[] = { 0xFF };
+    Image img(xbmData, 8, 1, 64, 0);  // default at (64, 0)
+
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawImage(img, 10, 20);  // override to (10, 20)
+
+    ASSERT_FALSE(suite->driver_->getPixel(64, 0));   // Not at default
+    ASSERT_TRUE(suite->driver_->getPixel(10, 20));    // At explicit position
+    ASSERT_TRUE(suite->driver_->getPixel(17, 20));
+}
+
+// Test: Null image data doesn't crash
+void displayDriverNullImageSafety(NativeDisplayDriverTestSuite* suite) {
+    Image img(nullptr, 128, 64, 0, 0);
+
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawImage(img);
+
+    ASSERT_FALSE(suite->driver_->getPixel(0, 0));
+}
+
+// Test: Two drawImage calls overlay correctly (like AwakenSequence state)
+void displayDriverDoubleDrawImage(NativeDisplayDriverTestSuite* suite) {
+    // First image: 8px wide, sets pixels at (0,0)
+    const unsigned char imgA[] = { 0xFF };
+    Image imageA(imgA, 8, 1, 0, 0);
+
+    // Second image: 8px wide, sets pixels at (64,0)
+    const unsigned char imgB[] = { 0xFF };
+    Image imageB(imgB, 8, 1, 64, 0);
+
+    // Chain like game code: invalidateScreen()->drawImage(A)->drawImage(B)
+    suite->driver_->invalidateScreen()->drawImage(imageA)->drawImage(imageB);
+
+    // Both images should be present
+    ASSERT_TRUE(suite->driver_->getPixel(0, 0));    // From imageA
+    ASSERT_TRUE(suite->driver_->getPixel(7, 0));    // From imageA
+    ASSERT_FALSE(suite->driver_->getPixel(32, 0));  // Gap between images
+    ASSERT_TRUE(suite->driver_->getPixel(64, 0));   // From imageB
+    ASSERT_TRUE(suite->driver_->getPixel(71, 0));   // From imageB
+}
+
+// Test: Text overlays on image correctly (like Idle state)
+void displayDriverDrawImageThenText(NativeDisplayDriverTestSuite* suite) {
+    // Draw a small image at origin
+    const unsigned char xbmData[] = { 0xFF };
+    Image img(xbmData, 8, 1, 0, 0);
+
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawImage(img);
+    suite->driver_->drawText("Hi", 0, 10);
+
+    // Image pixels at row 0 should still be on
+    ASSERT_TRUE(suite->driver_->getPixel(0, 0));
+    // Text pixels at row 10 should also be on
+    ASSERT_TRUE(suite->driver_->getPixel(0, 11));  // 'H' has pixel at bit 1
+
+    // Text should also be in history
+    const auto& history = suite->driver_->getTextHistory();
+    ASSERT_EQ(history.size(), 1u);
+    ASSERT_EQ(history[0], "Hi");
+}
+
+// Test: renderToAscii output dimensions at 2x2 scale (blank screen)
+void displayDriverRenderToAsciiDimensions(NativeDisplayDriverTestSuite* suite) {
+    auto lines = suite->driver_->renderToAscii(2, 2);
+
+    // 64 height / (2*2) = 16 lines
+    ASSERT_EQ(lines.size(), 16u);
+
+    // Blank screen: all spaces (1 byte each), 128/2 = 64 chars per line
+    for (const auto& line : lines) {
+        ASSERT_EQ(line.size(), 64u);
+    }
+}
+
+// Test: renderToAscii produces correct half-block characters for known pixels
+void displayDriverRenderToAsciiContent(NativeDisplayDriverTestSuite* suite) {
+    suite->driver_->invalidateScreen();
+
+    // At scale (2,2): character at column 0, line 0 covers pixels (0..1, 0..1) upper and (0..1, 2..3) lower
+    // Set only upper-left pixel block: (0,0) and (1,0) on
+    // This should produce upper half-block for the first character
+
+    // Set pixels in upper half only (rows 0-1) of first char cell
+    unsigned char topOnly[1024];
+    memset(topOnly, 0, sizeof(topOnly));
+    // Row 0: first two pixels on = 0x03 (bits 0,1)
+    topOnly[0] = 0x03;
+    Image img(topOnly, 128, 64, 0, 0);
+    suite->driver_->drawImage(img);
+
+    auto lines = suite->driver_->renderToAscii(2, 2);
+
+    // First character of first line should be upper half-block
+    std::string upperBlock = "\xe2\x96\x80";  // UTF-8 for ▀
+    ASSERT_GE(lines[0].size(), 3u);
+    ASSERT_EQ(lines[0].substr(0, 3), upperBlock);
+}
+
+// Test: renderToAscii full block for pixels in both halves
+void displayDriverRenderToAsciiFullBlock(NativeDisplayDriverTestSuite* suite) {
+    suite->driver_->invalidateScreen();
+
+    // Set pixels in both upper (rows 0-1) and lower (rows 2-3) of first char cell
+    unsigned char bothHalves[1024];
+    memset(bothHalves, 0, sizeof(bothHalves));
+    bothHalves[0] = 0x03;  // Row 0: pixels 0,1 on
+    // Row 2 byte index: 2 * 16 = 32, pixels 0,1 on
+    bothHalves[32] = 0x03;
+    Image img(bothHalves, 128, 64, 0, 0);
+    suite->driver_->drawImage(img);
+
+    auto lines = suite->driver_->renderToAscii(2, 2);
+
+    // First character should be full block
+    std::string fullBlock = "\xe2\x96\x88";  // UTF-8 for █
+    ASSERT_GE(lines[0].size(), 3u);
+    ASSERT_EQ(lines[0].substr(0, 3), fullBlock);
+}
+
+// --- Braille rendering tests ---
+
+// Test: renderToBraille output dimensions (blank screen)
+void displayDriverRenderToBrailleDimensions(NativeDisplayDriverTestSuite* suite) {
+    auto lines = suite->driver_->renderToBraille();
+
+    // 64 height / 4 = 16 lines
+    ASSERT_EQ(lines.size(), 16u);
+
+    // Blank screen: all U+2800 (3 bytes each), 128/2 = 64 chars = 192 bytes per line
+    for (const auto& line : lines) {
+        ASSERT_EQ(line.size(), 192u);
+    }
+}
+
+// Test: renderToBraille blank screen produces empty braille characters
+void displayDriverRenderToBrailleBlank(NativeDisplayDriverTestSuite* suite) {
+    suite->driver_->invalidateScreen();
+    auto lines = suite->driver_->renderToBraille();
+
+    // Every character should be U+2800 (empty braille) = 0xE2 0xA0 0x80
+    std::string emptyBraille = "\xe2\xa0\x80";
+    ASSERT_EQ(lines[0].substr(0, 3), emptyBraille);
+    ASSERT_EQ(lines[15].substr(189, 3), emptyBraille);  // Last char of last line
+}
+
+// Test: renderToBraille encodes individual pixel positions correctly
+void displayDriverRenderToBrailleContent(NativeDisplayDriverTestSuite* suite) {
+    suite->driver_->invalidateScreen();
+
+    // Set pixel (0,0) — maps to braille dot 1 (bit 0x01) → U+2801
+    const unsigned char singlePixel[1024] = {};
+    unsigned char data[1024];
+    memset(data, 0, sizeof(data));
+    data[0] = 0x01;  // Row 0, pixel 0 on
+    Image img(data, 128, 64, 0, 0);
+    suite->driver_->drawImage(img);
+
+    auto lines = suite->driver_->renderToBraille();
+
+    // First char should be U+2801 = 0xE2 0xA0 0x81
+    std::string expected = "\xe2\xa0\x81";
+    ASSERT_EQ(lines[0].substr(0, 3), expected);
+}
+
+// Test: renderToBraille full block when all 8 pixels in a 2x4 cell are set
+void displayDriverRenderToBrailleFullBlock(NativeDisplayDriverTestSuite* suite) {
+    suite->driver_->invalidateScreen();
+
+    // Fill all pixels to produce U+28FF (all 8 dots)
+    unsigned char allOn[1024];
+    memset(allOn, 0xFF, sizeof(allOn));
+    Image img(allOn, 128, 64, 0, 0);
+    suite->driver_->drawImage(img);
+
+    auto lines = suite->driver_->renderToBraille();
+
+    // Every character should be U+28FF = 0xE2 0xA3 0xBF
+    std::string fullBraille = "\xe2\xa3\xbf";
+    ASSERT_EQ(lines[0].substr(0, 3), fullBraille);
+    ASSERT_EQ(lines[8].substr(96, 3), fullBraille);  // Mid-screen spot check
+}
+
+// Test: renderToBraille correctly maps right-column pixel to dot 4
+void displayDriverRenderToBrailleDotMapping(NativeDisplayDriverTestSuite* suite) {
+    suite->driver_->invalidateScreen();
+
+    // Set pixel (1,0) — maps to braille dot 4 (bit 0x08) → U+2808
+    unsigned char data[1024];
+    memset(data, 0, sizeof(data));
+    data[0] = 0x02;  // Row 0, pixel 1 on (LSB-first: bit1 = x=1)
+    Image img(data, 128, 64, 0, 0);
+    suite->driver_->drawImage(img);
+
+    auto lines = suite->driver_->renderToBraille();
+
+    // First char should be U+2808 = 0xE2 0xA0 0x88
+    std::string expected = "\xe2\xa0\x88";
+    ASSERT_EQ(lines[0].substr(0, 3), expected);
+}
+
+// ============================================
+// CLI DISPLAY COMMAND TEST SUITE
+// ============================================
+
+/*
+ * Lightweight test suite for mirror/captions/display commands.
+ * These commands only interact with the Renderer, so no devices needed.
+ */
+class CliDisplayCommandTestSuite : public testing::Test {
+public:
+    std::vector<cli::DeviceInstance> devices_;
+    int selectedDevice_ = 0;
+    cli::Renderer renderer_;
+    cli::CommandProcessor processor_;
+
+    cli::CommandResult exec(const std::string& cmd) {
+        return processor_.execute(cmd, devices_, selectedDevice_, renderer_);
+    }
+};
+
+// Test: mirror command toggles display mirror
+void cliCommandMirrorToggle(CliDisplayCommandTestSuite* suite) {
+    ASSERT_FALSE(suite->renderer_.isDisplayMirrorEnabled());  // Default OFF
+
+    suite->exec("mirror");
+    ASSERT_TRUE(suite->renderer_.isDisplayMirrorEnabled());
+
+    suite->exec("mirror");
+    ASSERT_FALSE(suite->renderer_.isDisplayMirrorEnabled());
+}
+
+// Test: mirror on/off explicit arguments
+void cliCommandMirrorOnOff(CliDisplayCommandTestSuite* suite) {
+    suite->exec("mirror on");
+    ASSERT_TRUE(suite->renderer_.isDisplayMirrorEnabled());
+
+    suite->exec("mirror off");
+    ASSERT_FALSE(suite->renderer_.isDisplayMirrorEnabled());
+}
+
+// Test: captions command toggles captions
+void cliCommandCaptionsToggle(CliDisplayCommandTestSuite* suite) {
+    ASSERT_TRUE(suite->renderer_.isCaptionsEnabled());  // Default ON
+
+    suite->exec("captions");
+    ASSERT_FALSE(suite->renderer_.isCaptionsEnabled());
+
+    suite->exec("captions");
+    ASSERT_TRUE(suite->renderer_.isCaptionsEnabled());
+}
+
+// Test: captions on/off explicit arguments
+void cliCommandCaptionsOnOff(CliDisplayCommandTestSuite* suite) {
+    suite->exec("captions off");
+    ASSERT_FALSE(suite->renderer_.isCaptionsEnabled());
+
+    suite->exec("captions on");
+    ASSERT_TRUE(suite->renderer_.isCaptionsEnabled());
+}
+
+// Test: captions alias "cap" works
+void cliCommandCaptionsAlias(CliDisplayCommandTestSuite* suite) {
+    suite->exec("cap");
+    ASSERT_FALSE(suite->renderer_.isCaptionsEnabled());
+
+    suite->exec("cap on");
+    ASSERT_TRUE(suite->renderer_.isCaptionsEnabled());
+}
+
+// Test: display on sets both mirror and captions on
+void cliCommandDisplayOn(CliDisplayCommandTestSuite* suite) {
+    // Start with both off
+    suite->renderer_.setDisplayMirror(false);
+    suite->renderer_.setCaptions(false);
+
+    suite->exec("display on");
+    ASSERT_TRUE(suite->renderer_.isDisplayMirrorEnabled());
+    ASSERT_TRUE(suite->renderer_.isCaptionsEnabled());
+}
+
+// Test: display off sets both mirror and captions off
+void cliCommandDisplayOff(CliDisplayCommandTestSuite* suite) {
+    suite->renderer_.setDisplayMirror(true);
+    suite->renderer_.setCaptions(true);
+
+    suite->exec("display off");
+    ASSERT_FALSE(suite->renderer_.isDisplayMirrorEnabled());
+    ASSERT_FALSE(suite->renderer_.isCaptionsEnabled());
+}
+
+// Test: display toggle when both agree (both off -> both on)
+void cliCommandDisplayToggleBothOff(CliDisplayCommandTestSuite* suite) {
+    suite->renderer_.setDisplayMirror(false);
+    suite->renderer_.setCaptions(false);
+
+    suite->exec("display");
+    ASSERT_TRUE(suite->renderer_.isDisplayMirrorEnabled());
+    ASSERT_TRUE(suite->renderer_.isCaptionsEnabled());
+}
+
+// Test: display toggle when both agree (both on -> both off)
+void cliCommandDisplayToggleBothOn(CliDisplayCommandTestSuite* suite) {
+    suite->renderer_.setDisplayMirror(true);
+    suite->renderer_.setCaptions(true);
+
+    suite->exec("display");
+    ASSERT_FALSE(suite->renderer_.isDisplayMirrorEnabled());
+    ASSERT_FALSE(suite->renderer_.isCaptionsEnabled());
+}
+
+// Test: display toggle when mirror and captions disagree -> forces both on
+void cliCommandDisplayToggleDisagree(CliDisplayCommandTestSuite* suite) {
+    // Mirror on, captions off
+    suite->renderer_.setDisplayMirror(true);
+    suite->renderer_.setCaptions(false);
+
+    suite->exec("display");
+    ASSERT_TRUE(suite->renderer_.isDisplayMirrorEnabled());
+    ASSERT_TRUE(suite->renderer_.isCaptionsEnabled());
+}
+
+// Test: display toggle disagree (opposite direction)
+void cliCommandDisplayToggleDisagreeReverse(CliDisplayCommandTestSuite* suite) {
+    // Mirror off, captions on
+    suite->renderer_.setDisplayMirror(false);
+    suite->renderer_.setCaptions(true);
+
+    suite->exec("display");
+    ASSERT_TRUE(suite->renderer_.isDisplayMirrorEnabled());
+    ASSERT_TRUE(suite->renderer_.isCaptionsEnabled());
+}
+
+// Test: display alias "d" works
+void cliCommandDisplayAlias(CliDisplayCommandTestSuite* suite) {
+    suite->exec("d on");
+    ASSERT_TRUE(suite->renderer_.isDisplayMirrorEnabled());
+    ASSERT_TRUE(suite->renderer_.isCaptionsEnabled());
+
+    suite->exec("d off");
+    ASSERT_FALSE(suite->renderer_.isDisplayMirrorEnabled());
+    ASSERT_FALSE(suite->renderer_.isCaptionsEnabled());
+}
+
+// ============================================
+// CLI COMMAND / REBOOT TEST SUITE
+// ============================================
+
+class CliCommandTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        globalClock_ = new NativeClockDriver("test_cmd_clock");
+        globalLogger_ = new NativeLoggerDriver("test_cmd_logger");
+        globalLogger_->setSuppressOutput(true);
+        g_logger = globalLogger_;
+        SimpleTimer::setPlatformClock(globalClock_);
+        device_ = cli::DeviceFactory::createDevice(0, true);
+    }
+
+    void TearDown() override {
+        cli::DeviceFactory::destroyDevice(device_);
+        SimpleTimer::setPlatformClock(nullptr);
+        g_logger = nullptr;
+        delete globalLogger_;
+        delete globalClock_;
+    }
+
+    cli::DeviceInstance device_;
+    NativeClockDriver* globalClock_;
+    NativeLoggerDriver* globalLogger_;
+};
+
+// Test: Mock HTTP fetch transitions device from FetchUserData to WelcomeMessage
+void cliDeviceMockHttpFetchTransitions(CliCommandTestSuite* suite) {
+    // Device starts at FetchUserData (state 1) after createDevice
+    State* state = suite->device_.game->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), FETCH_USER_DATA);
+
+    // Run a few loop cycles — mock HTTP responds immediately
+    for (int i = 0; i < 10; i++) {
+        suite->device_.pdn->loop();
+        suite->device_.game->loop();
+    }
+
+    // Should have transitioned to WelcomeMessage
+    state = suite->device_.game->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), WELCOME_MESSAGE);
+}
+
+// Test: Reboot resets device back to FetchUserData
+void cliCommandRebootResetsState(CliCommandTestSuite* suite) {
+    // Advance past FetchUserData
+    for (int i = 0; i < 10; i++) {
+        suite->device_.pdn->loop();
+        suite->device_.game->loop();
+    }
+    State* state = suite->device_.game->getCurrentState();
+    ASSERT_NE(state->getStateId(), FETCH_USER_DATA);
+
+    // Reboot: same sequence as cmdReboot
+    suite->device_.httpClientDriver->setMockServerEnabled(true);
+    suite->device_.httpClientDriver->setConnected(true);
+    suite->device_.stateHistory.clear();
+    suite->device_.lastStateId = -1;
+    suite->device_.game->skipToState(1);
+
+    // Should be back at FetchUserData
+    state = suite->device_.game->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), FETCH_USER_DATA);
+}
+
+// Test: Reboot from a later state returns to FetchUserData and can re-transition
+void cliCommandRebootFromLaterState(CliCommandTestSuite* suite) {
+    // Advance device further (past FetchUserData into WelcomeMessage or beyond)
+    for (int i = 0; i < 10; i++) {
+        suite->device_.pdn->loop();
+        suite->device_.game->loop();
+    }
+    ASSERT_EQ(suite->device_.game->getCurrentState()->getStateId(), WELCOME_MESSAGE);
+
+    // Reboot
+    suite->device_.httpClientDriver->setMockServerEnabled(true);
+    suite->device_.httpClientDriver->setConnected(true);
+    suite->device_.stateHistory.clear();
+    suite->device_.lastStateId = -1;
+    suite->device_.game->skipToState(1);
+
+    ASSERT_EQ(suite->device_.game->getCurrentState()->getStateId(), FETCH_USER_DATA);
+
+    // Run loops again — should transition to WelcomeMessage again
+    for (int i = 0; i < 10; i++) {
+        suite->device_.pdn->loop();
+        suite->device_.game->loop();
+    }
+    ASSERT_EQ(suite->device_.game->getCurrentState()->getStateId(), WELCOME_MESSAGE);
+}
+
+// Test: Reboot clears state history and resets lastStateId
+void cliCommandRebootClearsHistory(CliCommandTestSuite* suite) {
+    // Add some fake state history
+    suite->device_.stateHistory.push_back(1);
+    suite->device_.stateHistory.push_back(5);
+    suite->device_.stateHistory.push_back(7);
+    suite->device_.lastStateId = 7;
+
+    ASSERT_EQ(suite->device_.stateHistory.size(), 3u);
+    ASSERT_EQ(suite->device_.lastStateId, 7);
+
+    // Reboot
+    suite->device_.httpClientDriver->setMockServerEnabled(true);
+    suite->device_.httpClientDriver->setConnected(true);
+    suite->device_.stateHistory.clear();
+    suite->device_.lastStateId = -1;
+    suite->device_.game->skipToState(1);
+
+    // History should be cleared
+    ASSERT_TRUE(suite->device_.stateHistory.empty());
+    ASSERT_EQ(suite->device_.lastStateId, -1);
+
+    // Device should be at FetchUserData
+    ASSERT_EQ(suite->device_.game->getCurrentState()->getStateId(), FETCH_USER_DATA);
 }


### PR DESCRIPTION
## Summary

Adds a high-fidelity display mirror to the CLI simulator using Unicode braille characters (U+2800-U+28FF), providing 4x the detail of half-block characters in the same terminal footprint. The mirror renders each device's 128x64 OLED display alongside readable text captions in a hybrid layout.

### Features

- **Braille rendering** — `renderToBraille()` maps 2x4 pixel grids to braille codepoints, producing 64x16 character output from a 128x64 pixel buffer
- **XBM bitmap decoding** — `decodeXBMToBuffer()` and `drawImage()` properly decode XBM format (LSB-first, row-major) into the pixel buffer
- **Hybrid display layout** — When mirror is ON, captions float alongside the first 4 lines of ASCII art; when OFF, captions display alone
- **`mirror` command** — Toggle, on, off (aliases: `m`)
- **`captions` command** — Toggle, on, off (aliases: `cap`, `cc`)
- **`display` command** — Toggles both mirror and captions together; forces both ON if they disagree (aliases: `d`)
- **`reboot` command** — Resets device state machine back to initial state (aliases: `restart`)

### Test Coverage

41 new tests (80 total), covering:
- Display driver text history, XBM decoding, image compositing, ASCII rendering
- Braille rendering (dimensions, blank, content, full block, dot mapping)
- All CLI commands (mirror, captions, display, reboot) with toggle/on/off/alias/edge cases

## Test plan

- [x] `pio test -e native_cli_test` — all 80 tests pass
- [ ] `pio run -e native_cli` — build simulator, run with `mirror on`, verify braille art + captions side-by-side
- [ ] Verify `display on`/`display off` toggles both mirror and captions
- [ ] Verify `captions off` hides captions while mirror remains visible