### PR TITLE
Fix inverted text in DRAW image and hidden caption text

### DIFF
--- a/include/device/drivers/native/native-display-driver.hpp
+++ b/include/device/drivers/native/native-display-driver.hpp
@@ -187,6 +187,9 @@ public:
 
     Display* drawImage(Image image, int xStart, int yStart) override {
         currentImage_ = image;
+        if (image.name) {
+            addToTextHistory(image.name);
+        }
         int x = image.defaultStartX;
         int y = image.defaultStartY;
         if (xStart != -1) x = xStart;

--- a/include/device/drivers/native/native-display-driver.hpp
+++ b/include/device/drivers/native/native-display-driver.hpp
@@ -340,9 +340,7 @@ private:
                 int byteIndex = row * bytesPerRow + col / 8;
                 int bitIndex = col % 8;  // LSB first
                 bool pixelOn = (data[byteIndex] >> bitIndex) & 1;
-                if (pixelOn) {
-                    setPixel(offsetX + col, offsetY + row, true);
-                }
+                setPixel(offsetX + col, offsetY + row, pixelOn);
             }
         }
     }

--- a/include/game/quickdraw-resources.hpp
+++ b/include/game/quickdraw-resources.hpp
@@ -17,13 +17,13 @@ const ImageCollection alleycatImageCollection = {
 {ImageType::LOGO_LEFT, Image(image_logo_alley, 128, 64, 0, 0)},
 {ImageType::IDLE, Image(image_alley_0, 128, 64, 0, 0)},
 {ImageType::STAMP, Image(image_alley_stamp, 128, 64, 64, 0)},
-{ImageType::CONNECT, Image(image_alley_connect, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_THREE, Image(image_alley_count3, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_TWO, Image(image_alley_count2, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_ONE, Image(image_alley_count1, 128, 64, 0, 0)},
-{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0)},
-{ImageType::WIN, Image(image_alley_victor, 128, 64, 0, 0)},
-{ImageType::LOSE, Image(image_alley_loser, 128, 64, 0, 0)},
+{ImageType::CONNECT, Image(image_alley_connect, 128, 64, 0, 0, "CONNECTED")},
+{ImageType::COUNTDOWN_THREE, Image(image_alley_count3, 128, 64, 0, 0, "3")},
+{ImageType::COUNTDOWN_TWO, Image(image_alley_count2, 128, 64, 0, 0, "2")},
+{ImageType::COUNTDOWN_ONE, Image(image_alley_count1, 128, 64, 0, 0, "1")},
+{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0, "DRAW!")},
+{ImageType::WIN, Image(image_alley_victor, 128, 64, 0, 0, "VICTORY")},
+{ImageType::LOSE, Image(image_alley_loser, 128, 64, 0, 0, "DEFEATED")},
 };
 
 const ImageCollection helixImageCollection = {
@@ -31,13 +31,13 @@ const ImageCollection helixImageCollection = {
     {ImageType::LOGO_LEFT, Image(image_logo_helix, 128, 64, 0, 0)},
 {ImageType::IDLE, Image(image_helix_0, 128, 64, 0, 0)},
 {ImageType::STAMP, Image(image_helix_stamp, 128, 64, 64, 0)},
-{ImageType::CONNECT, Image(image_helix_connect, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_THREE, Image(image_helix_count3, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_TWO, Image(image_helix_count2, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_ONE, Image(image_helix_count1, 128, 64, 0, 0)},
-{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0)},
-{ImageType::WIN, Image(image_helix_victor, 128, 64, 0, 0)},
-{ImageType::LOSE, Image(image_helix_loser, 128, 64, 0, 0)},
+{ImageType::CONNECT, Image(image_helix_connect, 128, 64, 0, 0, "CONNECTED")},
+{ImageType::COUNTDOWN_THREE, Image(image_helix_count3, 128, 64, 0, 0, "3")},
+{ImageType::COUNTDOWN_TWO, Image(image_helix_count2, 128, 64, 0, 0, "2")},
+{ImageType::COUNTDOWN_ONE, Image(image_helix_count1, 128, 64, 0, 0, "1")},
+{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0, "DRAW!")},
+{ImageType::WIN, Image(image_helix_victor, 128, 64, 0, 0, "VICTORY")},
+{ImageType::LOSE, Image(image_helix_loser, 128, 64, 0, 0, "DEFEATED")},
 };
 
 const ImageCollection endlineImageCollection = {
@@ -45,13 +45,13 @@ const ImageCollection endlineImageCollection = {
 {ImageType::LOGO_LEFT, Image(image_logo_endline, 128, 64, 0, 0)},
 {ImageType::IDLE, Image(image_endline_0, 128, 64, 0, 0)},
 {ImageType::STAMP, Image(image_endline_stamp, 128, 64, 64, 0)},
-{ImageType::CONNECT, Image(image_endline_connect, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_THREE, Image(image_endline_count3, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_TWO, Image(image_endline_count2, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_ONE, Image(image_endline_count1, 128, 64, 0, 0)},
-{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0)},
-{ImageType::WIN, Image(image_endline_victor, 128, 64, 0, 0)},
-{ImageType::LOSE, Image(image_endline_loser, 128, 64, 0, 0)},
+{ImageType::CONNECT, Image(image_endline_connect, 128, 64, 0, 0, "CONNECTED")},
+{ImageType::COUNTDOWN_THREE, Image(image_endline_count3, 128, 64, 0, 0, "3")},
+{ImageType::COUNTDOWN_TWO, Image(image_endline_count2, 128, 64, 0, 0, "2")},
+{ImageType::COUNTDOWN_ONE, Image(image_endline_count1, 128, 64, 0, 0, "1")},
+{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0, "DRAW!")},
+{ImageType::WIN, Image(image_endline_victor, 128, 64, 0, 0, "VICTORY")},
+{ImageType::LOSE, Image(image_endline_loser, 128, 64, 0, 0, "DEFEATED")},
 };
 
 const ImageCollection resistanceImageCollection = {
@@ -59,13 +59,13 @@ const ImageCollection resistanceImageCollection = {
 {ImageType::LOGO_LEFT, Image(image_resistance_stamp, 128, 64, 0, 0)},
 {ImageType::IDLE, Image(image_resistance_0, 128, 64, 0, 0)},
 {ImageType::STAMP, Image(image_resistance_stamp, 128, 64, 64, 0)},
-{ImageType::CONNECT, Image(image_resistance_connect, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_THREE, Image(image_resistance_count3, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_TWO, Image(image_resistance_count2, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_ONE, Image(image_resistance_count1, 128, 64, 0, 0)},
-{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0)},
-{ImageType::WIN, Image(image_resistance_victor, 128, 64, 0, 0)},
-{ImageType::LOSE, Image(image_resistance_loser, 128, 64, 0, 0)},
+{ImageType::CONNECT, Image(image_resistance_connect, 128, 64, 0, 0, "CONNECTED")},
+{ImageType::COUNTDOWN_THREE, Image(image_resistance_count3, 128, 64, 0, 0, "3")},
+{ImageType::COUNTDOWN_TWO, Image(image_resistance_count2, 128, 64, 0, 0, "2")},
+{ImageType::COUNTDOWN_ONE, Image(image_resistance_count1, 128, 64, 0, 0, "1")},
+{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0, "DRAW!")},
+{ImageType::WIN, Image(image_resistance_victor, 128, 64, 0, 0, "VICTORY")},
+{ImageType::LOSE, Image(image_resistance_loser, 128, 64, 0, 0, "DEFEATED")},
 };
 
 // Equivalent LEDColor palettes (derived from FastLED HTML colors in crgb.h):

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -18,14 +18,16 @@ enum class ImageType {
 };
 
 struct Image {
-    Image() : rawImage(nullptr), width(0), height(0), defaultStartX(0), defaultStartY(0) {}
-    
-    Image(const unsigned char* rawImage, int width, int height, int defaultStartX, int defaultStartY) {
+    Image() : rawImage(nullptr), width(0), height(0), defaultStartX(0), defaultStartY(0), name(nullptr) {}
+
+    Image(const unsigned char* rawImage, int width, int height,
+          int defaultStartX, int defaultStartY, const char* name = nullptr) {
         this->rawImage = rawImage;
         this->width = width;
         this->height = height;
         this->defaultStartX = defaultStartX;
         this->defaultStartY = defaultStartY;
+        this->name = name;
     }
 
     const unsigned char* rawImage;
@@ -33,4 +35,5 @@ struct Image {
     int height;
     int defaultStartX;
     int defaultStartY;
+    const char* name;
 };

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -312,6 +312,14 @@ TEST_F(NativeDisplayDriverTestSuite, RenderToBrailleDotMapping) {
 }
 
 // ============================================
+// NATIVE DISPLAY DRIVER TESTS - Opaque Rendering
+// ============================================
+
+TEST_F(NativeDisplayDriverTestSuite, OpaqueImageClearing) {
+    displayDriverOpaqueImageClearing(this);
+}
+
+// ============================================
 // CLI DISPLAY COMMAND TESTS
 // ============================================
 

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -312,8 +312,16 @@ TEST_F(NativeDisplayDriverTestSuite, RenderToBrailleDotMapping) {
 }
 
 // ============================================
-// NATIVE DISPLAY DRIVER TESTS - Opaque Rendering
+// NATIVE DISPLAY DRIVER TESTS - Image Captions & Opaque Rendering
 // ============================================
+
+TEST_F(NativeDisplayDriverTestSuite, ImageCaptionAddsToHistory) {
+    displayDriverImageCaptionAddsToHistory(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, ImageNullNameNoCaption) {
+    displayDriverImageNullNameNoCaption(this);
+}
 
 TEST_F(NativeDisplayDriverTestSuite, OpaqueImageClearing) {
     displayDriverOpaqueImageClearing(this);

--- a/test/test_cli/native-driver-tests.hpp
+++ b/test/test_cli/native-driver-tests.hpp
@@ -749,7 +749,32 @@ void displayDriverRenderToBrailleDotMapping(NativeDisplayDriverTestSuite* suite)
     ASSERT_EQ(lines[0].substr(0, 3), expected);
 }
 
-// --- Opaque rendering tests ---
+// --- Image caption and opaque rendering tests ---
+
+// Test: drawImage with a named image adds caption to text history
+void displayDriverImageCaptionAddsToHistory(NativeDisplayDriverTestSuite* suite) {
+    const unsigned char xbmData[] = { 0xFF };
+    Image img(xbmData, 8, 1, 0, 0, "DRAW!");
+
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawImage(img);
+
+    const auto& history = suite->driver_->getTextHistory();
+    ASSERT_EQ(history.size(), 1u);
+    ASSERT_EQ(history[0], "DRAW!");
+}
+
+// Test: drawImage with null name does not add to text history
+void displayDriverImageNullNameNoCaption(NativeDisplayDriverTestSuite* suite) {
+    const unsigned char xbmData[] = { 0xFF };
+    Image img(xbmData, 8, 1, 0, 0);  // no name (nullptr)
+
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawImage(img);
+
+    const auto& history = suite->driver_->getTextHistory();
+    ASSERT_TRUE(history.empty());
+}
 
 // Test: Opaque rendering — 0-bits in a second image clear pixels from a first image
 void displayDriverOpaqueImageClearing(NativeDisplayDriverTestSuite* suite) {


### PR DESCRIPTION
## Summary
- **Opaque image rendering**: `decodeXBMToBuffer` now writes both ON and OFF pixels, so overlaid images (like the duel DRAW screen) properly clear underlying pixels. This makes dark text like "NOW!" visible on the white box instead of bleeding through the IDLE image underneath.
- **Image captions**: Added a `name` field to the `Image` struct. The native display driver adds it to text history when present, so CLI captions show "3", "2", "1", "DRAW!" during countdown instead of stale idle-state text. Caption strings added for CONNECT, COUNTDOWN_THREE/TWO/ONE, DRAW, WIN, and LOSE across all 4 allegiance collections.

## Test plan
- [x] 3 new tests added (83 total, all passing)
- [x] Run simulator with 2 devices, cable them, trigger countdown
- [x] Verify braille mirror shows "NOW!" as dark text on white box in duel state
- [x] Verify captions show "3", "2", "1", "DRAW!" during countdown
- [x] Verify `display on`, `display off`, `mirror`, `captions` commands still work