### PR TITLE
Fix opaque rendering and add image captions

### DIFF
--- a/include/device/drivers/native/native-display-driver.hpp
+++ b/include/device/drivers/native/native-display-driver.hpp
@@ -187,6 +187,9 @@ public:
 
     Display* drawImage(Image image, int xStart, int yStart) override {
         currentImage_ = image;
+        if (image.name) {
+            addToTextHistory(image.name);
+        }
         int x = image.defaultStartX;
         int y = image.defaultStartY;
         if (xStart != -1) x = xStart;

--- a/include/device/drivers/native/native-display-driver.hpp
+++ b/include/device/drivers/native/native-display-driver.hpp
@@ -340,9 +340,7 @@ private:
                 int byteIndex = row * bytesPerRow + col / 8;
                 int bitIndex = col % 8;  // LSB first
                 bool pixelOn = (data[byteIndex] >> bitIndex) & 1;
-                if (pixelOn) {
-                    setPixel(offsetX + col, offsetY + row, true);
-                }
+                setPixel(offsetX + col, offsetY + row, pixelOn);
             }
         }
     }

--- a/include/game/quickdraw-resources.hpp
+++ b/include/game/quickdraw-resources.hpp
@@ -17,13 +17,13 @@ const ImageCollection alleycatImageCollection = {
 {ImageType::LOGO_LEFT, Image(image_logo_alley, 128, 64, 0, 0)},
 {ImageType::IDLE, Image(image_alley_0, 128, 64, 0, 0)},
 {ImageType::STAMP, Image(image_alley_stamp, 128, 64, 64, 0)},
-{ImageType::CONNECT, Image(image_alley_connect, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_THREE, Image(image_alley_count3, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_TWO, Image(image_alley_count2, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_ONE, Image(image_alley_count1, 128, 64, 0, 0)},
-{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0)},
-{ImageType::WIN, Image(image_alley_victor, 128, 64, 0, 0)},
-{ImageType::LOSE, Image(image_alley_loser, 128, 64, 0, 0)},
+{ImageType::CONNECT, Image(image_alley_connect, 128, 64, 0, 0, "CONNECTED")},
+{ImageType::COUNTDOWN_THREE, Image(image_alley_count3, 128, 64, 0, 0, "3")},
+{ImageType::COUNTDOWN_TWO, Image(image_alley_count2, 128, 64, 0, 0, "2")},
+{ImageType::COUNTDOWN_ONE, Image(image_alley_count1, 128, 64, 0, 0, "1")},
+{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0, "DRAW!")},
+{ImageType::WIN, Image(image_alley_victor, 128, 64, 0, 0, "VICTORY")},
+{ImageType::LOSE, Image(image_alley_loser, 128, 64, 0, 0, "DEFEATED")},
 };
 
 const ImageCollection helixImageCollection = {
@@ -31,13 +31,13 @@ const ImageCollection helixImageCollection = {
     {ImageType::LOGO_LEFT, Image(image_logo_helix, 128, 64, 0, 0)},
 {ImageType::IDLE, Image(image_helix_0, 128, 64, 0, 0)},
 {ImageType::STAMP, Image(image_helix_stamp, 128, 64, 64, 0)},
-{ImageType::CONNECT, Image(image_helix_connect, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_THREE, Image(image_helix_count3, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_TWO, Image(image_helix_count2, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_ONE, Image(image_helix_count1, 128, 64, 0, 0)},
-{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0)},
-{ImageType::WIN, Image(image_helix_victor, 128, 64, 0, 0)},
-{ImageType::LOSE, Image(image_helix_loser, 128, 64, 0, 0)},
+{ImageType::CONNECT, Image(image_helix_connect, 128, 64, 0, 0, "CONNECTED")},
+{ImageType::COUNTDOWN_THREE, Image(image_helix_count3, 128, 64, 0, 0, "3")},
+{ImageType::COUNTDOWN_TWO, Image(image_helix_count2, 128, 64, 0, 0, "2")},
+{ImageType::COUNTDOWN_ONE, Image(image_helix_count1, 128, 64, 0, 0, "1")},
+{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0, "DRAW!")},
+{ImageType::WIN, Image(image_helix_victor, 128, 64, 0, 0, "VICTORY")},
+{ImageType::LOSE, Image(image_helix_loser, 128, 64, 0, 0, "DEFEATED")},
 };
 
 const ImageCollection endlineImageCollection = {
@@ -45,13 +45,13 @@ const ImageCollection endlineImageCollection = {
 {ImageType::LOGO_LEFT, Image(image_logo_endline, 128, 64, 0, 0)},
 {ImageType::IDLE, Image(image_endline_0, 128, 64, 0, 0)},
 {ImageType::STAMP, Image(image_endline_stamp, 128, 64, 64, 0)},
-{ImageType::CONNECT, Image(image_endline_connect, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_THREE, Image(image_endline_count3, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_TWO, Image(image_endline_count2, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_ONE, Image(image_endline_count1, 128, 64, 0, 0)},
-{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0)},
-{ImageType::WIN, Image(image_endline_victor, 128, 64, 0, 0)},
-{ImageType::LOSE, Image(image_endline_loser, 128, 64, 0, 0)},
+{ImageType::CONNECT, Image(image_endline_connect, 128, 64, 0, 0, "CONNECTED")},
+{ImageType::COUNTDOWN_THREE, Image(image_endline_count3, 128, 64, 0, 0, "3")},
+{ImageType::COUNTDOWN_TWO, Image(image_endline_count2, 128, 64, 0, 0, "2")},
+{ImageType::COUNTDOWN_ONE, Image(image_endline_count1, 128, 64, 0, 0, "1")},
+{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0, "DRAW!")},
+{ImageType::WIN, Image(image_endline_victor, 128, 64, 0, 0, "VICTORY")},
+{ImageType::LOSE, Image(image_endline_loser, 128, 64, 0, 0, "DEFEATED")},
 };
 
 const ImageCollection resistanceImageCollection = {
@@ -59,13 +59,13 @@ const ImageCollection resistanceImageCollection = {
 {ImageType::LOGO_LEFT, Image(image_resistance_stamp, 128, 64, 0, 0)},
 {ImageType::IDLE, Image(image_resistance_0, 128, 64, 0, 0)},
 {ImageType::STAMP, Image(image_resistance_stamp, 128, 64, 64, 0)},
-{ImageType::CONNECT, Image(image_resistance_connect, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_THREE, Image(image_resistance_count3, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_TWO, Image(image_resistance_count2, 128, 64, 0, 0)},
-{ImageType::COUNTDOWN_ONE, Image(image_resistance_count1, 128, 64, 0, 0)},
-{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0)},
-{ImageType::WIN, Image(image_resistance_victor, 128, 64, 0, 0)},
-{ImageType::LOSE, Image(image_resistance_loser, 128, 64, 0, 0)},
+{ImageType::CONNECT, Image(image_resistance_connect, 128, 64, 0, 0, "CONNECTED")},
+{ImageType::COUNTDOWN_THREE, Image(image_resistance_count3, 128, 64, 0, 0, "3")},
+{ImageType::COUNTDOWN_TWO, Image(image_resistance_count2, 128, 64, 0, 0, "2")},
+{ImageType::COUNTDOWN_ONE, Image(image_resistance_count1, 128, 64, 0, 0, "1")},
+{ImageType::DRAW, Image(image_draw, 128, 64, 64, 0, "DRAW!")},
+{ImageType::WIN, Image(image_resistance_victor, 128, 64, 0, 0, "VICTORY")},
+{ImageType::LOSE, Image(image_resistance_loser, 128, 64, 0, 0, "DEFEATED")},
 };
 
 // Equivalent LEDColor palettes (derived from FastLED HTML colors in crgb.h):

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -18,14 +18,16 @@ enum class ImageType {
 };
 
 struct Image {
-    Image() : rawImage(nullptr), width(0), height(0), defaultStartX(0), defaultStartY(0) {}
-    
-    Image(const unsigned char* rawImage, int width, int height, int defaultStartX, int defaultStartY) {
+    Image() : rawImage(nullptr), width(0), height(0), defaultStartX(0), defaultStartY(0), name(nullptr) {}
+
+    Image(const unsigned char* rawImage, int width, int height,
+          int defaultStartX, int defaultStartY, const char* name = nullptr) {
         this->rawImage = rawImage;
         this->width = width;
         this->height = height;
         this->defaultStartX = defaultStartX;
         this->defaultStartY = defaultStartY;
+        this->name = name;
     }
 
     const unsigned char* rawImage;
@@ -33,4 +35,5 @@ struct Image {
     int height;
     int defaultStartX;
     int defaultStartY;
+    const char* name;
 };

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -312,6 +312,22 @@ TEST_F(NativeDisplayDriverTestSuite, RenderToBrailleDotMapping) {
 }
 
 // ============================================
+// NATIVE DISPLAY DRIVER TESTS - Image Captions & Opaque Rendering
+// ============================================
+
+TEST_F(NativeDisplayDriverTestSuite, ImageCaptionAddsToHistory) {
+    displayDriverImageCaptionAddsToHistory(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, ImageNullNameNoCaption) {
+    displayDriverImageNullNameNoCaption(this);
+}
+
+TEST_F(NativeDisplayDriverTestSuite, OpaqueImageClearing) {
+    displayDriverOpaqueImageClearing(this);
+}
+
+// ============================================
 // CLI DISPLAY COMMAND TESTS
 // ============================================
 

--- a/test/test_cli/native-driver-tests.hpp
+++ b/test/test_cli/native-driver-tests.hpp
@@ -749,6 +749,63 @@ void displayDriverRenderToBrailleDotMapping(NativeDisplayDriverTestSuite* suite)
     ASSERT_EQ(lines[0].substr(0, 3), expected);
 }
 
+// --- Image caption and opaque rendering tests ---
+
+// Test: drawImage with a named image adds caption to text history
+void displayDriverImageCaptionAddsToHistory(NativeDisplayDriverTestSuite* suite) {
+    const unsigned char xbmData[] = { 0xFF };
+    Image img(xbmData, 8, 1, 0, 0, "DRAW!");
+
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawImage(img);
+
+    const auto& history = suite->driver_->getTextHistory();
+    ASSERT_EQ(history.size(), 1u);
+    ASSERT_EQ(history[0], "DRAW!");
+}
+
+// Test: drawImage with null name does not add to text history
+void displayDriverImageNullNameNoCaption(NativeDisplayDriverTestSuite* suite) {
+    const unsigned char xbmData[] = { 0xFF };
+    Image img(xbmData, 8, 1, 0, 0);  // no name (nullptr)
+
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawImage(img);
+
+    const auto& history = suite->driver_->getTextHistory();
+    ASSERT_TRUE(history.empty());
+}
+
+// Test: Opaque rendering — 0-bits in a second image clear pixels from a first image
+void displayDriverOpaqueImageClearing(NativeDisplayDriverTestSuite* suite) {
+    // First image: all white (all pixels on)
+    unsigned char whiteData[16];  // 8x1 row = 1 byte, but use 128x1 = 16 bytes
+    memset(whiteData, 0xFF, sizeof(whiteData));
+    Image whiteImg(whiteData, 128, 1, 0, 0);
+
+    // Second image: alternating pattern (some pixels off)
+    // 0xAA = 10101010 LSB-first: pixels 1,3,5,7 on; 0,2,4,6 off
+    unsigned char mixedData[16];
+    memset(mixedData, 0xAA, sizeof(mixedData));
+    Image mixedImg(mixedData, 128, 1, 0, 0);
+
+    suite->driver_->invalidateScreen();
+    suite->driver_->drawImage(whiteImg);
+
+    // All pixels should be on after first image
+    ASSERT_TRUE(suite->driver_->getPixel(0, 0));
+    ASSERT_TRUE(suite->driver_->getPixel(1, 0));
+
+    // Draw second image on top — 0-bits should clear pixels
+    suite->driver_->drawImage(mixedImg);
+
+    // 0xAA LSB-first: bit0=0, bit1=1, bit2=0, bit3=1, ...
+    ASSERT_FALSE(suite->driver_->getPixel(0, 0));  // bit 0 = 0 → cleared
+    ASSERT_TRUE(suite->driver_->getPixel(1, 0));   // bit 1 = 1 → still on
+    ASSERT_FALSE(suite->driver_->getPixel(2, 0));  // bit 2 = 0 → cleared
+    ASSERT_TRUE(suite->driver_->getPixel(3, 0));   // bit 3 = 1 → still on
+}
+
 // ============================================
 // CLI DISPLAY COMMAND TEST SUITE
 // ============================================


### PR DESCRIPTION
Fixes #69

## Summary
- **Opaque image rendering**: `decodeXBMToBuffer` now writes both ON and OFF pixels, so overlay images (like "NOW!" during duel) properly clear underlying pixels instead of blending
- **Image captions**: Added `name` field to `Image` struct; native display driver adds it to text history when present, giving countdown/game screens accurate captions

## Test plan
- [ ] Tests added for opaque rendering and caption behavior
- [ ] All existing tests pass (80/80)
- [ ] Verify in simulator: countdown shows "3", "2", "1", "DRAW!" captions
- [ ] Verify in simulator: braille mirror shows "NOW!" dark text on white box