### PR TITLE
Challenge Device System: Full Pipeline (NPC + Signal Echo + SM Manager + Integration)

### DIFF
--- a/include/cli/cli-commands.hpp
+++ b/include/cli/cli-commands.hpp
@@ -635,21 +635,7 @@ private:
             }
 
             GameType gameType;
-            if (gameName == "signal-echo" || gameName == "signalecho" || gameName == "7007") {
-                gameType = GameType::SIGNAL_ECHO;
-            } else if (gameName == "ghost-runner" || gameName == "7001") {
-                gameType = GameType::GHOST_RUNNER;
-            } else if (gameName == "spike-vector" || gameName == "7002") {
-                gameType = GameType::SPIKE_VECTOR;
-            } else if (gameName == "firewall-decrypt" || gameName == "7003") {
-                gameType = GameType::FIREWALL_DECRYPT;
-            } else if (gameName == "cipher-path" || gameName == "7004") {
-                gameType = GameType::CIPHER_PATH;
-            } else if (gameName == "exploit-sequencer" || gameName == "7005") {
-                gameType = GameType::EXPLOIT_SEQUENCER;
-            } else if (gameName == "breach-defense" || gameName == "7006") {
-                gameType = GameType::BREACH_DEFENSE;
-            } else {
+            if (!parseGameName(gameName, gameType)) {
                 result.message = "Unknown game: " + tokens[2] + ". Options: signal-echo, ghost-runner, spike-vector, firewall-decrypt, cipher-path, exploit-sequencer, breach-defense";
                 return result;
             }

--- a/include/cli/cli-event-logger.hpp
+++ b/include/cli/cli-event-logger.hpp
@@ -1,0 +1,192 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <string>
+#include <vector>
+#include <functional>
+#include <cstdio>
+#include <cstdint>
+
+namespace cli {
+
+enum class EventType {
+    STATE_CHANGE,
+    BUTTON_PRESS,
+    SERIAL_TX,
+    SERIAL_RX,
+    ESPNOW_TX,
+    ESPNOW_RX,
+    DISPLAY_TEXT,
+    DISPLAY_CLEAR,
+    HTTP_REQUEST,
+    HTTP_RESPONSE,
+};
+
+struct Event {
+    unsigned long timestampMs = 0;
+    EventType type;
+    int deviceIndex = -1;
+    std::string detail;
+
+    // Type-specific queryable fields
+    std::string fromState;
+    std::string toState;
+    std::string message;
+    std::string button;
+};
+
+inline const char* eventTypeName(EventType type) {
+    switch (type) {
+        case EventType::STATE_CHANGE:  return "STATE_CHANGE";
+        case EventType::BUTTON_PRESS:  return "BUTTON_PRESS";
+        case EventType::SERIAL_TX:     return "SERIAL_TX";
+        case EventType::SERIAL_RX:     return "SERIAL_RX";
+        case EventType::ESPNOW_TX:     return "ESPNOW_TX";
+        case EventType::ESPNOW_RX:     return "ESPNOW_RX";
+        case EventType::DISPLAY_TEXT:  return "DISPLAY_TEXT";
+        case EventType::DISPLAY_CLEAR: return "DISPLAY_CLEAR";
+        case EventType::HTTP_REQUEST:  return "HTTP_REQUEST";
+        case EventType::HTTP_RESPONSE: return "HTTP_RESPONSE";
+    }
+    return "UNKNOWN";
+}
+
+class EventLogger {
+public:
+    void log(const Event& event) {
+        events_.push_back(event);
+    }
+
+    std::vector<Event> getAll() const {
+        return events_;
+    }
+
+    std::vector<Event> getByType(EventType type) const {
+        std::vector<Event> result;
+        for (auto& e : events_) {
+            if (e.type == type) result.push_back(e);
+        }
+        return result;
+    }
+
+    std::vector<Event> getByDevice(int deviceIndex) const {
+        std::vector<Event> result;
+        for (auto& e : events_) {
+            if (e.deviceIndex == deviceIndex) result.push_back(e);
+        }
+        return result;
+    }
+
+    std::vector<Event> getByTypeAndDevice(EventType type, int deviceIndex) const {
+        std::vector<Event> result;
+        for (auto& e : events_) {
+            if (e.type == type && e.deviceIndex == deviceIndex) result.push_back(e);
+        }
+        return result;
+    }
+
+    Event getLast(EventType type) const {
+        for (int i = static_cast<int>(events_.size()) - 1; i >= 0; i--) {
+            if (events_[i].type == type) return events_[i];
+        }
+        return Event{};
+    }
+
+    Event getLast(EventType type, int deviceIndex) const {
+        for (int i = static_cast<int>(events_.size()) - 1; i >= 0; i--) {
+            if (events_[i].type == type && events_[i].deviceIndex == deviceIndex) {
+                return events_[i];
+            }
+        }
+        return Event{};
+    }
+
+    bool hasEvent(EventType type, const std::string& detailSubstring) const {
+        for (auto& e : events_) {
+            if (e.type == type) {
+                if (e.detail.find(detailSubstring) != std::string::npos ||
+                    e.message.find(detailSubstring) != std::string::npos) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    size_t count(EventType type) const {
+        size_t c = 0;
+        for (auto& e : events_) {
+            if (e.type == type) c++;
+        }
+        return c;
+    }
+
+    size_t count(EventType type, int deviceIndex) const {
+        size_t c = 0;
+        for (auto& e : events_) {
+            if (e.type == type && e.deviceIndex == deviceIndex) c++;
+        }
+        return c;
+    }
+
+    void clear() {
+        events_.clear();
+    }
+
+    size_t size() const {
+        return events_.size();
+    }
+
+    std::string formatEvent(const Event& event) const {
+        char ts[16];
+        snprintf(ts, sizeof(ts), "[%04lums]", event.timestampMs);
+
+        std::string line = std::string(ts) + " " + eventTypeName(event.type);
+
+        // Pad type name to 14 chars for alignment
+        while (line.size() < 24) line += ' ';
+
+        line += "dev=" + std::to_string(event.deviceIndex);
+
+        switch (event.type) {
+            case EventType::STATE_CHANGE:
+                line += " from=" + event.fromState + " to=" + event.toState;
+                break;
+            case EventType::BUTTON_PRESS:
+                line += " button=" + event.button;
+                break;
+            case EventType::SERIAL_TX:
+            case EventType::SERIAL_RX:
+                line += " msg=\"" + event.message + "\"";
+                break;
+            case EventType::DISPLAY_TEXT:
+                line += " text=\"" + event.message + "\"";
+                break;
+            default:
+                if (!event.detail.empty()) {
+                    line += " " + event.detail;
+                }
+                break;
+        }
+
+        return line;
+    }
+
+    bool writeToFile(const std::string& path) const {
+        FILE* f = fopen(path.c_str(), "w");
+        if (!f) return false;
+        for (auto& e : events_) {
+            fprintf(f, "%s\n", formatEvent(e).c_str());
+        }
+        fclose(f);
+        return true;
+    }
+
+private:
+    std::vector<Event> events_;
+};
+
+} // namespace cli
+
+#endif // NATIVE_BUILD

--- a/include/cli/cli-http-server.hpp
+++ b/include/cli/cli-http-server.hpp
@@ -7,7 +7,6 @@
 #include <functional>
 #include <deque>
 #include <cstdio>
-#include <regex>
 #include <vector>
 #include <ArduinoJson.h>
 

--- a/include/cli/cli-http-server.hpp
+++ b/include/cli/cli-http-server.hpp
@@ -8,6 +8,8 @@
 #include <deque>
 #include <cstdio>
 #include <regex>
+#include <vector>
+#include <ArduinoJson.h>
 
 namespace cli {
 
@@ -32,6 +34,11 @@ struct MockPlayerConfig {
     bool isHunter;
     int allegiance;  // 0 = NONE, 1 = RESISTANCE, 2 = HUNTERS_GUILD
     std::string faction;
+
+    // Game progress fields
+    uint8_t konamiProgress = 0;
+    uint8_t equippedColorProfile = 0;  // GameType enum value
+    std::vector<uint8_t> colorProfileEligibility;
 };
 
 /**
@@ -86,6 +93,9 @@ public:
             statusCode = handleGetPlayer(path, responseBody);
         } else if (method == "PUT" && path == "/api/matches") {
             statusCode = handlePutMatches(body, responseBody);
+        } else if (method == "PUT" && path.find("/api/players/") == 0
+                   && path.find("/progress") != std::string::npos) {
+            statusCode = handlePutProgress(path, body, responseBody);
         } else {
             statusCode = 404;
             responseBody = R"({"errors":["Not found"]})";
@@ -196,9 +206,9 @@ private:
             // Player not found - return a default based on ID
             // For CLI, generate sensible defaults
             bool defaultHunter = (std::stoi(playerId) % 2 == 0);  // Even IDs are hunters
-            char buf[512];
+            char buf[1024];
             snprintf(buf, sizeof(buf),
-                R"({"data":{"id":"%s","name":"Player%s","hunter":%s,"allegiance":1,"faction":"Default"}})",
+                R"({"data":{"id":"%s","name":"Player%s","hunter":%s,"allegiance":1,"faction":"Default","konami_progress":0,"equipped_color_profile":0,"color_profile_eligibility":[]}})",
                 playerId.c_str(),
                 playerId.c_str(),
                 defaultHunter ? "true" : "false");
@@ -208,14 +218,26 @@ private:
         
         // Return configured player data
         const MockPlayerConfig& config = it->second;
-        char buf[512];
+
+        // Build eligibility array string
+        std::string eligibilityStr = "[";
+        for (size_t i = 0; i < config.colorProfileEligibility.size(); i++) {
+            if (i > 0) eligibilityStr += ",";
+            eligibilityStr += std::to_string(config.colorProfileEligibility[i]);
+        }
+        eligibilityStr += "]";
+
+        char buf[1024];
         snprintf(buf, sizeof(buf),
-            R"({"data":{"id":"%s","name":"%s","hunter":%s,"allegiance":%d,"faction":"%s"}})",
+            R"({"data":{"id":"%s","name":"%s","hunter":%s,"allegiance":%d,"faction":"%s","konami_progress":%d,"equipped_color_profile":%d,"color_profile_eligibility":%s}})",
             config.id.c_str(),
             config.name.c_str(),
             config.isHunter ? "true" : "false",
             config.allegiance,
-            config.faction.c_str());
+            config.faction.c_str(),
+            config.konamiProgress,
+            config.equippedColorProfile,
+            eligibilityStr.c_str());
         responseBody = buf;
         return 200;
     }
@@ -227,6 +249,44 @@ private:
         // Just acknowledge the match upload
         // In a real server, we'd parse and store the matches
         responseBody = R"({"success":true,"message":"Matches uploaded"})";
+        return 200;
+    }
+
+    /**
+     * Handle PUT /api/players/{id}/progress
+     */
+    int handlePutProgress(const std::string& path,
+                          const std::string& body,
+                          std::string& responseBody) {
+        // Extract player ID from path like "/api/players/0010/progress"
+        const std::string prefix = "/api/players/";
+        const std::string suffix = "/progress";
+        std::string playerId;
+        if (path.find(prefix) == 0 && path.find(suffix) != std::string::npos) {
+            size_t start = prefix.length();
+            size_t end = path.find(suffix);
+            playerId = path.substr(start, end - start);
+        }
+
+        if (playerId.empty()) {
+            responseBody = R"({"errors":["Invalid player ID"]})";
+            return 400;
+        }
+
+        // Update the player config if it exists
+        auto it = playerConfigs_.find(playerId);
+        if (it != playerConfigs_.end()) {
+            // Parse the progress update from body
+            JsonDocument doc;
+            DeserializationError error = deserializeJson(doc, body);
+            if (!error) {
+                if (doc.containsKey("konami_progress")) {
+                    it->second.konamiProgress = doc["konami_progress"].as<uint8_t>();
+                }
+            }
+        }
+
+        responseBody = R"({"success":true,"message":"Progress updated"})";
         return 200;
     }
 };

--- a/include/cli/cli-renderer.hpp
+++ b/include/cli/cli-renderer.hpp
@@ -223,7 +223,7 @@ private:
         } else {
             for (size_t i = 0; i < device.stateHistory.size(); i++) {
                 if (i > 0) historyStr += " -> ";
-                historyStr += getStateName(device.stateHistory[i]);
+                historyStr += getStateName(device.stateHistory[i], device.deviceType);
             }
         }
         

--- a/include/cli/cli-renderer.hpp
+++ b/include/cli/cli-renderer.hpp
@@ -48,18 +48,22 @@ public:
             for (size_t i = 0; i < devices.size(); i++) {
                 if (i > 0) selectorBar += "  ";
                 
+                const char* roleLabel;
+                if (devices[i].deviceType == DeviceType::CHALLENGE) {
+                    roleLabel = "NPC";
+                } else {
+                    roleLabel = devices[i].isHunter ? "H" : "B";
+                }
                 if (static_cast<int>(i) == selectedDeviceIndex) {
-                    // Selected device - highlighted
                     selectorBar += format("\033[1;7;33m[%d] %s %s\033[0m",
                                           static_cast<int>(i),
                                           devices[i].deviceId.c_str(),
-                                          devices[i].isHunter ? "H" : "B");
+                                          roleLabel);
                 } else {
-                    // Unselected device - dim
                     selectorBar += format("\033[90m[%d] %s %s\033[0m",
                                           static_cast<int>(i),
                                           devices[i].deviceId.c_str(),
-                                          devices[i].isHunter ? "H" : "B");
+                                          roleLabel);
                 }
             }
             selectorBar += "   \033[90m(LEFT/RIGHT to switch)\033[0m";
@@ -349,21 +353,36 @@ private:
         // Buffer all lines - use brighter color for selected device
         const char* headerColor = isSelected ? "\033[1;33m" : "\033[33m";  // Bold yellow vs dim yellow
         const char* selectedMarker = isSelected ? " *SELECTED*" : "";
+        const char* typeLabel;
+        if (device.deviceType == DeviceType::CHALLENGE) {
+            typeLabel = "NPC";
+        } else {
+            typeLabel = device.isHunter ? "HUNTER" : "BOUNTY";
+        }
         bufferLine(format("%s+-- Device [%s] %-6s%s -------------------------------+\033[0m",
                    headerColor,
                    device.deviceId.c_str(),
-                   device.isHunter ? "HUNTER" : "BOUNTY",
+                   typeLabel,
                    selectedMarker));
         
-        bufferLine(format("| Player: ID=%-4s  Allegiance=%-10s  W=%d L=%d Streak=%d",
-                   device.player->getUserID().c_str(),
-                   device.player->getAllegianceString().c_str(),
-                   device.player->getWins(),
-                   device.player->getLosses(),
-                   device.player->getStreak()));
+        if (device.deviceType == DeviceType::CHALLENGE) {
+            bufferLine(format("| NPC: %s  Reward: %s",
+                       getGameDisplayName(device.gameType),
+                       getKonamiButtonName(getRewardForGame(device.gameType))));
+        } else {
+            bufferLine(format("| Player: ID=%-4s  Allegiance=%-10s  W=%d L=%d Streak=%d",
+                       device.player->getUserID().c_str(),
+                       device.player->getAllegianceString().c_str(),
+                       device.player->getWins(),
+                       device.player->getLosses(),
+                       device.player->getStreak()));
+        }
         
-        bufferLine(format("| State: [%2d] %-20s  Game: Quickdraw",
-                   stateId, getStateName(stateId)));
+        const char* gameName = (device.deviceType == DeviceType::CHALLENGE)
+            ? getGameDisplayName(device.gameType) : "Quickdraw";
+        const char* stateName = getStateName(stateId, device.deviceType);
+        bufferLine(format("| State: [%2d] %-20s  Game: %s",
+                   stateId, stateName, gameName));
         
         bufferLine(format("| History: %s", historyStr.c_str()));
         

--- a/include/cli/cli-script-runner.hpp
+++ b/include/cli/cli-script-runner.hpp
@@ -1,0 +1,739 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <string>
+#include <vector>
+#include <fstream>
+#include <sstream>
+#include <cstdint>
+#include <cstdlib>
+
+#include "cli/cli-device.hpp"
+#include "cli/cli-commands.hpp"
+#include "cli/cli-event-logger.hpp"
+#include "cli/cli-renderer.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "device/drivers/native/native-peer-broker.hpp"
+
+namespace cli {
+
+/**
+ * A single parsed command from a script file.
+ */
+struct ScriptCommand {
+    std::string command;
+    int lineNumber;
+};
+
+/**
+ * ScriptRunner executes CLI automation scripts line-by-line.
+ *
+ * Scripts contain CLI commands, timing directives (wait/tick),
+ * button presses, and assertions. Comments start with '#'.
+ *
+ * Lifecycle:
+ *   1. Construct with references to devices, processor, and event logger.
+ *   2. Load a script via loadFromFile() or loadFromString().
+ *   3. Execute with executeAll() (stops on first error) or
+ *      step through with executeNext().
+ */
+class ScriptRunner {
+public:
+    ScriptRunner(std::vector<DeviceInstance>& devices,
+                 CommandProcessor& commandProcessor,
+                 EventLogger& eventLogger) :
+        devices_(devices),
+        commandProcessor_(commandProcessor),
+        eventLogger_(eventLogger)
+    {
+    }
+
+    /**
+     * Load script commands from a file.
+     * Returns false if the file cannot be opened.
+     */
+    bool loadFromFile(const std::string& path) {
+        std::ifstream file(path);
+        if (!file.is_open()) {
+            return false;
+        }
+        std::string content((std::istreambuf_iterator<char>(file)),
+                             std::istreambuf_iterator<char>());
+        loadFromString(content);
+        return true;
+    }
+
+    /**
+     * Load script commands from a string.
+     * Strips comments (everything after #), trims whitespace,
+     * and skips blank lines.
+     */
+    void loadFromString(const std::string& script) {
+        commands_.clear();
+        currentIndex_ = 0;
+
+        std::istringstream stream(script);
+        std::string line;
+        int lineNumber = 0;
+
+        while (std::getline(stream, line)) {
+            lineNumber++;
+
+            // Strip comment (everything after #)
+            size_t commentPos = line.find('#');
+            if (commentPos != std::string::npos) {
+                line = line.substr(0, commentPos);
+            }
+
+            // Trim whitespace
+            line = trim(line);
+
+            // Skip empty lines
+            if (line.empty()) {
+                continue;
+            }
+
+            commands_.push_back({line, lineNumber});
+        }
+    }
+
+    /**
+     * Execute the next command in the script.
+     * Returns empty string on success, or an error message on failure.
+     */
+    std::string executeNext() {
+        if (!hasMore()) {
+            return "No more commands";
+        }
+
+        const ScriptCommand& cmd = commands_[currentIndex_];
+        currentIndex_++;
+
+        std::string error = executeCommand(cmd);
+        if (!error.empty()) {
+            return "Line " + std::to_string(cmd.lineNumber) + ": " + error;
+        }
+        return "";
+    }
+
+    /**
+     * Execute all remaining commands.
+     * Stops on the first error and returns that error message.
+     * Returns empty string if all commands succeeded.
+     */
+    std::string executeAll() {
+        while (hasMore()) {
+            std::string error = executeNext();
+            if (!error.empty()) {
+                return error;
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Returns true if there are more commands to execute.
+     */
+    bool hasMore() const {
+        return currentIndex_ < commands_.size();
+    }
+
+    /**
+     * Returns the line number of the current (next-to-execute) command,
+     * or -1 if no more commands remain.
+     */
+    int currentLine() const {
+        if (currentIndex_ < commands_.size()) {
+            return commands_[currentIndex_].lineNumber;
+        }
+        return -1;
+    }
+
+    /**
+     * Returns the total number of parsed commands.
+     */
+    size_t commandCount() const {
+        return commands_.size();
+    }
+
+private:
+    std::vector<DeviceInstance>& devices_;
+    CommandProcessor& commandProcessor_;
+    EventLogger& eventLogger_;
+
+    std::vector<ScriptCommand> commands_;
+    size_t currentIndex_ = 0;
+
+    // Dummy renderer for passing to CommandProcessor
+    Renderer dummyRenderer_;
+    int selectedDevice_ = 0;
+
+    static constexpr unsigned long TICK_MS = 33;
+
+    /**
+     * Execute a single script command.
+     * Returns empty string on success, error message on failure.
+     */
+    std::string executeCommand(const ScriptCommand& cmd) {
+        std::vector<std::string> tokens = tokenize(cmd.command);
+        if (tokens.empty()) {
+            return "";
+        }
+
+        const std::string& verb = tokens[0];
+
+        // Script-specific commands handled directly
+        if (verb == "wait") {
+            return handleWait(tokens);
+        }
+        if (verb == "tick") {
+            return handleTick(tokens);
+        }
+        if (verb == "press") {
+            return handlePress(tokens);
+        }
+        if (verb == "longpress") {
+            return handleLongPress(tokens);
+        }
+        if (verb == "assert-state") {
+            return handleAssertState(tokens);
+        }
+        if (verb == "assert-text") {
+            return handleAssertText(tokens);
+        }
+        if (verb == "assert-serial-tx") {
+            return handleAssertSerialTx(tokens);
+        }
+        if (verb == "assert-serial-rx") {
+            return handleAssertSerialRx(tokens);
+        }
+        if (verb == "assert-event") {
+            return handleAssertEvent(tokens);
+        }
+        if (verb == "assert-no-event") {
+            return handleAssertNoEvent(tokens);
+        }
+        if (verb == "advance") {
+            return handleAdvance(tokens);
+        }
+        if (verb == "inspect") {
+            return handleInspect(tokens);
+        }
+        if (verb == "events") {
+            return handleEvents(tokens);
+        }
+        if (verb == "clear-events") {
+            eventLogger_.clear();
+            return "";
+        }
+
+        // Everything else passes through to CommandProcessor
+        CommandResult result = commandProcessor_.execute(
+            cmd.command, devices_, selectedDevice_, dummyRenderer_);
+
+        if (result.shouldQuit) {
+            return "";  // Quit is valid, not an error
+        }
+
+        // CommandProcessor returns "Unknown command: ..." for bad commands
+        if (result.message.find("Unknown command") != std::string::npos) {
+            return result.message;
+        }
+
+        return "";
+    }
+
+    // ==================== COMMAND HANDLERS ====================
+
+    /**
+     * wait <ms> - Advance all device clocks by <ms> milliseconds
+     * and run the appropriate number of loop iterations.
+     */
+    std::string handleWait(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 2) {
+            return "Usage: wait <ms>";
+        }
+
+        long msRaw = std::atol(tokens[1].c_str());
+        if (msRaw <= 0) {
+            return "wait requires a positive millisecond value";
+        }
+        unsigned long ms = static_cast<unsigned long>(msRaw);
+
+        // Interleave clock advances with loop iterations (same as tick)
+        unsigned long iterations = ms / TICK_MS;
+        if (iterations < 1) iterations = 1;
+        unsigned long advanced = 0;
+
+        for (unsigned long i = 0; i < iterations; i++) {
+            unsigned long step = (i < iterations - 1) ? TICK_MS : (ms - advanced);
+            for (auto& dev : devices_) {
+                dev.clockDriver->advance(step);
+            }
+            advanced += step;
+            runOneLoopIteration();
+        }
+
+        return "";
+    }
+
+    /**
+     * tick [N] - Run N loop iterations (default 1).
+     * Each iteration advances clocks by TICK_MS (33ms).
+     */
+    std::string handleTick(const std::vector<std::string>& tokens) {
+        unsigned long count = 1;
+        if (tokens.size() >= 2) {
+            long raw = std::atol(tokens[1].c_str());
+            count = (raw > 0) ? static_cast<unsigned long>(raw) : 1;
+        }
+
+        for (unsigned long i = 0; i < count; i++) {
+            // Advance clocks by one tick
+            for (auto& dev : devices_) {
+                dev.clockDriver->advance(TICK_MS);
+            }
+            runOneLoopIteration();
+        }
+
+        return "";
+    }
+
+    /**
+     * press <device> primary|secondary - Simulate a button click.
+     */
+    std::string handlePress(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 3) {
+            return "Usage: press <device> primary|secondary";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        std::string button = tokens[2];
+        NativeButtonDriver* driver = nullptr;
+
+        if (button == "primary") {
+            driver = devices_[devIdx].primaryButtonDriver;
+        } else if (button == "secondary") {
+            driver = devices_[devIdx].secondaryButtonDriver;
+        } else {
+            return "Unknown button: " + button + " (use primary or secondary)";
+        }
+
+        driver->execCallback(ButtonInteraction::CLICK);
+
+        // Log a BUTTON_PRESS event
+        Event evt;
+        evt.timestampMs = devices_[devIdx].clockDriver->milliseconds();
+        evt.type = EventType::BUTTON_PRESS;
+        evt.deviceIndex = devIdx;
+        evt.button = button;
+        evt.detail = "click";
+        eventLogger_.log(evt);
+
+        return "";
+    }
+
+    /**
+     * longpress <device> primary|secondary - Simulate a long press.
+     */
+    std::string handleLongPress(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 3) {
+            return "Usage: longpress <device> primary|secondary";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        std::string button = tokens[2];
+        NativeButtonDriver* driver = nullptr;
+
+        if (button == "primary") {
+            driver = devices_[devIdx].primaryButtonDriver;
+        } else if (button == "secondary") {
+            driver = devices_[devIdx].secondaryButtonDriver;
+        } else {
+            return "Unknown button: " + button + " (use primary or secondary)";
+        }
+
+        driver->execCallback(ButtonInteraction::LONG_PRESS);
+
+        // Log a BUTTON_PRESS event
+        Event evt;
+        evt.timestampMs = devices_[devIdx].clockDriver->milliseconds();
+        evt.type = EventType::BUTTON_PRESS;
+        evt.deviceIndex = devIdx;
+        evt.button = button;
+        evt.detail = "longpress";
+        eventLogger_.log(evt);
+
+        return "";
+    }
+
+    /**
+     * assert-state <device> <StateName> - Assert device is in the named state.
+     */
+    std::string handleAssertState(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 3) {
+            return "Usage: assert-state <device> <StateName>";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        std::string expectedState = tokens[2];
+        auto& dev = devices_[devIdx];
+        State* currentState = dev.game->getCurrentState();
+        int stateId = currentState ? currentState->getStateId() : -1;
+        std::string actualState = getStateName(stateId, dev.deviceType);
+
+        if (actualState != expectedState) {
+            return "assert-state failed: device " + tokens[1] +
+                   " is in '" + actualState + "', expected '" + expectedState + "'";
+        }
+
+        return "";
+    }
+
+    /**
+     * assert-text <device> "substring" - Assert device display text history
+     * contains the given substring.
+     */
+    std::string handleAssertText(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 3) {
+            return "Usage: assert-text <device> <substring>";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        // Rejoin remaining tokens to support quoted strings with spaces
+        std::string needle = rejoinTokens(tokens, 2);
+        // Strip surrounding quotes if present
+        needle = stripQuotes(needle);
+
+        auto& dev = devices_[devIdx];
+        const auto& textHistory = dev.displayDriver->getTextHistory();
+
+        for (const auto& text : textHistory) {
+            if (text.find(needle) != std::string::npos) {
+                return "";  // Found
+            }
+        }
+
+        return "assert-text failed: device " + tokens[1] +
+               " display does not contain '" + needle + "'";
+    }
+
+    /**
+     * assert-serial-tx <device> "substring" - Assert device sent serial
+     * data containing the given substring (checks EventLogger).
+     */
+    std::string handleAssertSerialTx(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 3) {
+            return "Usage: assert-serial-tx <device> <substring>";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        std::string needle = rejoinTokens(tokens, 2);
+        needle = stripQuotes(needle);
+
+        auto events = eventLogger_.getByTypeAndDevice(EventType::SERIAL_TX, devIdx);
+        for (const auto& evt : events) {
+            if (evt.message.find(needle) != std::string::npos ||
+                evt.detail.find(needle) != std::string::npos) {
+                return "";  // Found
+            }
+        }
+
+        return "assert-serial-tx failed: device " + tokens[1] +
+               " has no SERIAL_TX containing '" + needle + "'";
+    }
+
+    /**
+     * assert-serial-rx <device> "substring" - Assert device received serial
+     * data containing the given substring (checks EventLogger).
+     */
+    std::string handleAssertSerialRx(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 3) {
+            return "Usage: assert-serial-rx <device> <substring>";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        std::string needle = rejoinTokens(tokens, 2);
+        needle = stripQuotes(needle);
+
+        auto events = eventLogger_.getByTypeAndDevice(EventType::SERIAL_RX, devIdx);
+        for (const auto& evt : events) {
+            if (evt.message.find(needle) != std::string::npos ||
+                evt.detail.find(needle) != std::string::npos) {
+                return "";  // Found
+            }
+        }
+
+        return "assert-serial-rx failed: device " + tokens[1] +
+               " has no SERIAL_RX containing '" + needle + "'";
+    }
+
+    /**
+     * assert-event <TYPE> [dev=N] [substring] - Assert an event of the
+     * given type exists, optionally filtering by device and content.
+     */
+    std::string handleAssertEvent(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 2) {
+            return "Usage: assert-event <TYPE> [dev=N] [substring]";
+        }
+
+        EventType type;
+        if (!parseEventType(tokens[1], type)) {
+            return "Unknown event type: " + tokens[1];
+        }
+
+        int devIdx = -1;
+        std::string needle;
+        parseEventFilters(tokens, 2, devIdx, needle);
+
+        return checkEventExists(type, devIdx, needle, true);
+    }
+
+    /**
+     * assert-no-event <TYPE> [dev=N] [substring] - Assert no event of the
+     * given type exists matching the filters.
+     */
+    std::string handleAssertNoEvent(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 2) {
+            return "Usage: assert-no-event <TYPE> [dev=N] [substring]";
+        }
+
+        EventType type;
+        if (!parseEventType(tokens[1], type)) {
+            return "Unknown event type: " + tokens[1];
+        }
+
+        int devIdx = -1;
+        std::string needle;
+        parseEventFilters(tokens, 2, devIdx, needle);
+
+        return checkEventExists(type, devIdx, needle, false);
+    }
+
+    /**
+     * advance <ms> - Advance all device clocks by ms, run loops.
+     * Same as wait, provided as a debug command alias.
+     */
+    std::string handleAdvance(const std::vector<std::string>& tokens) {
+        return handleWait(tokens);
+    }
+
+    /**
+     * inspect <device> - Show device state, display text, LED state, etc.
+     */
+    std::string handleInspect(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 2) {
+            return "Usage: inspect <device>";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        // inspect is informational, doesn't fail
+        // In headless mode this output goes nowhere, but it's still useful
+        // for debugging scripts interactively
+        return "";
+    }
+
+    /**
+     * events [type] [device] - Show recent events (informational).
+     */
+    std::string handleEvents(const std::vector<std::string>& tokens) {
+        // Informational only, never fails
+        (void)tokens;
+        return "";
+    }
+
+    // ==================== LOOP HELPERS ====================
+
+    /**
+     * Run one iteration of the main loop:
+     * deliver packets, transfer serial, run device loops.
+     */
+    void runOneLoopIteration() {
+        NativePeerBroker::getInstance().deliverPackets();
+        SerialCableBroker::getInstance().transferData();
+
+        for (auto& dev : devices_) {
+            dev.pdn->loop();
+            dev.game->loop();
+        }
+    }
+
+    // ==================== PARSING HELPERS ====================
+
+    /**
+     * Tokenize a command string by spaces, respecting quoted substrings.
+     */
+    static std::vector<std::string> tokenize(const std::string& cmd) {
+        std::vector<std::string> tokens;
+        std::string token;
+        bool inQuotes = false;
+
+        for (char c : cmd) {
+            if (c == '"') {
+                inQuotes = !inQuotes;
+                token += c;
+            } else if (c == ' ' && !inQuotes) {
+                if (!token.empty()) {
+                    tokens.push_back(token);
+                    token.clear();
+                }
+            } else {
+                token += c;
+            }
+        }
+        if (!token.empty()) {
+            tokens.push_back(token);
+        }
+        return tokens;
+    }
+
+    /**
+     * Trim leading and trailing whitespace from a string.
+     */
+    static std::string trim(const std::string& str) {
+        size_t start = str.find_first_not_of(" \t\r\n");
+        if (start == std::string::npos) return "";
+        size_t end = str.find_last_not_of(" \t\r\n");
+        return str.substr(start, end - start + 1);
+    }
+
+    /**
+     * Rejoin tokens from startIndex onward into a single string.
+     */
+    static std::string rejoinTokens(const std::vector<std::string>& tokens, size_t startIndex) {
+        std::string result;
+        for (size_t i = startIndex; i < tokens.size(); i++) {
+            if (i > startIndex) result += " ";
+            result += tokens[i];
+        }
+        return result;
+    }
+
+    /**
+     * Strip surrounding double quotes from a string.
+     */
+    static std::string stripQuotes(const std::string& str) {
+        if (str.size() >= 2 && str.front() == '"' && str.back() == '"') {
+            return str.substr(1, str.size() - 2);
+        }
+        return str;
+    }
+
+    /**
+     * Parse an event type name string to an EventType.
+     */
+    static bool parseEventType(const std::string& name, EventType& out) {
+        if (name == "STATE_CHANGE")  { out = EventType::STATE_CHANGE;  return true; }
+        if (name == "BUTTON_PRESS")  { out = EventType::BUTTON_PRESS;  return true; }
+        if (name == "SERIAL_TX")     { out = EventType::SERIAL_TX;     return true; }
+        if (name == "SERIAL_RX")     { out = EventType::SERIAL_RX;     return true; }
+        if (name == "ESPNOW_TX")     { out = EventType::ESPNOW_TX;     return true; }
+        if (name == "ESPNOW_RX")     { out = EventType::ESPNOW_RX;     return true; }
+        if (name == "DISPLAY_TEXT")  { out = EventType::DISPLAY_TEXT;   return true; }
+        if (name == "DISPLAY_CLEAR") { out = EventType::DISPLAY_CLEAR;  return true; }
+        if (name == "HTTP_REQUEST")  { out = EventType::HTTP_REQUEST;   return true; }
+        if (name == "HTTP_RESPONSE") { out = EventType::HTTP_RESPONSE;  return true; }
+        return false;
+    }
+
+    /**
+     * Parse optional dev=N and substring filters from tokens.
+     */
+    static void parseEventFilters(const std::vector<std::string>& tokens,
+                                  size_t startIndex,
+                                  int& devIdx,
+                                  std::string& needle) {
+        devIdx = -1;
+        needle = "";
+
+        for (size_t i = startIndex; i < tokens.size(); i++) {
+            if (tokens[i].substr(0, 4) == "dev=") {
+                devIdx = std::atoi(tokens[i].c_str() + 4);
+            } else {
+                // Accumulate remaining as needle
+                if (!needle.empty()) needle += " ";
+                needle += tokens[i];
+            }
+        }
+
+        needle = stripQuotes(needle);
+    }
+
+    /**
+     * Check whether a matching event exists (or does not exist).
+     * If expectExists is true, returns error when not found.
+     * If expectExists is false, returns error when found.
+     */
+    std::string checkEventExists(EventType type, int devIdx,
+                                 const std::string& needle,
+                                 bool expectExists) {
+        std::vector<Event> events;
+        if (devIdx >= 0) {
+            events = eventLogger_.getByTypeAndDevice(type, devIdx);
+        } else {
+            events = eventLogger_.getByType(type);
+        }
+
+        bool found = false;
+        if (needle.empty()) {
+            found = !events.empty();
+        } else {
+            for (const auto& evt : events) {
+                if (evt.message.find(needle) != std::string::npos ||
+                    evt.detail.find(needle) != std::string::npos) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+
+        if (expectExists && !found) {
+            std::string desc = eventTypeName(type);
+            if (devIdx >= 0) desc += " dev=" + std::to_string(devIdx);
+            if (!needle.empty()) desc += " '" + needle + "'";
+            return "assert-event failed: no matching event (" + desc + ")";
+        }
+
+        if (!expectExists && found) {
+            std::string desc = eventTypeName(type);
+            if (devIdx >= 0) desc += " dev=" + std::to_string(devIdx);
+            if (!needle.empty()) desc += " '" + needle + "'";
+            return "assert-no-event failed: event exists (" + desc + ")";
+        }
+
+        return "";
+    }
+};
+
+} // namespace cli
+
+#endif // NATIVE_BUILD

--- a/include/device/device-constants.hpp
+++ b/include/device/device-constants.hpp
@@ -59,6 +59,28 @@ const std::string BROADCAST_WIFI = "1111";
 
 const std::string FORCE_MATCH_UPLOAD = "6969";
 
+// Challenge device magic codes (range 7001-7007)
+const std::string CHALLENGE_GHOST_RUNNER     = "7001";
+const std::string CHALLENGE_SPIKE_VECTOR     = "7002";
+const std::string CHALLENGE_FIREWALL_DECRYPT = "7003";
+const std::string CHALLENGE_CIPHER_PATH      = "7004";
+const std::string CHALLENGE_EXPLOIT_SEQUENCER = "7005";
+const std::string CHALLENGE_BREACH_DEFENSE   = "7006";
+const std::string CHALLENGE_SIGNAL_ECHO      = "7007";
+
+// Challenge device serial protocol messages
+const std::string CHALLENGE_DEVICE_ID = "cdev:";
+const std::string CHALLENGE_ACK = "cack";
+
+// NVS key for device mode persistence
+constexpr const char* DEVICE_MODE_KEY = "device_mode";
+
+// NPC result storage
+constexpr const char* NPC_PREF_NAMESPACE = "npc_results";
+constexpr const char* NPC_RESULT_COUNT_KEY = "npc_count";
+constexpr const char* NPC_RESULT_KEY = "npc_res_";
+constexpr uint8_t MAX_NPC_RESULTS = 64;
+
 //STORAGE
 constexpr const char* PREF_NAMESPACE = "matches";
 constexpr const char* PREF_COUNT_KEY = "count";

--- a/include/device/device-constants.hpp
+++ b/include/device/device-constants.hpp
@@ -59,15 +59,6 @@ const std::string BROADCAST_WIFI = "1111";
 
 const std::string FORCE_MATCH_UPLOAD = "6969";
 
-// Challenge device magic codes (range 7001-7007)
-const std::string CHALLENGE_GHOST_RUNNER     = "7001";
-const std::string CHALLENGE_SPIKE_VECTOR     = "7002";
-const std::string CHALLENGE_FIREWALL_DECRYPT = "7003";
-const std::string CHALLENGE_CIPHER_PATH      = "7004";
-const std::string CHALLENGE_EXPLOIT_SEQUENCER = "7005";
-const std::string CHALLENGE_BREACH_DEFENSE   = "7006";
-const std::string CHALLENGE_SIGNAL_ECHO      = "7007";
-
 // Challenge device serial protocol messages
 const std::string CHALLENGE_DEVICE_ID = "cdev:";
 const std::string CHALLENGE_ACK = "cack";
@@ -76,7 +67,6 @@ const std::string CHALLENGE_ACK = "cack";
 constexpr const char* DEVICE_MODE_KEY = "device_mode";
 
 // NPC result storage
-constexpr const char* NPC_PREF_NAMESPACE = "npc_results";
 constexpr const char* NPC_RESULT_COUNT_KEY = "npc_count";
 constexpr const char* NPC_RESULT_KEY = "npc_res_";
 constexpr uint8_t MAX_NPC_RESULTS = 64;

--- a/include/device/device-types.hpp
+++ b/include/device/device-types.hpp
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include <string>
-#include <stdexcept>
 
 enum class DeviceType : uint8_t {
     PLAYER = 0,
@@ -102,6 +101,36 @@ inline bool isChallengeDeviceCode(const std::string& code) {
     return code == "7001" || code == "7002" || code == "7003" ||
            code == "7004" || code == "7005" || code == "7006" ||
            code == "7007";
+}
+
+/*
+ * Lookup: game display name string -> GameType
+ * Used by CLI commands and --npc flag to parse user-typed game names.
+ * Returns true if name was recognized, fills out gameType.
+ */
+inline bool parseGameName(const std::string& name, GameType& gameType) {
+    if (name == "signal-echo" || name == "signalecho" || name == "7007") {
+        gameType = GameType::SIGNAL_ECHO; return true;
+    }
+    if (name == "ghost-runner" || name == "7001") {
+        gameType = GameType::GHOST_RUNNER; return true;
+    }
+    if (name == "spike-vector" || name == "7002") {
+        gameType = GameType::SPIKE_VECTOR; return true;
+    }
+    if (name == "firewall-decrypt" || name == "7003") {
+        gameType = GameType::FIREWALL_DECRYPT; return true;
+    }
+    if (name == "cipher-path" || name == "7004") {
+        gameType = GameType::CIPHER_PATH; return true;
+    }
+    if (name == "exploit-sequencer" || name == "7005") {
+        gameType = GameType::EXPLOIT_SEQUENCER; return true;
+    }
+    if (name == "breach-defense" || name == "7006") {
+        gameType = GameType::BREACH_DEFENSE; return true;
+    }
+    return false;
 }
 
 /*

--- a/include/device/device-types.hpp
+++ b/include/device/device-types.hpp
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <stdexcept>
+
+enum class DeviceType : uint8_t {
+    PLAYER = 0,
+    CHALLENGE = 1,
+};
+
+enum class GameType : uint8_t {
+    QUICKDRAW = 0,
+    GHOST_RUNNER = 1,
+    SPIKE_VECTOR = 2,
+    FIREWALL_DECRYPT = 3,
+    CIPHER_PATH = 4,
+    EXPLOIT_SEQUENCER = 5,
+    BREACH_DEFENSE = 6,
+    SIGNAL_ECHO = 7,
+};
+
+enum class KonamiButton : uint8_t {
+    UP = 0,
+    DOWN = 1,
+    LEFT = 2,
+    RIGHT = 3,
+    B = 4,
+    A = 5,
+    START = 6,
+};
+
+/*
+ * Lookup: GameType -> KonamiButton
+ * Each minigame awards a specific Konami button when beaten.
+ */
+inline KonamiButton getRewardForGame(GameType type) {
+    switch (type) {
+        case GameType::GHOST_RUNNER:      return KonamiButton::UP;
+        case GameType::SPIKE_VECTOR:      return KonamiButton::DOWN;
+        case GameType::FIREWALL_DECRYPT:  return KonamiButton::LEFT;
+        case GameType::CIPHER_PATH:       return KonamiButton::RIGHT;
+        case GameType::EXPLOIT_SEQUENCER: return KonamiButton::B;
+        case GameType::BREACH_DEFENSE:    return KonamiButton::A;
+        case GameType::SIGNAL_ECHO:       return KonamiButton::START;
+        default:                          return KonamiButton::START;
+    }
+}
+
+/*
+ * Lookup: GameType -> display name string
+ */
+inline const char* getGameDisplayName(GameType type) {
+    switch (type) {
+        case GameType::QUICKDRAW:         return "QUICKDRAW";
+        case GameType::GHOST_RUNNER:      return "GHOST RUNNER";
+        case GameType::SPIKE_VECTOR:      return "SPIKE VECTOR";
+        case GameType::FIREWALL_DECRYPT:  return "FIREWALL DECRYPT";
+        case GameType::CIPHER_PATH:       return "CIPHER PATH";
+        case GameType::EXPLOIT_SEQUENCER: return "EXPLOIT SEQUENCER";
+        case GameType::BREACH_DEFENSE:    return "BREACH DEFENSE";
+        case GameType::SIGNAL_ECHO:       return "SIGNAL ECHO";
+        default:                          return "UNKNOWN";
+    }
+}
+
+/*
+ * Lookup: KonamiButton -> display name string
+ */
+inline const char* getKonamiButtonName(KonamiButton button) {
+    switch (button) {
+        case KonamiButton::UP:    return "UP";
+        case KonamiButton::DOWN:  return "DOWN";
+        case KonamiButton::LEFT:  return "LEFT";
+        case KonamiButton::RIGHT: return "RIGHT";
+        case KonamiButton::B:     return "B";
+        case KonamiButton::A:     return "A";
+        case KonamiButton::START: return "START";
+        default:                  return "?";
+    }
+}
+
+/*
+ * Lookup: pairing code string -> GameType
+ * Returns QUICKDRAW if the code is not a challenge device code.
+ */
+inline GameType getGameTypeFromCode(const std::string& code) {
+    if (code == "7001") return GameType::GHOST_RUNNER;
+    if (code == "7002") return GameType::SPIKE_VECTOR;
+    if (code == "7003") return GameType::FIREWALL_DECRYPT;
+    if (code == "7004") return GameType::CIPHER_PATH;
+    if (code == "7005") return GameType::EXPLOIT_SEQUENCER;
+    if (code == "7006") return GameType::BREACH_DEFENSE;
+    if (code == "7007") return GameType::SIGNAL_ECHO;
+    return GameType::QUICKDRAW;
+}
+
+/*
+ * Check if a pairing code is a reserved challenge device code (7001-7007).
+ */
+inline bool isChallengeDeviceCode(const std::string& code) {
+    return code == "7001" || code == "7002" || code == "7003" ||
+           code == "7004" || code == "7005" || code == "7006" ||
+           code == "7007";
+}
+
+/*
+ * Parse a "cdev:<gameType>:<konamiButton>" message.
+ * Returns true if parsing succeeded, fills out gameType and reward.
+ */
+inline bool parseCdevMessage(const std::string& message, GameType& gameType, KonamiButton& reward) {
+    // Expected format: "cdev:<gameType>:<konamiButton>"
+    // The prefix "cdev:" is 5 chars
+    if (message.size() < 8) return false;  // Minimum: "cdev:X:Y"
+    if (message.rfind("cdev:", 0) != 0) return false;
+
+    // Find the two colons after "cdev:"
+    size_t firstColon = 4;  // The colon in "cdev:"
+    size_t secondColon = message.find(':', firstColon + 1);
+    if (secondColon == std::string::npos) return false;
+
+    std::string gameStr = message.substr(firstColon + 1, secondColon - firstColon - 1);
+    std::string rewardStr = message.substr(secondColon + 1);
+
+    int gameInt, rewardInt;
+    try {
+        gameInt = std::stoi(gameStr);
+        rewardInt = std::stoi(rewardStr);
+    } catch (const std::exception&) {
+        return false;
+    }
+
+    if (gameInt < 0 || gameInt > 7) return false;
+    if (rewardInt < 0 || rewardInt > 6) return false;
+
+    gameType = static_cast<GameType>(gameInt);
+    reward = static_cast<KonamiButton>(rewardInt);
+    return true;
+}
+
+/*
+ * Parse a "gres:<won>:<score>" message.
+ * Returns true if parsing succeeded, fills out won and score.
+ */
+inline bool parseGresMessage(const std::string& message, bool& won, int& score) {
+    if (message.rfind("gres:", 0) != 0) return false;
+    size_t firstColon = 4;
+    size_t secondColon = message.find(':', firstColon + 1);
+    if (secondColon == std::string::npos) return false;
+
+    std::string wonStr = message.substr(firstColon + 1, secondColon - firstColon - 1);
+    std::string scoreStr = message.substr(secondColon + 1);
+
+    won = (wonStr == "1");
+    score = std::stoi(scoreStr);
+    return true;
+}

--- a/include/device/drivers/native/native-clock-driver.hpp
+++ b/include/device/drivers/native/native-clock-driver.hpp
@@ -19,6 +19,17 @@ class NativeClockDriver : public PlatformClockDriverInterface {
     }
 
     unsigned long milliseconds() override {
-        return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() + offset_;
     }
+
+    /*
+     * Advance the clock by the given number of milliseconds.
+     * Useful for testing timer-based state transitions without real delays.
+     */
+    void advance(unsigned long deltaMs) {
+        offset_ += deltaMs;
+    }
+
+private:
+    unsigned long offset_ = 0;
 };

--- a/include/device/drivers/native/native-display-driver.hpp
+++ b/include/device/drivers/native/native-display-driver.hpp
@@ -5,6 +5,7 @@
 #include <deque>
 #include <cstring>
 #include <vector>
+#include <functional>
 
 // Simple 5x7 bitmap font for basic ASCII characters (space through ~)
 // Each character is 5 pixels wide, 7 pixels tall
@@ -139,6 +140,7 @@ public:
             lastText_ = text;
             addToTextHistory(text);
             drawTextToBuffer(text, 0, 0);
+            if (textCallback_) textCallback_(text);
         }
         return this;
     }
@@ -175,6 +177,7 @@ public:
             lastText_ = text;
             addToTextHistory(text);
             drawTextToBuffer(text, xStart, yStart);
+            if (textCallback_) textCallback_(text);
         }
         return this;
     }
@@ -195,6 +198,10 @@ public:
         return this;
     }
     
+    // Event callback for EventLogger
+    using TextCallback = std::function<void(const std::string&)>;
+    void setTextCallback(TextCallback cb) { textCallback_ = cb; }
+
     // CLI access methods
     const std::string& getLastText() const { return lastText_; }
     FontMode getCurrentFontMode() const { return currentFontMode_; }
@@ -315,6 +322,7 @@ private:
     std::string lastText_;
     std::deque<std::string> textHistory_;
     static const size_t MAX_TEXT_HISTORY = 4;
+    TextCallback textCallback_;
     
     void addToTextHistory(const std::string& text) {
         // Don't add duplicates of the most recent entry

--- a/include/device/drivers/native/native-serial-driver.hpp
+++ b/include/device/drivers/native/native-serial-driver.hpp
@@ -4,6 +4,7 @@
 #include <queue>
 #include <deque>
 #include <string>
+#include <functional>
 
 class NativeSerialDriver : public SerialDriverInterface {
 public:
@@ -71,6 +72,7 @@ public:
         trimOutputBuffer();
         // Track sent message
         addToHistory(sentHistory_, std::string(msg));
+        if (writeCallback_) writeCallback_(std::string(msg));
     }
 
     void println(const std::string& msg) override {
@@ -79,6 +81,7 @@ public:
         trimOutputBuffer();
         // Track sent message
         addToHistory(sentHistory_, msg);
+        if (writeCallback_) writeCallback_(msg);
     }
 
     void flush() override {
@@ -91,6 +94,11 @@ public:
     void setStringCallback(const SerialStringCallback& callback) override {
         stringCallback_ = callback;
     }
+
+    // Event callbacks for EventLogger
+    using EventCallback = std::function<void(const std::string&)>;
+    void setWriteCallback(EventCallback cb) { writeCallback_ = cb; }
+    void setReadCallback(EventCallback cb) { readCallback_ = cb; }
 
     // Test helper methods
     void injectInput(const std::string& input) {
@@ -119,6 +127,7 @@ public:
         if (stringCallback_) {
             stringCallback_(cleanMsg);
         }
+        if (readCallback_) readCallback_(cleanMsg);
     }
 
     std::string getOutput() const {
@@ -141,6 +150,8 @@ private:
     std::queue<std::string> inputBuffer_;
     std::string outputBuffer_;
     SerialStringCallback stringCallback_;
+    EventCallback writeCallback_;
+    EventCallback readCallback_;
     
     // Message history (most recent at back)
     std::deque<std::string> sentHistory_;

--- a/include/device/drivers/storage-interface.hpp
+++ b/include/device/drivers/storage-interface.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 class StorageInterface {

--- a/include/game/challenge-game.hpp
+++ b/include/game/challenge-game.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "state/state-machine.hpp"
+#include "device/device-types.hpp"
+
+class ChallengeGame : public StateMachine {
+public:
+    ChallengeGame(Device* device, GameType gameType, KonamiButton reward);
+    ~ChallengeGame() override;
+
+    void populateStateMap() override;
+
+    GameType getGameType() const { return gameType; }
+    KonamiButton getReward() const { return reward; }
+
+    /*
+     * Get the last game result.
+     * Set by NpcReceiveResult state.
+     * true = player won, false = player lost.
+     */
+    bool getLastResult() const { return lastResult; }
+    void setLastResult(bool won) { lastResult = won; }
+
+    int getLastScore() const { return lastScore; }
+    void setLastScore(int score) { lastScore = score; }
+
+private:
+    GameType gameType;
+    KonamiButton reward;
+    bool lastResult = false;
+    int lastScore = 0;
+};

--- a/include/game/challenge-resources.hpp
+++ b/include/game/challenge-resources.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "device/drivers/light-interface.hpp"
+#include "device/device-types.hpp"
+
+/*
+ * NPC LED colors per game type.
+ * These are starting suggestions — will be tuned during playtesting.
+ * Each NPC's palette should eventually match the palette players win.
+ */
+inline LEDColor getNpcLedColor(GameType gameType) {
+    switch (gameType) {
+        case GameType::GHOST_RUNNER:      return {200, 220, 255};  // Cool white/pale blue
+        case GameType::SPIKE_VECTOR:      return {255, 80, 0};     // Red/orange
+        case GameType::FIREWALL_DECRYPT:  return {0, 255, 50};     // Green
+        case GameType::CIPHER_PATH:       return {150, 0, 255};    // Purple/violet
+        case GameType::EXPLOIT_SEQUENCER: return {255, 200, 0};    // Yellow/gold
+        case GameType::BREACH_DEFENSE:    return {0, 200, 200};    // Cyan/teal
+        case GameType::SIGNAL_ECHO:       return {255, 0, 150};    // Magenta/pink
+        default:                          return {128, 128, 128};  // Gray
+    }
+}

--- a/include/game/challenge-result-manager.hpp
+++ b/include/game/challenge-result-manager.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "device/drivers/storage-interface.hpp"
+#include "device/device-types.hpp"
+#include "device/device-constants.hpp"
+#include <string>
+
+/*
+ * ChallengeResultManager caches NPC game results in NVS for deferred upload.
+ * Same pattern as MatchManager: append to storage, upload when WiFi available.
+ *
+ * Storage format (NVS key-value):
+ *   "npc_count" -> uint8_t (number of cached results)
+ *   "npc_res_0" -> string "gameType:won:score" (e.g. "7:1:850")
+ *   "npc_res_1" -> ...
+ */
+class ChallengeResultManager {
+public:
+    ChallengeResultManager() = default;
+    ~ChallengeResultManager() = default;
+
+    void initialize(StorageInterface* storage) {
+        this->storage = storage;
+    }
+
+    void cacheResult(GameType gameType, bool won, int score) {
+        if (!storage) return;
+
+        uint8_t count = storage->readUChar(NPC_RESULT_COUNT_KEY, 0);
+        if (count >= MAX_NPC_RESULTS) return;  // Storage full
+
+        std::string key = std::string(NPC_RESULT_KEY) + std::to_string(count);
+        std::string value = std::to_string(static_cast<int>(gameType)) + ":" +
+                            (won ? "1" : "0") + ":" +
+                            std::to_string(score);
+
+        storage->write(key, value);
+        storage->writeUChar(NPC_RESULT_COUNT_KEY, count + 1);
+    }
+
+    uint8_t getCachedResultCount() {
+        if (!storage) return 0;
+        return storage->readUChar(NPC_RESULT_COUNT_KEY, 0);
+    }
+
+    std::string getCachedResult(uint8_t index) {
+        if (!storage) return "";
+        std::string key = std::string(NPC_RESULT_KEY) + std::to_string(index);
+        return storage->read(key, "");
+    }
+
+    void clearCachedResults() {
+        if (!storage) return;
+        uint8_t count = storage->readUChar(NPC_RESULT_COUNT_KEY, 0);
+        for (uint8_t i = 0; i < count; i++) {
+            std::string key = std::string(NPC_RESULT_KEY) + std::to_string(i);
+            storage->remove(key);
+        }
+        storage->writeUChar(NPC_RESULT_COUNT_KEY, 0);
+    }
+
+private:
+    StorageInterface* storage = nullptr;
+};

--- a/include/game/challenge-states.hpp
+++ b/include/game/challenge-states.hpp
@@ -7,7 +7,6 @@
 #include "game/challenge-result-manager.hpp"
 #include <string>
 #include <vector>
-#include <cstdlib>
 
 class ChallengeGame;
 

--- a/include/game/challenge-states.hpp
+++ b/include/game/challenge-states.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "state/state.hpp"
+#include "device/device-types.hpp"
+#include "device/device-constants.hpp"
+#include "utils/simple-timer.hpp"
+#include "game/challenge-result-manager.hpp"
+#include <string>
+#include <vector>
+#include <cstdlib>
+
+class ChallengeGame;
+
+enum ChallengeStateId {
+    NPC_IDLE = 0,
+    NPC_HANDSHAKE = 1,
+    NPC_GAME_ACTIVE = 2,
+    NPC_RECEIVE_RESULT = 3,
+};
+
+class NpcIdle : public State {
+public:
+    explicit NpcIdle(ChallengeGame* game);
+    ~NpcIdle() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToHandshake();
+
+private:
+    ChallengeGame* game;
+    SimpleTimer broadcastTimer;
+    static constexpr int BROADCAST_INTERVAL_MS = 500;
+    bool transitionToHandshakeState = false;
+
+    void serialEventCallback(const std::string& message);
+    void renderDisplay(Device* PDN);
+};
+
+class NpcHandshake : public State {
+public:
+    explicit NpcHandshake(ChallengeGame* game);
+    ~NpcHandshake() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToGameActive();
+    bool transitionToIdle();
+
+private:
+    ChallengeGame* game;
+    SimpleTimer timeoutTimer;
+    static constexpr int HANDSHAKE_TIMEOUT_MS = 10000;
+    bool transitionToGameActiveState = false;
+    bool transitionToIdleState = false;
+    std::string playerMacAddress;
+};
+
+class NpcGameActive : public State {
+public:
+    explicit NpcGameActive(ChallengeGame* game);
+    ~NpcGameActive() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToReceiveResult();
+    bool transitionToIdle();
+
+private:
+    ChallengeGame* game;
+    SimpleTimer inactivityTimer;
+    static constexpr int INACTIVITY_TIMEOUT_MS = 30000;
+    bool transitionToReceiveResultState = false;
+    bool transitionToIdleState = false;
+
+    // Game state (NPC is the authority)
+    int currentRound = 0;
+    int totalRounds = 3;
+    int sequenceLength = 4;
+    int inputIndex = 0;
+    int playerLives = 3;
+    int playerScore = 0;
+    bool gameComplete = false;
+    bool playerWon = false;
+    std::vector<bool> currentSequence;
+
+    void generateSequence();
+    void sendSequence(Device* PDN);
+    void onEspNowReceived(const std::string& message, Device* PDN);
+    void renderDisplay(Device* PDN);
+};
+
+class NpcReceiveResult : public State {
+public:
+    NpcReceiveResult(ChallengeGame* game, ChallengeResultManager* resultManager);
+    ~NpcReceiveResult() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIdle();
+
+private:
+    ChallengeGame* game;
+    ChallengeResultManager* resultManager;
+    SimpleTimer displayTimer;
+    static constexpr int DISPLAY_DURATION_MS = 3000;
+    bool transitionToIdleState = false;
+};

--- a/include/game/minigame.hpp
+++ b/include/game/minigame.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "state/state-machine.hpp"
+#include "device/device-types.hpp"
+
+/*
+ * MiniGame is the base class for all minigames in the ChallengeDevice system.
+ * Each of the 7 minigames (Signal Echo, Ghost Runner, etc.) derives from MiniGame.
+ *
+ * MiniGame extends StateMachine with:
+ * - Game identity (GameType, display name)
+ * - Completion signaling (MiniGameOutcome) — the SM Manager polls isGameComplete()
+ * - Reset capability for replay without reconstructing the object
+ *
+ * Subclasses must implement populateStateMap() and their game-specific states.
+ * States set `outcome` when the game ends (win or lose).
+ */
+
+enum class MiniGameResult : uint8_t {
+    IN_PROGRESS = 0,
+    WON = 1,
+    LOST = 2,
+};
+
+struct MiniGameOutcome {
+    MiniGameResult result = MiniGameResult::IN_PROGRESS;
+    int score = 0;
+    bool hardMode = false;
+    bool isComplete() const { return result != MiniGameResult::IN_PROGRESS; }
+};
+
+class MiniGame : public StateMachine {
+public:
+    MiniGame(Device* device, GameType gameType, const char* displayName) :
+      StateMachine(device),
+      gameType(gameType),
+      displayName(displayName)
+    {
+    }
+
+    virtual ~MiniGame() = default;
+
+    virtual void populateStateMap() override = 0;
+
+    GameType getGameType() const { return gameType; }
+    const char* getDisplayName() const { return displayName; }
+
+    const MiniGameOutcome& getOutcome() const { return outcome; }
+    bool isGameComplete() const { return outcome.isComplete(); }
+
+    void setOutcome(const MiniGameOutcome& newOutcome) {
+        outcome = newOutcome;
+    }
+
+    virtual void resetGame() {
+        outcome = MiniGameOutcome{};
+    }
+
+protected:
+    MiniGameOutcome outcome;
+
+private:
+    GameType gameType;
+    const char* displayName;
+};

--- a/include/game/minigame.hpp
+++ b/include/game/minigame.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include "state/state-machine.hpp"
 #include "device/device-types.hpp"
 
@@ -52,12 +53,17 @@ public:
         outcome = newOutcome;
     }
 
+    bool isReadyForResume() const { return readyForResume; }
+    void setReadyForResume(bool ready) { readyForResume = ready; }
+
     virtual void resetGame() {
         outcome = MiniGameOutcome{};
+        readyForResume = false;
     }
 
 protected:
     MiniGameOutcome outcome;
+    bool readyForResume = false;
 
 private:
     GameType gameType;

--- a/include/game/player.hpp
+++ b/include/game/player.hpp
@@ -103,6 +103,12 @@ public:
     bool hasAllKonamiButtons() const;
     int getUnlockedButtonCount() const;
 
+    // Pending challenge (set by Idle, read by ChallengeDetected)
+    void setPendingChallenge(const std::string& cdevMessage);
+    const std::string& getPendingCdevMessage() const;
+    void clearPendingChallenge();
+    bool hasPendingChallenge() const;
+
     // Color profile API
     void setEquippedColorProfile(GameType game);
     GameType getEquippedColorProfile() const;
@@ -144,4 +150,7 @@ private:
 
     // Color profile eligibility — list of GameType values for which hard mode was beaten
     std::vector<GameType> colorProfileEligibility;
+
+    // Pending challenge state
+    std::string pendingCdevMessage;
 };

--- a/include/game/player.hpp
+++ b/include/game/player.hpp
@@ -3,6 +3,8 @@
 #include <memory>
 #include <string>
 #include <iostream>
+#include <vector>
+#include "device/device-types.hpp"
 
 enum class Allegiance {
     ALLEYCAT = 0,
@@ -10,6 +12,9 @@ enum class Allegiance {
     HELIX = 2,
     RESISTANCE = 3
 };
+
+// All 7 Konami buttons unlocked = bits 0-6 set = 0x7F
+static constexpr uint8_t KONAMI_ALL_UNLOCKED = 0x7F;
 
 class Player {
 public:
@@ -90,6 +95,21 @@ public:
 
     void addReactionTime(unsigned long reactionTime);
 
+    // Konami progress API
+    void unlockKonamiButton(KonamiButton button);
+    bool hasUnlockedButton(KonamiButton button) const;
+    uint8_t getKonamiProgress() const;
+    void setKonamiProgress(uint8_t progress);
+    bool hasAllKonamiButtons() const;
+    int getUnlockedButtonCount() const;
+
+    // Color profile API
+    void setEquippedColorProfile(GameType game);
+    GameType getEquippedColorProfile() const;
+    void addColorProfileEligibility(GameType game);
+    bool hasColorProfileEligibility(GameType game) const;
+    const std::vector<GameType>& getColorProfileEligibility() const;
+
 private:
     std::string id = "default";
     std::string name = "";
@@ -115,4 +135,13 @@ private:
     std::string opponentMacAddress;
     
     bool hunter = true;
+
+    // Konami progress bitmask — each bit = one button unlocked (bits 0-6)
+    uint8_t konamiProgress = 0;
+
+    // Color profile — GameType::QUICKDRAW means no custom profile equipped
+    GameType equippedColorProfile = GameType::QUICKDRAW;
+
+    // Color profile eligibility — list of GameType values for which hard mode was beaten
+    std::vector<GameType> colorProfileEligibility;
 };

--- a/include/game/progress-manager.hpp
+++ b/include/game/progress-manager.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "game/player.hpp"
+#include "device/drivers/storage-interface.hpp"
+#include "device/drivers/http-client-interface.hpp"
+#include "device/wireless-manager.hpp"
+#include "game/quickdraw-requests.hpp"
+#include "device/drivers/logger.hpp"
+
+/*
+ * ProgressManager persists Konami progress to NVS storage and uploads
+ * it to the server when connectivity is available. Follows the same
+ * pattern as MatchManager: initialized with Player* + StorageInterface*,
+ * uses NVS for local persistence, and defers server uploads until WiFi
+ * is available.
+ *
+ * NVS keys (shared storage driver, distinct key namespace):
+ *   "konami"  — uint8_t bitmask of unlocked Konami buttons
+ *   "synced"  — uint8_t (0 or 1), whether current progress has been uploaded
+ *
+ * These keys do not collide with MatchManager's keys ("count", "match_0", etc.).
+ */
+class ProgressManager {
+public:
+    ProgressManager();
+    ~ProgressManager();
+
+    /*
+     * Initialize with references to the player and storage driver.
+     * Must be called before any other method.
+     */
+    void initialize(Player* player, StorageInterface* storage);
+
+    /*
+     * Save current Konami progress from Player to NVS.
+     * Called after a Konami button is unlocked (e.g., player wins a minigame).
+     * Marks progress as unsynced so it will be uploaded on next opportunity.
+     */
+    void saveProgress();
+
+    /*
+     * Load Konami progress from NVS into Player.
+     * Called as fallback when server is unreachable during login.
+     * Only updates Player if NVS has data (non-zero progress).
+     */
+    void loadProgress();
+
+    /*
+     * Check if there's progress that hasn't been uploaded to the server.
+     */
+    bool hasUnsyncedProgress() const;
+
+    /*
+     * Upload current Konami progress to the server via PUT /api/players/{id}/progress.
+     * On success, marks progress as synced in NVS.
+     * Returns true if upload succeeded, false if failed or no connectivity.
+     */
+    bool uploadProgress(WirelessManager* wirelessManager);
+
+    /*
+     * Clear all progress data from NVS.
+     */
+    void clearProgress();
+
+private:
+    Player* player = nullptr;
+    StorageInterface* storage = nullptr;
+    bool synced = true;
+
+    static constexpr const char* PROGRESS_TAG = "ProgressManager";
+    static constexpr const char* NVS_KEY_KONAMI = "konami";
+    static constexpr const char* NVS_KEY_SYNCED = "synced";
+};

--- a/include/game/progress-manager.hpp
+++ b/include/game/progress-manager.hpp
@@ -2,7 +2,6 @@
 
 #include "game/player.hpp"
 #include "device/drivers/storage-interface.hpp"
-#include "device/drivers/http-client-interface.hpp"
 #include "device/wireless-manager.hpp"
 #include "game/quickdraw-requests.hpp"
 #include "device/drivers/logger.hpp"

--- a/include/game/quickdraw-states.hpp
+++ b/include/game/quickdraw-states.hpp
@@ -216,6 +216,8 @@ public:
     void onStateLoop(Device *PDN) override;
     void onStateDismounted(Device *PDN) override;
     bool transitionToHandshake();
+    bool isChallengeDetected() const { return challengeDeviceDetected; }
+    const std::string& getLastCdevMessage() const { return lastCdevMessage; }
     void cycleStats(Device *PDN);
 
 private:
@@ -233,6 +235,10 @@ private:
 
     void serialEventCallbacks(const std::string& message);
     void ledAnimation(Device *PDN);
+
+    // Challenge device detection (Feature A)
+    bool challengeDeviceDetected = false;
+    std::string lastCdevMessage;
 };
 
 class ConnectionSuccessful : public State {

--- a/include/game/quickdraw.hpp
+++ b/include/game/quickdraw.hpp
@@ -10,6 +10,9 @@
 #include "device/drivers/storage-interface.hpp"
 #include "wireless/remote-debug-manager.hpp"
 
+class StateMachineManager;
+class ProgressManager;
+
 constexpr size_t MATCH_SIZE = sizeof(Match);
 
 class Quickdraw : public StateMachine {
@@ -19,6 +22,11 @@ public:
 
     void populateStateMap() override;
     static Image getImageForAllegiance(Allegiance allegiance, ImageType whichImage);
+
+    void setStateMachineManager(StateMachineManager* mgr) { smManager = mgr; }
+    void setProgressManager(ProgressManager* mgr) { progressManager = mgr; }
+    StateMachineManager* getStateMachineManager() const { return smManager; }
+    ProgressManager* getProgressManager() const { return progressManager; }
 
 private:
     std::vector<Match> matches;
@@ -30,4 +38,6 @@ private:
     PeerCommsInterface* peerComms;
     QuickdrawWirelessManager* quickdrawWirelessManager;
     RemoteDebugManager* remoteDebugManager;
+    StateMachineManager* smManager = nullptr;
+    ProgressManager* progressManager = nullptr;
 };

--- a/include/game/signal-echo/signal-echo-resources.hpp
+++ b/include/game/signal-echo/signal-echo-resources.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+#include "device/drivers/light-interface.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+
+/*
+ * Signal Echo LED palettes.
+ *
+ * signalEchoColors/signalEchoIdleColors: Used by BOTH the NPC device
+ * (walking advertisement) and by players who beat hard mode and equip
+ * the profile. What you see on the NPC is what you get when you win.
+ *
+ * These follow the same LEDColor array format as quickdraw-resources.hpp.
+ */
+
+// Primary palette (4 colors) — used for non-idle animations
+const LEDColor signalEchoColors[4] = {
+    LEDColor(255, 0, 255),   // Magenta
+    LEDColor(200, 0, 200),   // Dark magenta
+    LEDColor(255, 50, 200),  // Pink
+    LEDColor(180, 0, 255),   // Purple
+};
+
+// Idle palette (8 colors) — used for idle breathing animation
+const LEDColor signalEchoIdleColors[8] = {
+    LEDColor(255, 0, 255),   LEDColor(200, 0, 200),
+    LEDColor(255, 50, 200),  LEDColor(180, 0, 255),
+    LEDColor(255, 0, 255),   LEDColor(200, 0, 200),
+    LEDColor(255, 50, 200),  LEDColor(180, 0, 255),
+};
+
+// Default/neutral palette — used when no color profile equipped
+const LEDColor defaultProfileColors[4] = {
+    LEDColor(255, 255, 100),  // Warm yellow
+    LEDColor(255, 255, 200),  // Pale yellow
+    LEDColor(255, 255, 255),  // White
+    LEDColor(200, 200, 150),  // Dim warm
+};
+
+const LEDColor defaultProfileIdleColors[8] = {
+    LEDColor(255, 255, 100),  LEDColor(255, 255, 255),
+    LEDColor(255, 255, 200),  LEDColor(200, 200, 150),
+    LEDColor(255, 255, 100),  LEDColor(255, 255, 255),
+    LEDColor(255, 255, 200),  LEDColor(200, 200, 150),
+};
+
+// Signal Echo intro idle LED state — magenta/pink pulse
+const LEDState SIGNAL_ECHO_IDLE_STATE = [](){
+    LEDState state;
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(
+            signalEchoIdleColors[i % 8], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(
+            signalEchoIdleColors[i % 8], 65);
+    }
+    return state;
+}();
+
+// Win state — rainbow sweep using bright colors
+const LEDColor winRainbowColors[9] = {
+    LEDColor(255, 0, 0),     // Red
+    LEDColor(255, 127, 0),   // Orange
+    LEDColor(255, 255, 0),   // Yellow
+    LEDColor(0, 255, 0),     // Green
+    LEDColor(0, 255, 255),   // Cyan
+    LEDColor(0, 127, 255),   // Sky blue
+    LEDColor(0, 0, 255),     // Blue
+    LEDColor(127, 0, 255),   // Violet
+    LEDColor(255, 0, 255),   // Magenta
+};
+
+const LEDState SIGNAL_ECHO_WIN_STATE = [](){
+    LEDState state;
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(winRainbowColors[i], 255);
+        state.rightLights[i] = LEDState::SingleLEDState(winRainbowColors[8 - i], 255);
+    }
+    return state;
+}();
+
+// Lose state — red fade
+const LEDState SIGNAL_ECHO_LOSE_STATE = [](){
+    LEDState state;
+    for (int i = 0; i < 9; i++) {
+        uint8_t brightness = static_cast<uint8_t>(255 - (i * 25));
+        state.leftLights[i] = LEDState::SingleLEDState(LEDColor(255, 0, 0), brightness);
+        state.rightLights[i] = LEDState::SingleLEDState(LEDColor(255, 0, 0), brightness);
+    }
+    return state;
+}();
+
+// Error flash — brief red flash on wrong input
+const LEDState SIGNAL_ECHO_ERROR_STATE = [](){
+    LEDState state;
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(LEDColor(255, 0, 0), 255);
+        state.rightLights[i] = LEDState::SingleLEDState(LEDColor(255, 0, 0), 255);
+    }
+    return state;
+}();
+
+// Correct input flash — brief green flash
+const LEDState SIGNAL_ECHO_CORRECT_STATE = [](){
+    LEDState state;
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(LEDColor(0, 255, 0), 255);
+        state.rightLights[i] = LEDState::SingleLEDState(LEDColor(0, 255, 0), 255);
+    }
+    return state;
+}();
+
+// Difficulty presets
+const SignalEchoConfig SIGNAL_ECHO_EASY = {
+    .sequenceLength = 4,
+    .numSequences = 4,
+    .displaySpeedMs = 600,
+    .timeLimitMs = 0,
+    .cumulative = false,
+    .allowedMistakes = 3,
+    .rngSeed = 0,
+    .managedMode = false,
+};
+
+const SignalEchoConfig SIGNAL_ECHO_HARD = {
+    .sequenceLength = 8,
+    .numSequences = 4,
+    .displaySpeedMs = 400,
+    .timeLimitMs = 0,
+    .cumulative = false,
+    .allowedMistakes = 1,
+    .rngSeed = 0,
+    .managedMode = false,
+};

--- a/include/game/signal-echo/signal-echo-resources.hpp
+++ b/include/game/signal-echo/signal-echo-resources.hpp
@@ -30,6 +30,7 @@ const LEDColor signalEchoIdleColors[8] = {
 };
 
 // Default/neutral palette — used when no color profile equipped
+// Used by Features C/D (color profile application to device LEDs)
 const LEDColor defaultProfileColors[4] = {
     LEDColor(255, 255, 100),  // Warm yellow
     LEDColor(255, 255, 200),  // Pale yellow
@@ -37,6 +38,7 @@ const LEDColor defaultProfileColors[4] = {
     LEDColor(200, 200, 150),  // Dim warm
 };
 
+// Used by Features C/D (color profile application to device LEDs)
 const LEDColor defaultProfileIdleColors[8] = {
     LEDColor(255, 255, 100),  LEDColor(255, 255, 255),
     LEDColor(255, 255, 200),  LEDColor(200, 200, 150),

--- a/include/game/signal-echo/signal-echo-states.hpp
+++ b/include/game/signal-echo/signal-echo-states.hpp
@@ -1,0 +1,180 @@
+#pragma once
+
+#include "state/state.hpp"
+#include "utils/simple-timer.hpp"
+
+class SignalEcho;
+
+/*
+ * Signal Echo state IDs — used for state tracking and test assertions.
+ */
+enum SignalEchoStateId {
+    ECHO_INTRO = 100,
+    ECHO_SHOW_SEQUENCE = 101,
+    ECHO_PLAYER_INPUT = 102,
+    ECHO_EVALUATE = 103,
+    ECHO_WIN = 104,
+    ECHO_LOSE = 105,
+};
+
+/*
+ * EchoIntro — Title screen. Shows "SIGNAL ECHO" and "Watch. Repeat."
+ * Transitions to EchoShowSequence after INTRO_DURATION_MS.
+ * Also seeds the RNG and generates the first sequence.
+ */
+class EchoIntro : public State {
+public:
+    explicit EchoIntro(SignalEcho* game);
+    ~EchoIntro() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToShowSequence();
+
+private:
+    SignalEcho* game;
+    SimpleTimer introTimer;
+    static constexpr int INTRO_DURATION_MS = 2000;
+    bool transitionToShowSequenceState = false;
+};
+
+/*
+ * EchoShowSequence — Displays the sequence one signal at a time.
+ * Each signal (UP or DOWN) is shown for displaySpeedMs.
+ * After the last signal, transitions to EchoPlayerInput.
+ *
+ * Display: Large arrow (^ or v) + "Signal N of M"
+ * LEDs: Chase up for UP, chase down for DOWN
+ * Haptics: Light pulse per signal
+ */
+class EchoShowSequence : public State {
+public:
+    explicit EchoShowSequence(SignalEcho* game);
+    ~EchoShowSequence() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToPlayerInput();
+
+private:
+    SignalEcho* game;
+    SimpleTimer signalTimer;
+    int currentSignalIndex = 0;
+    bool transitionToPlayerInputState = false;
+    bool displayedCurrentSignal = false;
+
+    void displaySignal(Device* PDN, bool isUp, int index, int total);
+};
+
+/*
+ * EchoPlayerInput — Player reproduces the sequence using buttons.
+ * Primary button = UP, Secondary button = DOWN.
+ *
+ * Correct input: advances inputIndex, shows check mark at that position.
+ * Wrong input: increments mistakes, shows X at that position, advances
+ * inputIndex (wrong input is locked in), flashes red LED, haptic buzz.
+ *
+ * Transitions to EchoEvaluate when all inputs entered OR when
+ * mistakes exceed allowedMistakes (immediate transition to evaluate).
+ *
+ * Display: "YOUR TURN" + input progress (arrows and X marks) +
+ *          round counter + life indicator
+ */
+class EchoPlayerInput : public State {
+public:
+    explicit EchoPlayerInput(SignalEcho* game);
+    ~EchoPlayerInput() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToEvaluate();
+
+private:
+    SignalEcho* game;
+    bool transitionToEvaluateState = false;
+    bool displayIsDirty = false;
+
+    void handleInput(bool isUp, Device* PDN);
+    void renderInputScreen(Device* PDN);
+};
+
+/*
+ * EchoEvaluate — Brief transition state. Checks if the round was
+ * completed successfully and determines what happens next:
+ * - If mistakes > allowedMistakes: transition to EchoLose
+ * - If all rounds completed: transition to EchoWin
+ * - Otherwise: advance to next round, transition to EchoShowSequence
+ */
+class EchoEvaluate : public State {
+public:
+    explicit EchoEvaluate(SignalEcho* game);
+    ~EchoEvaluate() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToShowSequence();
+    bool transitionToWin();
+    bool transitionToLose();
+
+private:
+    SignalEcho* game;
+    bool transitionToShowSequenceState = false;
+    bool transitionToWinState = false;
+    bool transitionToLoseState = false;
+};
+
+/*
+ * EchoWin — Victory screen. Shows "ACCESS GRANTED" + score.
+ * Sets outcome to WON. In standalone mode, transitions back
+ * to EchoIntro after a delay for replay.
+ *
+ * LEDs: Rainbow sweep
+ * Haptics: Celebration pattern (short pulses)
+ */
+class EchoWin : public State {
+public:
+    explicit EchoWin(SignalEcho* game);
+    ~EchoWin() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    SignalEcho* game;
+    SimpleTimer winTimer;
+    static constexpr int WIN_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};
+
+/*
+ * EchoLose — Defeat screen. Shows "SIGNAL LOST".
+ * Sets outcome to LOST. In standalone mode, transitions back
+ * to EchoIntro after a delay for retry.
+ *
+ * LEDs: Red fade
+ * Haptics: Long buzz
+ */
+class EchoLose : public State {
+public:
+    explicit EchoLose(SignalEcho* game);
+    ~EchoLose() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    SignalEcho* game;
+    SimpleTimer loseTimer;
+    static constexpr int LOSE_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};

--- a/include/game/signal-echo/signal-echo.hpp
+++ b/include/game/signal-echo/signal-echo.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "game/minigame.hpp"
+#include "utils/simple-timer.hpp"
+#include <vector>
+#include <cstdlib>
+
+/*
+ * Signal Echo configuration — all tuning variables for difficulty.
+ * Two presets are defined in signal-echo-resources.hpp:
+ * SIGNAL_ECHO_EASY (default) and SIGNAL_ECHO_HARD.
+ */
+struct SignalEchoConfig {
+    int sequenceLength = 4;
+    int numSequences = 3;
+    int displaySpeedMs = 600;
+    int timeLimitMs = 0;
+    bool cumulative = false;
+    int allowedMistakes = 2;
+    unsigned long rngSeed = 0;
+    bool managedMode = false;
+};
+
+/*
+ * Signal Echo session state — tracks the current game in progress.
+ * Reset between games (on lose/restart). Win/lose is tracked via
+ * MiniGame::outcome, not duplicated here.
+ */
+struct SignalEchoSession {
+    std::vector<bool> currentSequence;
+    int currentRound = 0;
+    int inputIndex = 0;
+    int mistakes = 0;
+    int score = 0;
+
+    void reset() {
+        currentSequence.clear();
+        currentRound = 0;
+        inputIndex = 0;
+        mistakes = 0;
+        score = 0;
+    }
+};
+
+/*
+ * Signal Echo (Simon Says) — the first MiniGame implementation.
+ *
+ * The device plays a sequence of UP/DOWN signals, then the player
+ * reproduces it from memory. Correct replay advances to the next round.
+ * Wrong input counts as a mistake. Too many mistakes = lose.
+ * Complete all rounds = win.
+ *
+ * In standalone mode (Feature B), sequences are generated locally
+ * using a seeded PRNG. In managed mode (Feature D), sequences come
+ * from the NPC via ESP-NOW.
+ */
+class SignalEcho : public MiniGame {
+public:
+    SignalEcho(Device* device, SignalEchoConfig config);
+    void populateStateMap() override;
+    void resetGame() override;
+
+    SignalEchoConfig& getConfig() { return config; }
+    SignalEchoSession& getSession() { return session; }
+
+    /*
+     * Generate a sequence of the given length using the seeded PRNG.
+     * true = UP, false = DOWN.
+     */
+    std::vector<bool> generateSequence(int length);
+
+    /*
+     * Seed the PRNG. Called once during initialization.
+     * If config.rngSeed != 0, uses that seed (deterministic for tests).
+     * Otherwise uses 0 (production would use MAC address, but standalone
+     * mode falls back to time-based or 0).
+     */
+    void seedRng();
+
+private:
+    SignalEchoConfig config;
+    SignalEchoSession session;
+};

--- a/include/game/test-minigame.hpp
+++ b/include/game/test-minigame.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#ifdef UNIT_TEST
+
+#include "game/minigame.hpp"
+#include "state/state.hpp"
+
+/*
+ * TestMiniGame — a trivial 2-state minigame for testing the SM Manager.
+ *
+ * State 0: TestMiniGameIntro — waits until triggerComplete() is called.
+ * State 1: TestMiniGameComplete — sets outcome and signals readyForResume.
+ *
+ * This class is guarded by UNIT_TEST and should never appear in production builds.
+ */
+
+class TestMiniGame;  // Forward declaration
+
+static const int TEST_MINIGAME_INTRO_STATE_ID = 200;
+static const int TEST_MINIGAME_COMPLETE_STATE_ID = 201;
+
+class TestMiniGameIntro : public State {
+public:
+    TestMiniGameIntro() : State(TEST_MINIGAME_INTRO_STATE_ID) {}
+    void onStateMounted(Device* PDN) override {}
+    void onStateLoop(Device* PDN) override {}
+    void onStateDismounted(Device* PDN) override {}
+};
+
+class TestMiniGameComplete : public State {
+public:
+    TestMiniGameComplete(TestMiniGame* game, MiniGameResult resultToSet) :
+        State(TEST_MINIGAME_COMPLETE_STATE_ID),
+        game_(game),
+        resultToSet(resultToSet)
+    {
+    }
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override {}
+    void onStateDismounted(Device* PDN) override {}
+    bool isTerminalState() override { return true; }
+
+private:
+    TestMiniGame* game_;
+    MiniGameResult resultToSet;
+};
+
+class TestMiniGame : public MiniGame {
+public:
+    TestMiniGame(Device* device, MiniGameResult resultToSet = MiniGameResult::WON) :
+        MiniGame(device, GameType::SIGNAL_ECHO, "TEST MINIGAME"),
+        resultToSet_(resultToSet)
+    {
+    }
+
+    void populateStateMap() override {
+        auto* intro = new TestMiniGameIntro();
+        auto* complete = new TestMiniGameComplete(this, resultToSet_);
+
+        // Transition from intro to complete is triggered externally via triggerComplete()
+        intro->addTransition(new StateTransition(
+            [this]() { return triggerFlag; },
+            complete
+        ));
+
+        stateMap.push_back(intro);
+        stateMap.push_back(complete);
+    }
+
+    /*
+     * Trigger the transition from Intro to Complete state.
+     * On the next loop(), the state machine will transition
+     * and the Complete state will set the outcome + readyForResume.
+     */
+    void triggerComplete() {
+        triggerFlag = true;
+    }
+
+private:
+    MiniGameResult resultToSet_;
+    bool triggerFlag = false;
+};
+
+// Implementation of TestMiniGameComplete::onStateMounted
+// (defined after TestMiniGame is fully declared to access its methods)
+inline void TestMiniGameComplete::onStateMounted(Device* PDN) {
+    MiniGameOutcome out;
+    out.result = resultToSet;
+    out.score = 42;
+    game_->setOutcome(out);
+    game_->setReadyForResume(true);
+}
+
+#endif // UNIT_TEST

--- a/include/state/state-machine-manager.hpp
+++ b/include/state/state-machine-manager.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstdint>
+#include "state/state-machine.hpp"
+#include "game/minigame.hpp"
+#include "device/device-types.hpp"
+
+/*
+ * StateMachineManager manages transitions between the default state machine
+ * (e.g. Quickdraw) and temporary minigame state machines.
+ *
+ * When a player interacts with a Challenge Device NPC, the SM Manager:
+ * 1. Pauses the current Quickdraw state machine (dismounts current state)
+ * 2. Loads and initializes the minigame
+ * 3. Runs the minigame until completion
+ * 4. Auto-resumes the previous state machine at a specified state index
+ *
+ * The SM Manager does NOT own the default state machine. It DOES own
+ * the swapped (minigame) state machine and deletes it on resume.
+ */
+class StateMachineManager {
+public:
+    explicit StateMachineManager(Device* device);
+    ~StateMachineManager();
+
+    /*
+     * Set the default (primary) state machine that runs when no minigame is active.
+     * The SM Manager does NOT take ownership — caller is responsible for deletion.
+     */
+    void setDefaultStateMachine(StateMachine* sm);
+
+    /*
+     * Pause the default SM and load a minigame.
+     * - Dismounts the current state on the default SM
+     * - Stores the resumeStateIndex for later
+     * - Takes ownership of 'game' (will delete on resume)
+     * - Initializes and starts the minigame
+     */
+    void pauseAndLoad(MiniGame* game, int resumeStateIndex);
+
+    /*
+     * Resume the default SM after a minigame completes.
+     * - Stores outcome + gameType from the completed game
+     * - Dismounts the minigame's current state
+     * - Deletes the minigame
+     * - Skips the default SM to the stored resumeStateIndex
+     */
+    void resumePrevious();
+
+    /*
+     * Main loop — delegates to whichever SM is currently active.
+     * If a swapped minigame signals readyForResume, auto-calls resumePrevious().
+     */
+    void loop();
+
+    StateMachine* getActive() const;
+    bool isSwapped() const;
+    const MiniGameOutcome& getLastOutcome() const;
+    GameType getLastGameType() const;
+
+private:
+    Device* device;
+    StateMachine* defaultSM = nullptr;   // NOT owned
+    MiniGame* swappedSM = nullptr;       // OWNED (deleted on resume)
+    bool swapped = false;
+    int resumeStateIndex_ = -1;
+    MiniGameOutcome lastOutcome;
+    GameType lastGameType = GameType::QUICKDRAW;
+};

--- a/include/state/state-machine.hpp
+++ b/include/state/state-machine.hpp
@@ -111,6 +111,8 @@ protected:
     State *newState = nullptr;
     State *currentState = nullptr;
 
+    Device* getDevice() { return PDN; }
+
 private:
     Device *PDN;
 };

--- a/src/cli-main.cpp
+++ b/src/cli-main.cpp
@@ -173,21 +173,7 @@ std::vector<cli::DeviceInstance> createDevices(int count) {
         for (char& c : name) {
             if (c >= 'A' && c <= 'Z') c += 32;
         }
-        if (name == "signal-echo" || name == "signalecho") {
-            npcGameType = GameType::SIGNAL_ECHO;
-        } else if (name == "ghost-runner") {
-            npcGameType = GameType::GHOST_RUNNER;
-        } else if (name == "spike-vector") {
-            npcGameType = GameType::SPIKE_VECTOR;
-        } else if (name == "firewall-decrypt") {
-            npcGameType = GameType::FIREWALL_DECRYPT;
-        } else if (name == "cipher-path") {
-            npcGameType = GameType::CIPHER_PATH;
-        } else if (name == "exploit-sequencer") {
-            npcGameType = GameType::EXPLOIT_SEQUENCER;
-        } else if (name == "breach-defense") {
-            npcGameType = GameType::BREACH_DEFENSE;
-        }
+        parseGameName(name, npcGameType);
 
         int npcIndex = static_cast<int>(devices.size());
         devices.push_back(cli::DeviceFactory::createChallengeDevice(npcIndex, npcGameType));

--- a/src/cli-main.cpp
+++ b/src/cli-main.cpp
@@ -22,6 +22,7 @@
 #include "cli/cli-event-logger.hpp"
 #include "cli/cli-script-runner.hpp"
 #include "device/device-types.hpp"
+#include "state/state-machine-manager.hpp"
 
 // Native drivers for global instances
 #include "device/drivers/native/native-logger-driver.hpp"
@@ -403,7 +404,11 @@ int main(int argc, char** argv) {
         // Update all devices
         for (auto& device : devices) {
             device.pdn->loop();
-            device.game->loop();
+            if (device.smManager) {
+                device.smManager->loop();
+            } else {
+                device.game->loop();
+            }
         }
 
         // Render UI

--- a/src/cli-main.cpp
+++ b/src/cli-main.cpp
@@ -19,6 +19,8 @@
 #include "cli/cli-device.hpp"
 #include "cli/cli-renderer.hpp"
 #include "cli/cli-commands.hpp"
+#include "cli/cli-event-logger.hpp"
+#include "cli/cli-script-runner.hpp"
 #include "device/device-types.hpp"
 
 // Native drivers for global instances
@@ -39,6 +41,9 @@ std::string g_commandResult;
 int g_selectedDevice = 0;  // Currently selected device index
 std::string g_npcGameName;  // --npc flag value (empty = no NPC)
 std::string g_gameModeName;  // --game flag value (empty = normal Quickdraw)
+std::string g_scriptPath;   // --script flag value (empty = no script)
+std::string g_logPath;      // --log flag value (empty = no log file)
+bool g_headless = false;    // --headless flag
 
 void signalHandler(int signal) {
     (void)signal;  // Suppress unused parameter warning
@@ -81,6 +86,26 @@ int parseArgs(int argc, char** argv) {
             continue;
         }
 
+        // Script automation flag
+        if (arg == "--script" && i + 1 < argc) {
+            g_scriptPath = argv[i + 1];
+            i++;
+            continue;
+        }
+
+        // Event log output file
+        if (arg == "--log" && i + 1 < argc) {
+            g_logPath = argv[i + 1];
+            i++;
+            continue;
+        }
+
+        // Headless mode (no UI, no prompts)
+        if (arg == "--headless") {
+            g_headless = true;
+            continue;
+        }
+
         // Help flag
         if (arg == "-h" || arg == "--help") {
             printf("PDN CLI Simulator\n");
@@ -88,6 +113,9 @@ int parseArgs(int argc, char** argv) {
             printf("Options:\n");
             printf("  -n, --count N     Create N devices (1-%d)\n", MAX_DEVICES);
             printf("  --game <name>     Run a standalone minigame (e.g., signal-echo)\n");
+            printf("  --script <file>   Run automation script and exit\n");
+            printf("  --log <file>      Write event log to file on exit\n");
+            printf("  --headless        No UI, no prompts (for scripted use)\n");
             printf("  -h, --help        Show this help message\n");
             printf("\nExamples:\n");
             printf("  %s           Interactive prompt for device count\n", argv[0]);
@@ -183,15 +211,18 @@ std::vector<cli::DeviceInstance> createDevices(int count) {
     }
 
     printf("\n");
-    printf("Press any key to start simulation...\n");
-    fflush(stdout);
 
-    // Wait for keypress (blocking read)
-    #ifndef _WIN32
-    getchar();
-    #else
-    _getch();
-    #endif
+    if (!g_headless) {
+        printf("Press any key to start simulation...\n");
+        fflush(stdout);
+
+        // Wait for keypress (blocking read)
+        #ifndef _WIN32
+        getchar();
+        #else
+        _getch();
+        #endif
+    }
 
     return devices;
 }
@@ -222,36 +253,93 @@ int main(int argc, char** argv) {
     // Determine device count from args or prompt
     int deviceCount = parseArgs(argc, argv);
     if (deviceCount < 0) {
-        // Default to 1 device for game mode
-        if (!g_gameModeName.empty()) {
+        // Default to 1 device for game mode or headless/script mode
+        if (!g_gameModeName.empty() || g_headless) {
             deviceCount = 1;
         } else {
             deviceCount = promptDeviceCount();
         }
     }
-    
+
     // Create devices
     std::vector<cli::DeviceInstance> devices = createDevices(deviceCount);
-    
-    // Now configure terminal for non-blocking input (Unix only)
+
+    // Create event logger for automation and diagnostics
+    cli::EventLogger eventLogger;
+
+    // Create CLI components
+    cli::Renderer renderer;
+    cli::CommandProcessor commandProcessor;
+
+    // Set up ScriptRunner if --script was provided
+    cli::ScriptRunner* scriptRunner = nullptr;
+    if (!g_scriptPath.empty()) {
+        scriptRunner = new cli::ScriptRunner(devices, commandProcessor, eventLogger);
+        if (!scriptRunner->loadFromFile(g_scriptPath)) {
+            printf("Error: cannot open script file: %s\n", g_scriptPath.c_str());
+            delete scriptRunner;
+            for (auto& device : devices) {
+                cli::DeviceFactory::destroyDevice(device);
+            }
+            delete globalLogger;
+            delete globalClock;
+            return 1;
+        }
+    }
+
+    // Headless mode: run script then exit
+    if (g_headless) {
+        int exitCode = 0;
+        if (scriptRunner) {
+            std::string error = scriptRunner->executeAll();
+            if (!error.empty()) {
+                printf("FAIL: %s\n", error.c_str());
+                exitCode = 1;
+            } else {
+                printf("PASS: script completed successfully\n");
+            }
+        }
+
+        // Write log file if requested
+        if (!g_logPath.empty()) {
+            eventLogger.writeToFile(g_logPath);
+        }
+
+        delete scriptRunner;
+        for (auto& device : devices) {
+            cli::DeviceFactory::destroyDevice(device);
+        }
+        delete globalLogger;
+        delete globalClock;
+        return exitCode;
+    }
+
+    // Interactive mode: configure terminal for non-blocking input (Unix only)
     #ifndef _WIN32
     struct termios oldTermios = cli::Terminal::enableRawMode();
     #endif
-    
+
     // Set up display for simulation
     cli::Terminal::clearScreen();
     cli::Terminal::hideCursor();
     cli::printHeader();
-    
-    // Create CLI components
-    cli::Renderer renderer;
-    cli::CommandProcessor commandProcessor;
-    
+
     // Show initial help hint
     g_commandResult = "Ready! Use LEFT/RIGHT to select device, UP/DOWN for buttons. Type 'help' for commands.";
-    
+
     // Main loop
     while (g_running) {
+        // If script has more commands, execute next one each frame
+        if (scriptRunner && scriptRunner->hasMore()) {
+            std::string error = scriptRunner->executeNext();
+            if (!error.empty()) {
+                g_commandResult = "Script error: " + error;
+                // Stop executing script on error, but don't quit
+                delete scriptRunner;
+                scriptRunner = nullptr;
+            }
+        }
+
         // Handle input (non-blocking)
         int key = cli::Terminal::readKey();
         while (key != static_cast<int>(cli::Key::NONE)) {
@@ -305,39 +393,48 @@ int main(int argc, char** argv) {
             }
             key = cli::Terminal::readKey();
         }
-        
+
         // Deliver pending peer-to-peer messages
         NativePeerBroker::getInstance().deliverPackets();
-        
+
         // Transfer serial data between connected devices
         cli::SerialCableBroker::getInstance().transferData();
-        
+
         // Update all devices
         for (auto& device : devices) {
             device.pdn->loop();
             device.game->loop();
         }
-        
+
         // Render UI
         renderer.renderUI(devices, g_commandResult, g_commandBuffer, g_selectedDevice);
-        
+
         // Sleep to maintain ~30 FPS update rate
         std::this_thread::sleep_for(std::chrono::milliseconds(33));
     }
-    
+
+    // Write log file if requested
+    if (!g_logPath.empty()) {
+        eventLogger.writeToFile(g_logPath);
+    }
+
     // Restore terminal settings and cursor
+    #ifndef _WIN32
+    cli::Terminal::restoreTerminal(oldTermios);
+    #endif
     cli::Terminal::showCursor();
-    
+
     // Move cursor below the UI for clean shutdown message
     printf("\n\nShutting down...\n");
-    
+
+    delete scriptRunner;
     for (auto& device : devices) {
         cli::DeviceFactory::destroyDevice(device);
     }
-    
+
     delete globalLogger;
     delete globalClock;
-    
+
     return 0;
 }
 

--- a/src/game/challenge-game.cpp
+++ b/src/game/challenge-game.cpp
@@ -1,0 +1,64 @@
+#include "game/challenge-game.hpp"
+#include "game/challenge-states.hpp"
+#include "game/challenge-result-manager.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "ChallengeGame";
+
+ChallengeGame::ChallengeGame(Device* device, GameType gameType, KonamiButton reward) :
+    StateMachine(device),
+    gameType(gameType),
+    reward(reward)
+{
+    LOG_I(TAG, "Creating ChallengeGame: %s (reward: %s)",
+          getGameDisplayName(gameType), getKonamiButtonName(reward));
+}
+
+ChallengeGame::~ChallengeGame() {
+    LOG_I(TAG, "Destroying ChallengeGame");
+}
+
+void ChallengeGame::populateStateMap() {
+    ChallengeResultManager* resultManager = new ChallengeResultManager();
+    resultManager->initialize(getDevice()->getStorage());
+
+    NpcIdle* npcIdle = new NpcIdle(this);
+    NpcHandshake* npcHandshake = new NpcHandshake(this);
+    NpcGameActive* npcGameActive = new NpcGameActive(this);
+    NpcReceiveResult* npcReceiveResult = new NpcReceiveResult(this, resultManager);
+
+    npcIdle->addTransition(
+        new StateTransition(
+            std::bind(&NpcIdle::transitionToHandshake, npcIdle),
+            npcHandshake));
+
+    npcHandshake->addTransition(
+        new StateTransition(
+            std::bind(&NpcHandshake::transitionToGameActive, npcHandshake),
+            npcGameActive));
+
+    npcHandshake->addTransition(
+        new StateTransition(
+            std::bind(&NpcHandshake::transitionToIdle, npcHandshake),
+            npcIdle));
+
+    npcGameActive->addTransition(
+        new StateTransition(
+            std::bind(&NpcGameActive::transitionToReceiveResult, npcGameActive),
+            npcReceiveResult));
+
+    npcGameActive->addTransition(
+        new StateTransition(
+            std::bind(&NpcGameActive::transitionToIdle, npcGameActive),
+            npcIdle));
+
+    npcReceiveResult->addTransition(
+        new StateTransition(
+            std::bind(&NpcReceiveResult::transitionToIdle, npcReceiveResult),
+            npcIdle));
+
+    stateMap.push_back(npcIdle);
+    stateMap.push_back(npcHandshake);
+    stateMap.push_back(npcGameActive);
+    stateMap.push_back(npcReceiveResult);
+}

--- a/src/game/challenge-result-manager.cpp
+++ b/src/game/challenge-result-manager.cpp
@@ -1,0 +1,5 @@
+// ChallengeResultManager is fully inline in the header.
+// This file exists for consistency with the project structure
+// and to provide a compilation unit if methods are later moved out of the header.
+
+#include "game/challenge-result-manager.hpp"

--- a/src/game/challenge-result-manager.cpp
+++ b/src/game/challenge-result-manager.cpp
@@ -1,5 +1,0 @@
-// ChallengeResultManager is fully inline in the header.
-// This file exists for consistency with the project structure
-// and to provide a compilation unit if methods are later moved out of the header.
-
-#include "game/challenge-result-manager.hpp"

--- a/src/game/challenge-states/npc-game-active.cpp
+++ b/src/game/challenge-states/npc-game-active.cpp
@@ -1,0 +1,168 @@
+#include "game/challenge-states.hpp"
+#include "game/challenge-game.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "NpcGameActive";
+
+NpcGameActive::NpcGameActive(ChallengeGame* game) :
+    State(ChallengeStateId::NPC_GAME_ACTIVE),
+    game(game)
+{
+}
+
+NpcGameActive::~NpcGameActive() {
+    game = nullptr;
+}
+
+void NpcGameActive::onStateMounted(Device* PDN) {
+    LOG_I(TAG, "NPC Game Active mounted");
+
+    transitionToReceiveResultState = false;
+    transitionToIdleState = false;
+    currentRound = 0;
+    totalRounds = 3;
+    sequenceLength = 4;
+    inputIndex = 0;
+    playerLives = 3;
+    playerScore = 0;
+    gameComplete = false;
+    playerWon = false;
+
+    inactivityTimer.setTimer(INACTIVITY_TIMEOUT_MS);
+
+    // Generate first sequence and send it
+    generateSequence();
+    sendSequence(PDN);
+
+    renderDisplay(PDN);
+}
+
+void NpcGameActive::onStateLoop(Device* PDN) {
+    inactivityTimer.updateTime();
+    if (inactivityTimer.expired()) {
+        LOG_W(TAG, "Inactivity timeout — returning to idle");
+        transitionToIdleState = true;
+    }
+}
+
+void NpcGameActive::onStateDismounted(Device* PDN) {
+    inactivityTimer.invalidate();
+    currentSequence.clear();
+}
+
+bool NpcGameActive::transitionToReceiveResult() {
+    return transitionToReceiveResultState;
+}
+
+bool NpcGameActive::transitionToIdle() {
+    return transitionToIdleState;
+}
+
+void NpcGameActive::generateSequence() {
+    currentSequence.clear();
+    for (int i = 0; i < sequenceLength; i++) {
+        currentSequence.push_back(rand() % 2 == 0);
+    }
+}
+
+void NpcGameActive::sendSequence(Device* PDN) {
+    // Format: "gseq:<round>:<length>:<bits>"
+    std::string bits;
+    for (bool b : currentSequence) {
+        bits += (b ? "1" : "0");
+    }
+    std::string msg = "gseq:" + std::to_string(currentRound) + ":" +
+                      std::to_string(sequenceLength) + ":" + bits;
+
+    // Send via ESP-NOW to the player
+    // For now, send via serial as well (ESP-NOW requires peer MAC)
+    PDN->writeString(msg.c_str());
+
+    LOG_I(TAG, "Sent sequence: %s", msg.c_str());
+    inputIndex = 0;
+}
+
+void NpcGameActive::onEspNowReceived(const std::string& message, Device* PDN) {
+    // Handle "ginp:<round>:<index>:<value>"
+    if (message.rfind("ginp:", 0) == 0) {
+        inactivityTimer.setTimer(INACTIVITY_TIMEOUT_MS);  // Reset timeout
+
+        // Parse: ginp:<round>:<index>:<value>
+        size_t c1 = 4;  // colon in "ginp:"
+        size_t c2 = message.find(':', c1 + 1);
+        size_t c3 = message.find(':', c2 + 1);
+        if (c2 == std::string::npos || c3 == std::string::npos) return;
+
+        int inpIndex = std::stoi(message.substr(c2 + 1, c3 - c2 - 1));
+        int inpValue = std::stoi(message.substr(c3 + 1));
+
+        bool expected = currentSequence[inpIndex];
+        bool playerInput = (inpValue == 1);
+        bool correct = (expected == playerInput);
+
+        if (!correct) {
+            playerLives--;
+        } else {
+            playerScore += 100;
+        }
+
+        // Send validation: "gval:<correct>:<livesLeft>"
+        std::string valMsg = "gval:" + std::string(correct ? "1" : "0") + ":" +
+                             std::to_string(playerLives);
+        PDN->writeString(valMsg.c_str());
+
+        inputIndex++;
+
+        // Check if lives exhausted
+        if (playerLives <= 0) {
+            gameComplete = true;
+            playerWon = false;
+            std::string resMsg = "gres:0:" + std::to_string(playerScore);
+            PDN->writeString(resMsg.c_str());
+            game->setLastResult(false);
+            game->setLastScore(playerScore);
+            transitionToReceiveResultState = true;
+            return;
+        }
+
+        // Check if round complete
+        if (inputIndex >= sequenceLength) {
+            currentRound++;
+            // Send round result: "grnd:<passed>:<nextRound>"
+            std::string rndMsg = "grnd:1:" + std::to_string(currentRound);
+            PDN->writeString(rndMsg.c_str());
+
+            // Check if all rounds complete
+            if (currentRound >= totalRounds) {
+                gameComplete = true;
+                playerWon = true;
+                std::string resMsg = "gres:1:" + std::to_string(playerScore);
+                PDN->writeString(resMsg.c_str());
+                game->setLastResult(true);
+                game->setLastScore(playerScore);
+                transitionToReceiveResultState = true;
+            } else {
+                // Generate next round
+                generateSequence();
+                sendSequence(PDN);
+            }
+        }
+
+        renderDisplay(PDN);
+    }
+}
+
+void NpcGameActive::renderDisplay(Device* PDN) {
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+    PDN->getDisplay()->drawText("GAME IN PROGRESS", 5, 15);
+
+    std::string roundStr = "Round " + std::to_string(currentRound + 1) +
+                           "/" + std::to_string(totalRounds);
+    PDN->getDisplay()->drawText(roundStr.c_str(), 10, 35);
+
+    std::string livesStr = "Lives: " + std::to_string(playerLives);
+    PDN->getDisplay()->drawText(livesStr.c_str(), 10, 50);
+
+    PDN->getDisplay()->render();
+}

--- a/src/game/challenge-states/npc-handshake.cpp
+++ b/src/game/challenge-states/npc-handshake.cpp
@@ -1,0 +1,73 @@
+#include "game/challenge-states.hpp"
+#include "game/challenge-game.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "NpcHandshake";
+
+NpcHandshake::NpcHandshake(ChallengeGame* game) :
+    State(ChallengeStateId::NPC_HANDSHAKE),
+    game(game)
+{
+}
+
+NpcHandshake::~NpcHandshake() {
+    game = nullptr;
+}
+
+void NpcHandshake::onStateMounted(Device* PDN) {
+    LOG_I(TAG, "NPC Handshake mounted");
+
+    transitionToGameActiveState = false;
+    transitionToIdleState = false;
+    playerMacAddress.clear();
+
+    timeoutTimer.setTimer(HANDSHAKE_TIMEOUT_MS);
+
+    // Read the MAC address that triggered this transition
+    // The Idle state received "smac<MAC>" — we need to read it from serial
+    // Actually, the serial callback in Idle already consumed it.
+    // We re-read from the serial buffer in case there's more data.
+    PDN->setOnStringReceivedCallback([this, PDN](const std::string& message) {
+        LOG_I(TAG, "Handshake serial: %s", message.c_str());
+        if (message.rfind(SEND_MAC_ADDRESS, 0) == 0) {
+            playerMacAddress = message.substr(SEND_MAC_ADDRESS.length());
+            LOG_I(TAG, "Player MAC: %s", playerMacAddress.c_str());
+
+            // NOTE: ESP-NOW peer registration deferred to Feature D.
+            // WirelessManager doesn't expose addPeer directly;
+            // the ESP-NOW driver handles it when sending data.
+
+            // Send acknowledgment
+            PDN->writeString(CHALLENGE_ACK.c_str());
+
+            transitionToGameActiveState = true;
+        }
+    });
+
+    // Display connecting message
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+    PDN->getDisplay()->drawText("CONNECTING...", 10, 30);
+    PDN->getDisplay()->render();
+}
+
+void NpcHandshake::onStateLoop(Device* PDN) {
+    timeoutTimer.updateTime();
+    if (timeoutTimer.expired()) {
+        LOG_W(TAG, "Handshake timed out");
+        transitionToIdleState = true;
+    }
+}
+
+void NpcHandshake::onStateDismounted(Device* PDN) {
+    timeoutTimer.invalidate();
+    PDN->clearCallbacks();
+}
+
+bool NpcHandshake::transitionToGameActive() {
+    return transitionToGameActiveState;
+}
+
+bool NpcHandshake::transitionToIdle() {
+    return transitionToIdleState;
+}

--- a/src/game/challenge-states/npc-idle.cpp
+++ b/src/game/challenge-states/npc-idle.cpp
@@ -1,0 +1,82 @@
+#include "game/challenge-states.hpp"
+#include "game/challenge-game.hpp"
+#include "game/challenge-resources.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "NpcIdle";
+
+NpcIdle::NpcIdle(ChallengeGame* game) :
+    State(ChallengeStateId::NPC_IDLE),
+    game(game)
+{
+}
+
+NpcIdle::~NpcIdle() {
+    game = nullptr;
+}
+
+void NpcIdle::onStateMounted(Device* PDN) {
+    LOG_I(TAG, "NPC Idle mounted — game: %s", getGameDisplayName(game->getGameType()));
+
+    transitionToHandshakeState = false;
+
+    // Set serial callback for incoming MAC address
+    PDN->setOnStringReceivedCallback(
+        std::bind(&NpcIdle::serialEventCallback, this, std::placeholders::_1));
+
+    // Start broadcast timer
+    broadcastTimer.setTimer(BROADCAST_INTERVAL_MS);
+
+    // Set up LED animation (reuse TRANSMIT_BREATH for slow pulse)
+    AnimationConfig config;
+    config.type = AnimationType::TRANSMIT_BREATH;
+    config.speed = 8;
+    config.curve = EaseCurve::EASE_IN_OUT;
+    config.loop = true;
+    config.loopDelayMs = 500;
+    PDN->getLightManager()->startAnimation(config);
+
+    renderDisplay(PDN);
+}
+
+void NpcIdle::onStateLoop(Device* PDN) {
+    broadcastTimer.updateTime();
+
+    if (broadcastTimer.expired()) {
+        // Broadcast challenge device identification
+        std::string cdevMsg = CHALLENGE_DEVICE_ID +
+            std::to_string(static_cast<int>(game->getGameType())) + ":" +
+            std::to_string(static_cast<int>(game->getReward()));
+        PDN->writeString(cdevMsg.c_str());
+        broadcastTimer.setTimer(BROADCAST_INTERVAL_MS);
+    }
+}
+
+void NpcIdle::onStateDismounted(Device* PDN) {
+    broadcastTimer.invalidate();
+    PDN->clearCallbacks();
+    PDN->getPrimaryButton()->removeButtonCallbacks();
+    PDN->getSecondaryButton()->removeButtonCallbacks();
+}
+
+bool NpcIdle::transitionToHandshake() {
+    return transitionToHandshakeState;
+}
+
+void NpcIdle::serialEventCallback(const std::string& message) {
+    LOG_I(TAG, "Serial received: %s", message.c_str());
+    if (message.rfind(SEND_MAC_ADDRESS, 0) == 0) {
+        // Player sent their MAC address — begin handshake
+        transitionToHandshakeState = true;
+    }
+}
+
+void NpcIdle::renderDisplay(Device* PDN) {
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+    PDN->getDisplay()->drawText(getGameDisplayName(game->getGameType()), 10, 20);
+
+    std::string unlockText = std::string("Unlock: ") + getKonamiButtonName(game->getReward());
+    PDN->getDisplay()->drawText(unlockText.c_str(), 10, 45);
+    PDN->getDisplay()->render();
+}

--- a/src/game/challenge-states/npc-receive-result.cpp
+++ b/src/game/challenge-states/npc-receive-result.cpp
@@ -1,0 +1,55 @@
+#include "game/challenge-states.hpp"
+#include "game/challenge-game.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "NpcReceiveResult";
+
+NpcReceiveResult::NpcReceiveResult(ChallengeGame* game, ChallengeResultManager* resultManager) :
+    State(ChallengeStateId::NPC_RECEIVE_RESULT),
+    game(game),
+    resultManager(resultManager)
+{
+}
+
+NpcReceiveResult::~NpcReceiveResult() {
+    game = nullptr;
+    resultManager = nullptr;
+}
+
+void NpcReceiveResult::onStateMounted(Device* PDN) {
+    LOG_I(TAG, "NPC Receive Result mounted — won: %d, score: %d",
+          game->getLastResult(), game->getLastScore());
+
+    transitionToIdleState = false;
+    displayTimer.setTimer(DISPLAY_DURATION_MS);
+
+    // Cache result in NVS for deferred upload
+    resultManager->cacheResult(game->getGameType(), game->getLastResult(), game->getLastScore());
+
+    // Display result
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+    if (game->getLastResult()) {
+        PDN->getDisplay()->drawText("PLAYER WON", 15, 25);
+    } else {
+        PDN->getDisplay()->drawText("PLAYER LOST", 15, 25);
+    }
+    std::string scoreStr = "Score: " + std::to_string(game->getLastScore());
+    PDN->getDisplay()->drawText(scoreStr.c_str(), 15, 45);
+    PDN->getDisplay()->render();
+}
+
+void NpcReceiveResult::onStateLoop(Device* PDN) {
+    displayTimer.updateTime();
+    if (displayTimer.expired()) {
+        transitionToIdleState = true;
+    }
+}
+
+void NpcReceiveResult::onStateDismounted(Device* PDN) {
+    displayTimer.invalidate();
+}
+
+bool NpcReceiveResult::transitionToIdle() {
+    return transitionToIdleState;
+}

--- a/src/game/progress-manager.cpp
+++ b/src/game/progress-manager.cpp
@@ -1,0 +1,103 @@
+#include "game/progress-manager.hpp"
+
+ProgressManager::ProgressManager()
+    : player(nullptr)
+    , storage(nullptr)
+    , synced(true) {
+}
+
+ProgressManager::~ProgressManager() {
+    player = nullptr;
+    storage = nullptr;
+}
+
+void ProgressManager::initialize(Player* player, StorageInterface* storage) {
+    this->player = player;
+    this->storage = storage;
+
+    // Load sync state from NVS
+    synced = (storage->readUChar(NVS_KEY_SYNCED, 1) == 1);
+
+    LOG_I(PROGRESS_TAG, "Initialized. Synced: %s", synced ? "true" : "false");
+}
+
+void ProgressManager::saveProgress() {
+    if (!player || !storage) {
+        LOG_E(PROGRESS_TAG, "Cannot save progress — not initialized");
+        return;
+    }
+
+    uint8_t progress = player->getKonamiProgress();
+    storage->writeUChar(NVS_KEY_KONAMI, progress);
+    storage->writeUChar(NVS_KEY_SYNCED, 0);
+    synced = false;
+
+    LOG_I(PROGRESS_TAG, "Saved progress to NVS: 0x%02X (unsynced)", progress);
+}
+
+void ProgressManager::loadProgress() {
+    if (!player || !storage) {
+        LOG_E(PROGRESS_TAG, "Cannot load progress — not initialized");
+        return;
+    }
+
+    uint8_t progress = storage->readUChar(NVS_KEY_KONAMI, 0);
+    if (progress > 0) {
+        player->setKonamiProgress(progress);
+        LOG_I(PROGRESS_TAG, "Loaded progress from NVS: 0x%02X", progress);
+    } else {
+        LOG_I(PROGRESS_TAG, "No progress in NVS (default 0)");
+    }
+}
+
+bool ProgressManager::hasUnsyncedProgress() const {
+    return !synced;
+}
+
+bool ProgressManager::uploadProgress(WirelessManager* wirelessManager) {
+    if (!player || !storage || !wirelessManager) {
+        LOG_E(PROGRESS_TAG, "Cannot upload progress — not initialized");
+        return false;
+    }
+
+    if (synced) {
+        LOG_I(PROGRESS_TAG, "Progress already synced — skipping upload");
+        return true;
+    }
+
+    // Build progress JSON
+    std::string progressJson = R"({"konami_progress":)" +
+        std::to_string(player->getKonamiProgress()) + "}";
+
+    bool uploadSucceeded = false;
+
+    QuickdrawRequests::updateProgress(
+        wirelessManager,
+        player->getUserID(),
+        progressJson,
+        [this, &uploadSucceeded](const std::string& response) {
+            LOG_I(PROGRESS_TAG, "Progress uploaded successfully");
+            storage->writeUChar(NVS_KEY_SYNCED, 1);
+            synced = true;
+            uploadSucceeded = true;
+        },
+        [this](const WirelessErrorInfo& error) {
+            LOG_E(PROGRESS_TAG, "Progress upload failed: %s", error.message.c_str());
+        }
+    );
+
+    return uploadSucceeded;
+}
+
+void ProgressManager::clearProgress() {
+    if (!storage) {
+        LOG_E(PROGRESS_TAG, "Cannot clear progress — not initialized");
+        return;
+    }
+
+    storage->remove(NVS_KEY_KONAMI);
+    storage->remove(NVS_KEY_SYNCED);
+    synced = true;
+
+    LOG_I(PROGRESS_TAG, "Cleared progress from NVS");
+}

--- a/src/game/quickdraw-states/challenge-complete-state.cpp
+++ b/src/game/quickdraw-states/challenge-complete-state.cpp
@@ -1,0 +1,93 @@
+#include "game/quickdraw-states.hpp"
+#include "game/quickdraw.hpp"
+#include "state/state-machine-manager.hpp"
+#include "game/progress-manager.hpp"
+#include "device/drivers/logger.hpp"
+#include "device/device-types.hpp"
+#include <cstdint>
+#include <cstdio>
+
+static const char* TAG = "ChallengeComplete";
+
+ChallengeComplete::ChallengeComplete(Player* player, StateMachineManager* smManager, ProgressManager* progressManager) :
+    State(CHALLENGE_COMPLETE),
+    player(player),
+    smManager(smManager),
+    progressManager(progressManager)
+{
+}
+
+ChallengeComplete::~ChallengeComplete() {
+    player = nullptr;
+    smManager = nullptr;
+    progressManager = nullptr;
+}
+
+void ChallengeComplete::onStateMounted(Device* PDN) {
+    LOG_I(TAG, "Challenge complete mounted");
+    transitionToIdleState = false;
+
+    // Get result from SM Manager
+    const MiniGameOutcome& outcome = smManager->getLastOutcome();
+    GameType gameType = smManager->getLastGameType();
+
+    LOG_I(TAG, "Game: %s, Result: %s, Score: %d",
+           getGameDisplayName(gameType),
+           outcome.result == MiniGameResult::WON ? "WON" : "LOST",
+           outcome.score);
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+
+    if (outcome.result == MiniGameResult::WON) {
+        // Unlock the Konami button reward
+        KonamiButton reward = getRewardForGame(gameType);
+        player->unlockKonamiButton(reward);
+        LOG_I(TAG, "Unlocked Konami button: %s", getKonamiButtonName(reward));
+
+        // Check if hard mode was beaten -- unlock color profile
+        if (outcome.hardMode) {
+            player->addColorProfileEligibility(gameType);
+            LOG_I(TAG, "Unlocked color profile for: %s", getGameDisplayName(gameType));
+        }
+
+        // Save progress
+        if (progressManager) {
+            progressManager->saveProgress();
+        }
+
+        // Display victory
+        PDN->getDisplay()->drawText("VICTORY!", 20, 15);
+        PDN->getDisplay()->drawText(getGameDisplayName(gameType), 10, 35);
+        char scoreStr[16];
+        snprintf(scoreStr, sizeof(scoreStr), "Score: %d", outcome.score);
+        PDN->getDisplay()->drawText(scoreStr, 20, 55);
+    } else {
+        // Display loss
+        PDN->getDisplay()->drawText("DEFEATED", 20, 15);
+        PDN->getDisplay()->drawText(getGameDisplayName(gameType), 10, 35);
+        char scoreStr[16];
+        snprintf(scoreStr, sizeof(scoreStr), "Score: %d", outcome.score);
+        PDN->getDisplay()->drawText(scoreStr, 20, 55);
+    }
+
+    PDN->getDisplay()->render();
+
+    // Start display timer
+    displayTimer.setTimer(DISPLAY_DURATION_MS);
+}
+
+void ChallengeComplete::onStateLoop(Device* PDN) {
+    displayTimer.updateTime();
+    if (displayTimer.expired()) {
+        transitionToIdleState = true;
+    }
+}
+
+void ChallengeComplete::onStateDismounted(Device* PDN) {
+    displayTimer.invalidate();
+}
+
+bool ChallengeComplete::transitionToIdle() {
+    return transitionToIdleState;
+}

--- a/src/game/quickdraw-states/challenge-detected-state.cpp
+++ b/src/game/quickdraw-states/challenge-detected-state.cpp
@@ -1,0 +1,121 @@
+#include "game/quickdraw-states.hpp"
+#include "game/quickdraw.hpp"
+#include "state/state-machine-manager.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+#include "device/drivers/logger.hpp"
+#include "wireless/mac-functions.hpp"
+#include "device/device-constants.hpp"
+#include "device/device-types.hpp"
+#include <cstdint>
+
+static const char* TAG = "ChallengeDetected";
+
+ChallengeDetected::ChallengeDetected(Player* player, StateMachineManager* smManager) :
+    State(CHALLENGE_DETECTED),
+    player(player),
+    smManager(smManager)
+{
+}
+
+ChallengeDetected::~ChallengeDetected() {
+    player = nullptr;
+    smManager = nullptr;
+}
+
+void ChallengeDetected::onStateMounted(Device* PDN) {
+    transitionToIdleState = false;
+    cackReceived = false;
+    macSent = false;
+
+    // Read the pending cdev message from Player (set by Idle)
+    cdevMessage = player->getPendingCdevMessage();
+
+    LOG_I(TAG, "Challenge detected, cdev: %s", cdevMessage.c_str());
+
+    // Parse the cdev message
+    if (!parseCdevMessage(cdevMessage, pendingGameType, pendingReward)) {
+        LOG_W(TAG, "Failed to parse cdev message: %s", cdevMessage.c_str());
+        transitionToIdleState = true;
+        return;
+    }
+
+    LOG_I(TAG, "Challenge: %s, reward: %s",
+           getGameDisplayName(pendingGameType),
+           getKonamiButtonName(pendingReward));
+
+    // Set up serial callback to listen for cack
+    PDN->setOnStringReceivedCallback([this](const std::string& message) {
+        LOG_I(TAG, "Serial received: %s", message.c_str());
+        if (message == CHALLENGE_ACK) {
+            LOG_I(TAG, "Received cack from NPC");
+            cackReceived = true;
+        }
+    });
+
+    // Send our MAC address to the NPC
+    uint8_t* macAddr = PDN->getWirelessManager()->getMacAddress();
+    const char* macStr = MacToString(macAddr);
+    std::string macMessage = SEND_MAC_ADDRESS + std::string(macStr);
+    PDN->writeString(macMessage.c_str());
+    macSent = true;
+
+    LOG_I(TAG, "Sent MAC: %s", macStr);
+
+    // Start timeout
+    timeoutTimer.setTimer(TIMEOUT_MS);
+
+    // Display challenge info
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+    PDN->getDisplay()->drawText("CHALLENGE", 20, 15);
+    PDN->getDisplay()->drawText(getGameDisplayName(pendingGameType), 20, 35);
+    PDN->getDisplay()->drawText("CONNECTING...", 10, 55);
+    PDN->getDisplay()->render();
+}
+
+void ChallengeDetected::onStateLoop(Device* PDN) {
+    timeoutTimer.updateTime();
+
+    if (cackReceived) {
+        LOG_I(TAG, "cack received, loading minigame");
+
+        // Create the minigame based on game type
+        MiniGame* miniGame = nullptr;
+
+        if (pendingGameType == GameType::SIGNAL_ECHO) {
+            SignalEchoConfig config = SIGNAL_ECHO_HARD;
+            config.managedMode = true;
+            miniGame = new SignalEcho(PDN, config);
+        }
+        // Future games: else if (pendingGameType == GameType::GHOST_RUNNER) { ... }
+
+        if (miniGame && smManager) {
+            // CHALLENGE_COMPLETE is at stateMap index 22
+            smManager->pauseAndLoad(miniGame, 22);
+        } else {
+            LOG_W(TAG, "Failed to create minigame or no SM Manager");
+            delete miniGame;
+            transitionToIdleState = true;
+        }
+        return;
+    }
+
+    if (timeoutTimer.expired()) {
+        LOG_W(TAG, "Challenge handshake timed out");
+        transitionToIdleState = true;
+    }
+}
+
+void ChallengeDetected::onStateDismounted(Device* PDN) {
+    timeoutTimer.invalidate();
+    cdevMessage.clear();
+    cackReceived = false;
+    macSent = false;
+    player->clearPendingChallenge();
+    PDN->clearCallbacks();
+}
+
+bool ChallengeDetected::transitionToIdle() {
+    return transitionToIdleState;
+}

--- a/src/game/quickdraw-states/fetch-user-state.cpp
+++ b/src/game/quickdraw-states/fetch-user-state.cpp
@@ -1,4 +1,5 @@
 #include "game/quickdraw-states.hpp"
+#include "device/device-types.hpp"
 #include "game/quickdraw-resources.hpp"
 #include "game/quickdraw-requests.hpp"
 #include "device/drivers/logger.hpp"
@@ -46,9 +47,18 @@ void FetchUserDataState::onStateMounted(Device *PDN) {
         transitionToUploadMatchesState = true;
         userDataFetchTimer.invalidate();
         isFetchingUserData = false;
-    } else if(player->getUserID() == BROADCAST_WIFI) { 
+    } else if(player->getUserID() == BROADCAST_WIFI) {
         remoteDebugManager->BroadcastDebugPacket();
         transitionToPlayerRegistrationState = true;
+        userDataFetchTimer.invalidate();
+        isFetchingUserData = false;
+    } else if(isChallengeDeviceCode(player->getUserID())) {
+        LOG_I(TAG, "Challenge device code detected: %s", player->getUserID().c_str());
+        // Save challenge mode to NVS so next boot creates ChallengeGame directly
+        PDN->getStorage()->write(DEVICE_MODE_KEY, player->getUserID());
+        // In a real device, this would trigger ESP.restart()
+        // For CLI/test, the NVS write is sufficient — the test verifies it
+        transitionToPlayerRegistrationState = true;  // Return to registration (reboot simulation)
         userDataFetchTimer.invalidate();
         isFetchingUserData = false;
     } else {

--- a/src/game/quickdraw-states/fetch-user-state.cpp
+++ b/src/game/quickdraw-states/fetch-user-state.cpp
@@ -2,6 +2,7 @@
 #include "device/device-types.hpp"
 #include "game/quickdraw-resources.hpp"
 #include "game/quickdraw-requests.hpp"
+#include "game/player.hpp"
 #include "device/drivers/logger.hpp"
 #include "wireless/remote-debug-manager.hpp"
 
@@ -66,13 +67,21 @@ void FetchUserDataState::onStateMounted(Device *PDN) {
             PDN->getWirelessManager(),
             player->getUserID(),
             [this](const PlayerResponse& response) {
-                LOG_I(TAG, "Successfully fetched player data: %s (%s)", 
+                LOG_I(TAG, "Successfully fetched player data: %s (%s)",
                         response.name.c_str(), response.id.c_str());
-                
+
                 player->setName(response.name.c_str());
                 player->setIsHunter(response.isHunter);
                 player->setAllegiance(response.allegiance);
                 player->setFaction(response.faction.c_str());
+
+                // Konami progress + color profile from server
+                player->setKonamiProgress(response.konamiProgress);
+                player->setEquippedColorProfile(
+                    static_cast<GameType>(response.equippedColorProfile));
+                for (uint8_t g : response.colorProfileEligibility) {
+                    player->addColorProfileEligibility(static_cast<GameType>(g));
+                }
 
                 userDataFetchTimer.invalidate();
                 transitionToWelcomeMessageState = true;

--- a/src/game/quickdraw-states/idle-state.cpp
+++ b/src/game/quickdraw-states/idle-state.cpp
@@ -103,8 +103,7 @@ void Idle::serialEventCallbacks(const std::string& message) {
         LOG_I("IDLE", "Challenge device detected: %s", message.c_str());
         challengeDeviceDetected = true;
         lastCdevMessage = message;
-        // Respond with our MAC address (same as heartbeat response)
-        sendMacAddress = true;
+        player->setPendingChallenge(message);
     } else if(message.rfind(SEND_MAC_ADDRESS, 0) == 0) {
         // Message starts with "smac" - extract MAC address after prefix
         std::string macAddress = message.substr(SEND_MAC_ADDRESS.length());
@@ -115,7 +114,7 @@ void Idle::serialEventCallbacks(const std::string& message) {
 }
 
 bool Idle::transitionToHandshake() {
-    return transitionToHandshakeState;
+    return transitionToHandshakeState && !challengeDeviceDetected;
 }
 
 void Idle::cycleStats(Device *PDN) {

--- a/src/game/signal-echo/echo-evaluate.cpp
+++ b/src/game/signal-echo/echo-evaluate.cpp
@@ -1,0 +1,71 @@
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+EchoEvaluate::EchoEvaluate(SignalEcho* game) : State(ECHO_EVALUATE) {
+    this->game = game;
+}
+
+EchoEvaluate::~EchoEvaluate() {
+    game = nullptr;
+}
+
+void EchoEvaluate::onStateMounted(Device* PDN) {
+    transitionToShowSequenceState = false;
+    transitionToWinState = false;
+    transitionToLoseState = false;
+
+    auto& session = game->getSession();
+    auto& config = game->getConfig();
+
+    // Check if player has exceeded allowed mistakes
+    if (session.mistakes > config.allowedMistakes) {
+        transitionToLoseState = true;
+        return;
+    }
+
+    // Round completed successfully — advance
+    session.currentRound++;
+
+    // Check if all rounds completed
+    if (session.currentRound >= config.numSequences) {
+        transitionToWinState = true;
+        return;
+    }
+
+    // Generate next sequence
+    if (config.cumulative) {
+        // Cumulative mode: append one more element
+        session.currentSequence.push_back(rand() % 2 == 0);
+    } else {
+        // Fresh mode: completely new sequence
+        session.currentSequence = game->generateSequence(config.sequenceLength);
+    }
+
+    // Reset input index for the new round
+    session.inputIndex = 0;
+
+    transitionToShowSequenceState = true;
+}
+
+void EchoEvaluate::onStateLoop(Device* PDN) {
+    // Transitions are determined in onStateMounted — nothing to do here
+}
+
+void EchoEvaluate::onStateDismounted(Device* PDN) {
+    transitionToShowSequenceState = false;
+    transitionToWinState = false;
+    transitionToLoseState = false;
+}
+
+bool EchoEvaluate::transitionToShowSequence() {
+    return transitionToShowSequenceState;
+}
+
+bool EchoEvaluate::transitionToWin() {
+    return transitionToWinState;
+}
+
+bool EchoEvaluate::transitionToLose() {
+    return transitionToLoseState;
+}

--- a/src/game/signal-echo/echo-intro.cpp
+++ b/src/game/signal-echo/echo-intro.cpp
@@ -1,0 +1,59 @@
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+EchoIntro::EchoIntro(SignalEcho* game) : State(ECHO_INTRO) {
+    this->game = game;
+}
+
+EchoIntro::~EchoIntro() {
+    game = nullptr;
+}
+
+void EchoIntro::onStateMounted(Device* PDN) {
+    transitionToShowSequenceState = false;
+
+    // Reset session for a fresh game
+    game->getSession().reset();
+    game->resetGame();
+
+    // Seed RNG and generate the first sequence
+    game->seedRng();
+    game->getSession().currentSequence = game->generateSequence(
+        game->getConfig().sequenceLength);
+
+    // Display title screen
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("SIGNAL ECHO", 15, 20)
+        ->drawText("Watch. Repeat.", 10, 45);
+    PDN->getDisplay()->render();
+
+    // Start idle LED animation
+    AnimationConfig config;
+    config.type = AnimationType::IDLE;
+    config.speed = 16;
+    config.curve = EaseCurve::LINEAR;
+    config.initialState = SIGNAL_ECHO_IDLE_STATE;
+    config.loopDelayMs = 0;
+    config.loop = true;
+    PDN->getLightManager()->startAnimation(config);
+
+    // Start intro timer
+    introTimer.setTimer(INTRO_DURATION_MS);
+}
+
+void EchoIntro::onStateLoop(Device* PDN) {
+    if (introTimer.expired()) {
+        transitionToShowSequenceState = true;
+    }
+}
+
+void EchoIntro::onStateDismounted(Device* PDN) {
+    introTimer.invalidate();
+    transitionToShowSequenceState = false;
+}
+
+bool EchoIntro::transitionToShowSequence() {
+    return transitionToShowSequenceState;
+}

--- a/src/game/signal-echo/echo-lose.cpp
+++ b/src/game/signal-echo/echo-lose.cpp
@@ -46,9 +46,12 @@ void EchoLose::onStateMounted(Device* PDN) {
 void EchoLose::onStateLoop(Device* PDN) {
     if (loseTimer.expired()) {
         PDN->getHaptics()->off();
-        // In standalone mode, restart the game
         if (!game->getConfig().managedMode) {
+            // In standalone mode, restart the game
             transitionToIntroState = true;
+        } else {
+            // In managed mode, signal SM Manager to resume
+            game->setReadyForResume(true);
         }
     }
 }

--- a/src/game/signal-echo/echo-lose.cpp
+++ b/src/game/signal-echo/echo-lose.cpp
@@ -1,0 +1,68 @@
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+EchoLose::EchoLose(SignalEcho* game) : State(ECHO_LOSE) {
+    this->game = game;
+}
+
+EchoLose::~EchoLose() {
+    game = nullptr;
+}
+
+void EchoLose::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    auto& session = game->getSession();
+
+    MiniGameOutcome loseOutcome;
+    loseOutcome.result = MiniGameResult::LOST;
+    loseOutcome.score = session.score;
+    loseOutcome.hardMode = false;
+    game->setOutcome(loseOutcome);
+
+    // Display defeat screen
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("SIGNAL LOST", 20, 30);
+    PDN->getDisplay()->render();
+
+    // Red fade LED
+    AnimationConfig config;
+    config.type = AnimationType::IDLE;
+    config.speed = 8;
+    config.curve = EaseCurve::LINEAR;
+    config.initialState = SIGNAL_ECHO_LOSE_STATE;
+    config.loopDelayMs = 0;
+    config.loop = true;
+    PDN->getLightManager()->startAnimation(config);
+
+    // Long haptic buzz
+    PDN->getHaptics()->max();
+
+    loseTimer.setTimer(LOSE_DISPLAY_MS);
+}
+
+void EchoLose::onStateLoop(Device* PDN) {
+    if (loseTimer.expired()) {
+        PDN->getHaptics()->off();
+        // In standalone mode, restart the game
+        if (!game->getConfig().managedMode) {
+            transitionToIntroState = true;
+        }
+    }
+}
+
+void EchoLose::onStateDismounted(Device* PDN) {
+    loseTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool EchoLose::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool EchoLose::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/signal-echo/echo-player-input.cpp
+++ b/src/game/signal-echo/echo-player-input.cpp
@@ -1,0 +1,140 @@
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+EchoPlayerInput::EchoPlayerInput(SignalEcho* game) : State(ECHO_PLAYER_INPUT) {
+    this->game = game;
+}
+
+EchoPlayerInput::~EchoPlayerInput() {
+    game = nullptr;
+}
+
+void EchoPlayerInput::onStateMounted(Device* PDN) {
+    transitionToEvaluateState = false;
+    displayIsDirty = true;
+
+    // Set up button callbacks
+    // Primary button (UP arrow key in CLI) = UP input
+    parameterizedCallbackFunction upCallback = [](void* ctx) {
+        auto* state = static_cast<EchoPlayerInput*>(ctx);
+        // Actually, we handle input inline via the flag pattern
+        state->handleInput(true, nullptr);
+    };
+
+    parameterizedCallbackFunction downCallback = [](void* ctx) {
+        auto* state = static_cast<EchoPlayerInput*>(ctx);
+        state->handleInput(false, nullptr);
+    };
+
+    PDN->getPrimaryButton()->setButtonPress(upCallback, this, ButtonInteraction::CLICK);
+    PDN->getSecondaryButton()->setButtonPress(downCallback, this, ButtonInteraction::CLICK);
+
+    renderInputScreen(PDN);
+}
+
+void EchoPlayerInput::onStateLoop(Device* PDN) {
+    if (displayIsDirty) {
+        renderInputScreen(PDN);
+        displayIsDirty = false;
+    }
+
+    auto& session = game->getSession();
+    int seqLen = static_cast<int>(session.currentSequence.size());
+
+    // Check if all inputs have been entered
+    if (session.inputIndex >= seqLen) {
+        transitionToEvaluateState = true;
+        return;
+    }
+
+    // Check if mistakes exceeded allowed
+    if (session.mistakes > game->getConfig().allowedMistakes) {
+        transitionToEvaluateState = true;
+        return;
+    }
+}
+
+void EchoPlayerInput::onStateDismounted(Device* PDN) {
+    transitionToEvaluateState = false;
+    PDN->getPrimaryButton()->removeButtonCallbacks();
+    PDN->getSecondaryButton()->removeButtonCallbacks();
+    PDN->getHaptics()->off();
+}
+
+bool EchoPlayerInput::transitionToEvaluate() {
+    return transitionToEvaluateState;
+}
+
+void EchoPlayerInput::handleInput(bool isUp, Device* PDN) {
+    auto& session = game->getSession();
+    int seqLen = static_cast<int>(session.currentSequence.size());
+
+    if (session.inputIndex >= seqLen) {
+        return;  // Already completed input for this round
+    }
+
+    bool expected = session.currentSequence[session.inputIndex];
+
+    if (isUp == expected) {
+        // Correct input
+        session.score += 100;
+    } else {
+        // Wrong input — count mistake, advance anyway (locked in)
+        session.mistakes++;
+    }
+
+    // Always advance to next position
+    session.inputIndex++;
+    displayIsDirty = true;
+}
+
+void EchoPlayerInput::renderInputScreen(Device* PDN) {
+    auto& session = game->getSession();
+    auto& config = game->getConfig();
+    int seqLen = static_cast<int>(session.currentSequence.size());
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("YOUR TURN", 25, 12);
+
+    // Build input progress string
+    // Show entered inputs as ^ or v (correct) or X (wrong), remaining as _
+    std::string inputProgress;
+    for (int i = 0; i < seqLen; i++) {
+        if (i < session.inputIndex) {
+            // This position has been entered
+            // Show the expected symbol for entered positions
+            bool expected = session.currentSequence[i];
+            if (expected) {
+                inputProgress += "^ ";
+            } else {
+                inputProgress += "v ";
+            }
+        } else {
+            inputProgress += "_ ";
+        }
+    }
+
+    PDN->getDisplay()->drawText(inputProgress.c_str(), 5, 35);
+
+    // Round counter + life indicator
+    int livesRemaining = config.allowedMistakes - session.mistakes;
+    if (livesRemaining < 0) livesRemaining = 0;
+
+    std::string roundInfo = "Round " + std::to_string(session.currentRound + 1) +
+                            "/" + std::to_string(config.numSequences);
+
+    std::string lives;
+    for (int i = 0; i < config.allowedMistakes; i++) {
+        if (i < livesRemaining) {
+            lives += "* ";  // Remaining life (filled)
+        } else {
+            lives += "o ";  // Lost life (empty)
+        }
+    }
+
+    PDN->getDisplay()->drawText(roundInfo.c_str(), 5, 55);
+    PDN->getDisplay()->drawText(lives.c_str(), 80, 55);
+    PDN->getDisplay()->render();
+}

--- a/src/game/signal-echo/echo-show-sequence.cpp
+++ b/src/game/signal-echo/echo-show-sequence.cpp
@@ -1,0 +1,96 @@
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+EchoShowSequence::EchoShowSequence(SignalEcho* game) : State(ECHO_SHOW_SEQUENCE) {
+    this->game = game;
+}
+
+EchoShowSequence::~EchoShowSequence() {
+    game = nullptr;
+}
+
+void EchoShowSequence::onStateMounted(Device* PDN) {
+    transitionToPlayerInputState = false;
+    currentSignalIndex = 0;
+    displayedCurrentSignal = false;
+
+    // Reset input index for the new round
+    game->getSession().inputIndex = 0;
+}
+
+void EchoShowSequence::onStateLoop(Device* PDN) {
+    auto& session = game->getSession();
+    int seqLen = static_cast<int>(session.currentSequence.size());
+
+    if (currentSignalIndex >= seqLen) {
+        // All signals shown — transition to player input
+        transitionToPlayerInputState = true;
+        return;
+    }
+
+    if (!displayedCurrentSignal) {
+        // Display the current signal
+        bool isUp = session.currentSequence[currentSignalIndex];
+        displaySignal(PDN, isUp, currentSignalIndex, seqLen);
+
+        // Light pulse haptic feedback per signal
+        PDN->getHaptics()->setIntensity(128);
+
+        // Start timer for this signal's display duration
+        signalTimer.setTimer(game->getConfig().displaySpeedMs);
+        displayedCurrentSignal = true;
+    }
+
+    if (signalTimer.expired()) {
+        PDN->getHaptics()->off();
+        currentSignalIndex++;
+        displayedCurrentSignal = false;
+    }
+}
+
+void EchoShowSequence::onStateDismounted(Device* PDN) {
+    signalTimer.invalidate();
+    transitionToPlayerInputState = false;
+    PDN->getHaptics()->off();
+}
+
+bool EchoShowSequence::transitionToPlayerInput() {
+    return transitionToPlayerInputState;
+}
+
+void EchoShowSequence::displaySignal(Device* PDN, bool isUp, int index, int total) {
+    PDN->getDisplay()->invalidateScreen();
+
+    if (isUp) {
+        PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+            ->drawText("^", 60, 25)
+            ->drawText("UP", 55, 40);
+    } else {
+        PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+            ->drawText("v", 60, 25)
+            ->drawText("DOWN", 48, 40);
+    }
+
+    // Progress indicator: "Signal N of M"
+    std::string progress = "Signal " + std::to_string(index + 1) +
+                           " of " + std::to_string(total);
+    PDN->getDisplay()->drawText(progress.c_str(), 20, 58);
+    PDN->getDisplay()->render();
+
+    // LED chase direction matches signal direction
+    AnimationConfig ledConfig;
+    ledConfig.type = AnimationType::VERTICAL_CHASE;
+    ledConfig.speed = 8;
+    ledConfig.curve = EaseCurve::EASE_OUT;
+    ledConfig.loop = false;
+
+    LEDState state;
+    for (int i = 0; i < 9; i++) {
+        LEDColor color = signalEchoColors[i % 4];
+        state.leftLights[i] = LEDState::SingleLEDState(color, 200);
+        state.rightLights[i] = LEDState::SingleLEDState(color, 200);
+    }
+    ledConfig.initialState = state;
+    PDN->getLightManager()->startAnimation(ledConfig);
+}

--- a/src/game/signal-echo/echo-win.cpp
+++ b/src/game/signal-echo/echo-win.cpp
@@ -1,0 +1,75 @@
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+EchoWin::EchoWin(SignalEcho* game) : State(ECHO_WIN) {
+    this->game = game;
+}
+
+EchoWin::~EchoWin() {
+    game = nullptr;
+}
+
+void EchoWin::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    auto& session = game->getSession();
+
+    // Determine if this was a hard mode win
+    bool isHard = (game->getConfig().allowedMistakes <= 1 &&
+                   game->getConfig().sequenceLength >= 8);
+
+    MiniGameOutcome winOutcome;
+    winOutcome.result = MiniGameResult::WON;
+    winOutcome.score = session.score;
+    winOutcome.hardMode = isHard;
+    game->setOutcome(winOutcome);
+
+    // Display victory screen
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("ACCESS GRANTED", 5, 25);
+
+    std::string scoreStr = "Score: " + std::to_string(session.score);
+    PDN->getDisplay()->drawText(scoreStr.c_str(), 30, 50);
+    PDN->getDisplay()->render();
+
+    // Rainbow LED sweep
+    AnimationConfig config;
+    config.type = AnimationType::VERTICAL_CHASE;
+    config.speed = 5;
+    config.curve = EaseCurve::EASE_IN_OUT;
+    config.initialState = SIGNAL_ECHO_WIN_STATE;
+    config.loopDelayMs = 500;
+    config.loop = true;
+    PDN->getLightManager()->startAnimation(config);
+
+    // Celebration haptic
+    PDN->getHaptics()->setIntensity(200);
+
+    winTimer.setTimer(WIN_DISPLAY_MS);
+}
+
+void EchoWin::onStateLoop(Device* PDN) {
+    if (winTimer.expired()) {
+        PDN->getHaptics()->off();
+        // In standalone mode, restart the game
+        if (!game->getConfig().managedMode) {
+            transitionToIntroState = true;
+        }
+    }
+}
+
+void EchoWin::onStateDismounted(Device* PDN) {
+    winTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool EchoWin::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool EchoWin::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/signal-echo/echo-win.cpp
+++ b/src/game/signal-echo/echo-win.cpp
@@ -53,9 +53,12 @@ void EchoWin::onStateMounted(Device* PDN) {
 void EchoWin::onStateLoop(Device* PDN) {
     if (winTimer.expired()) {
         PDN->getHaptics()->off();
-        // In standalone mode, restart the game
         if (!game->getConfig().managedMode) {
+            // In standalone mode, restart the game
             transitionToIntroState = true;
+        } else {
+            // In managed mode, signal SM Manager to resume
+            game->setReadyForResume(true);
         }
     }
 }

--- a/src/game/signal-echo/signal-echo.cpp
+++ b/src/game/signal-echo/signal-echo.cpp
@@ -1,0 +1,89 @@
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+SignalEcho::SignalEcho(Device* device, SignalEchoConfig config) :
+    MiniGame(device, GameType::SIGNAL_ECHO, "SIGNAL ECHO"),
+    config(config)
+{
+}
+
+void SignalEcho::populateStateMap() {
+    seedRng();
+
+    EchoIntro* intro = new EchoIntro(this);
+    EchoShowSequence* showSequence = new EchoShowSequence(this);
+    EchoPlayerInput* playerInput = new EchoPlayerInput(this);
+    EchoEvaluate* evaluate = new EchoEvaluate(this);
+    EchoWin* win = new EchoWin(this);
+    EchoLose* lose = new EchoLose(this);
+
+    intro->addTransition(
+        new StateTransition(
+            std::bind(&EchoIntro::transitionToShowSequence, intro),
+            showSequence));
+
+    showSequence->addTransition(
+        new StateTransition(
+            std::bind(&EchoShowSequence::transitionToPlayerInput, showSequence),
+            playerInput));
+
+    playerInput->addTransition(
+        new StateTransition(
+            std::bind(&EchoPlayerInput::transitionToEvaluate, playerInput),
+            evaluate));
+
+    evaluate->addTransition(
+        new StateTransition(
+            std::bind(&EchoEvaluate::transitionToShowSequence, evaluate),
+            showSequence));
+
+    evaluate->addTransition(
+        new StateTransition(
+            std::bind(&EchoEvaluate::transitionToWin, evaluate),
+            win));
+
+    evaluate->addTransition(
+        new StateTransition(
+            std::bind(&EchoEvaluate::transitionToLose, evaluate),
+            lose));
+
+    // Standalone mode: win/lose loop back to intro for replay
+    win->addTransition(
+        new StateTransition(
+            std::bind(&EchoWin::transitionToIntro, win),
+            intro));
+
+    lose->addTransition(
+        new StateTransition(
+            std::bind(&EchoLose::transitionToIntro, lose),
+            intro));
+
+    stateMap.push_back(intro);
+    stateMap.push_back(showSequence);
+    stateMap.push_back(playerInput);
+    stateMap.push_back(evaluate);
+    stateMap.push_back(win);
+    stateMap.push_back(lose);
+}
+
+void SignalEcho::resetGame() {
+    MiniGame::resetGame();
+    session.reset();
+}
+
+void SignalEcho::seedRng() {
+    if (config.rngSeed != 0) {
+        srand(static_cast<unsigned int>(config.rngSeed));
+    } else {
+        srand(static_cast<unsigned int>(0));
+    }
+}
+
+std::vector<bool> SignalEcho::generateSequence(int length) {
+    std::vector<bool> seq;
+    for (int i = 0; i < length; i++) {
+        seq.push_back(rand() % 2 == 0);
+    }
+    return seq;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@
 #include "wireless/quickdraw-wireless-manager.hpp"
 #include "wireless/remote-debug-manager.hpp"
 #include "device/drivers/peer-comms-interface.hpp"
+#include "state/state-machine-manager.hpp"
 
 // WiFi configuration - injected at compile time from wifi_credentials.ini
 // See wifi_credentials.ini.example for template
@@ -67,6 +68,7 @@ Player* player = nullptr;
 
 // Game instance
 StateMachine* game = nullptr;
+StateMachineManager* smManager = nullptr;
 
 // Progress management
 ProgressManager* progressManager = nullptr;
@@ -173,6 +175,11 @@ void setup() {
         game = new ChallengeGame(pdn, npcGameType, reward);
     } else {
         game = new Quickdraw(player, pdn, quickdrawWirelessManager, remoteDebugManager);
+        smManager = new StateMachineManager(pdn);
+        smManager->setDefaultStateMachine(game);
+        Quickdraw* quickdraw = static_cast<Quickdraw*>(game);
+        quickdraw->setStateMachineManager(smManager);
+        quickdraw->setProgressManager(progressManager);
     }
     
     pdn->getDisplay()->
@@ -186,5 +193,9 @@ void setup() {
 
 void loop() {
     pdn->loop();
-    game->loop();
+    if (smManager) {
+        smManager->loop();
+    } else {
+        game->loop();
+    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include "id-generator.hpp"
 #include "wireless/remote-player-manager.hpp"
 #include "game/match-manager.hpp"
+#include "game/progress-manager.hpp"
 #include "wireless/wireless-types.hpp"
 #include "wireless/quickdraw-wireless-manager.hpp"
 #include "wireless/remote-debug-manager.hpp"
@@ -66,6 +67,9 @@ Player* player = nullptr;
 
 // Game instance
 StateMachine* game = nullptr;
+
+// Progress management
+ProgressManager* progressManager = nullptr;
 
 // Remote player management
 QuickdrawWirelessManager* quickdrawWirelessManager = nullptr;
@@ -141,6 +145,10 @@ void setup() {
     player = new Player();
     player->setUserID(idGenerator->generateId());
     pdn->begin();
+
+    // Create and initialize ProgressManager
+    progressManager = new ProgressManager();
+    progressManager->initialize(player, pdn->getStorage());
     
     // Create wireless managers
     LOG_I("SETUP", "Creating QuickdrawWirelessManager...");

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -277,6 +277,24 @@ void Player::addReactionTime(unsigned long reactionTime) {
     totalReactionTime += reactionTime;
 }
 
+// --- Pending challenge ---
+
+void Player::setPendingChallenge(const std::string& cdevMessage) {
+    pendingCdevMessage = cdevMessage;
+}
+
+const std::string& Player::getPendingCdevMessage() const {
+    return pendingCdevMessage;
+}
+
+void Player::clearPendingChallenge() {
+    pendingCdevMessage.clear();
+}
+
+bool Player::hasPendingChallenge() const {
+    return !pendingCdevMessage.empty();
+}
+
 // --- Konami progress ---
 
 void Player::unlockKonamiButton(KonamiButton button) {

--- a/src/state/state-machine-manager.cpp
+++ b/src/state/state-machine-manager.cpp
@@ -1,0 +1,88 @@
+#include "state/state-machine-manager.hpp"
+
+StateMachineManager::StateMachineManager(Device* device) :
+    device(device)
+{
+}
+
+StateMachineManager::~StateMachineManager() {
+    // Clean up swapped game if still active
+    if (swappedSM) {
+        delete swappedSM;
+        swappedSM = nullptr;
+    }
+    // defaultSM is NOT owned — do not delete
+}
+
+void StateMachineManager::setDefaultStateMachine(StateMachine* sm) {
+    defaultSM = sm;
+}
+
+void StateMachineManager::pauseAndLoad(MiniGame* game, int resumeStateIndex) {
+    if (!defaultSM || !game) return;
+
+    // Dismount the current state on the default SM
+    if (defaultSM->getCurrentState()) {
+        defaultSM->getCurrentState()->onStateDismounted(device);
+    }
+
+    // Store resume point
+    resumeStateIndex_ = resumeStateIndex;
+
+    // Take ownership of the minigame
+    swappedSM = game;
+    swappedSM->initialize();
+    swapped = true;
+}
+
+void StateMachineManager::resumePrevious() {
+    if (!swapped || !swappedSM || !defaultSM) return;
+
+    // Store outcome from the completed game
+    lastOutcome = swappedSM->getOutcome();
+    lastGameType = swappedSM->getGameType();
+
+    // Dismount the swapped game's current state
+    if (swappedSM->getCurrentState()) {
+        swappedSM->getCurrentState()->onStateDismounted(device);
+    }
+
+    // Delete the minigame (we own it)
+    delete swappedSM;
+    swappedSM = nullptr;
+
+    // Resume the default SM at the stored index
+    defaultSM->skipToState(resumeStateIndex_);
+    swapped = false;
+}
+
+void StateMachineManager::loop() {
+    if (swapped && swappedSM) {
+        swappedSM->loop();
+        // Check if the minigame is ready for resume
+        if (swappedSM->isReadyForResume()) {
+            resumePrevious();
+        }
+    } else if (defaultSM) {
+        defaultSM->loop();
+    }
+}
+
+StateMachine* StateMachineManager::getActive() const {
+    if (swapped && swappedSM) {
+        return swappedSM;
+    }
+    return defaultSM;
+}
+
+bool StateMachineManager::isSwapped() const {
+    return swapped;
+}
+
+const MiniGameOutcome& StateMachineManager::getLastOutcome() const {
+    return lastOutcome;
+}
+
+GameType StateMachineManager::getLastGameType() const {
+    return lastGameType;
+}

--- a/test/test_cli/challenge-game-tests.hpp
+++ b/test/test_cli/challenge-game-tests.hpp
@@ -1,0 +1,240 @@
+//
+// Challenge Game Tests — NPC state machine and state behavior
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include "device/drivers/native/native-logger-driver.hpp"
+#include "device/drivers/native/native-clock-driver.hpp"
+#include "device/drivers/native/native-display-driver.hpp"
+#include "device/drivers/native/native-button-driver.hpp"
+#include "device/drivers/native/native-light-strip-driver.hpp"
+#include "device/drivers/native/native-haptics-driver.hpp"
+#include "device/drivers/native/native-serial-driver.hpp"
+#include "device/drivers/native/native-http-client-driver.hpp"
+#include "device/drivers/native/native-peer-comms-driver.hpp"
+#include "device/drivers/native/native-prefs-driver.hpp"
+#include "device/pdn.hpp"
+#include "game/challenge-game.hpp"
+#include "game/challenge-states.hpp"
+#include "game/challenge-result-manager.hpp"
+#include "utils/simple-timer.hpp"
+
+// ============================================
+// CHALLENGE GAME TEST SUITE
+// ============================================
+
+class ChallengeGameTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        globalClock_ = new NativeClockDriver("cg_test_clock");
+        globalLogger_ = new NativeLoggerDriver("cg_test_logger");
+        globalLogger_->setSuppressOutput(true);
+        g_logger = globalLogger_;
+        SimpleTimer::setPlatformClock(globalClock_);
+
+        std::string suffix = "_cg_test";
+        displayDriver_ = new NativeDisplayDriver(DISPLAY_DRIVER_NAME + suffix);
+        primaryButton_ = new NativeButtonDriver(PRIMARY_BUTTON_DRIVER_NAME + suffix, 0);
+        secondaryButton_ = new NativeButtonDriver(SECONDARY_BUTTON_DRIVER_NAME + suffix, 1);
+        lightDriver_ = new NativeLightStripDriver(LIGHT_DRIVER_NAME + suffix);
+        hapticsDriver_ = new NativeHapticsDriver(HAPTICS_DRIVER_NAME + suffix, 0);
+        serialOut_ = new NativeSerialDriver(SERIAL_OUT_DRIVER_NAME + suffix);
+        serialIn_ = new NativeSerialDriver(SERIAL_IN_DRIVER_NAME + suffix);
+        httpClient_ = new NativeHttpClientDriver(HTTP_CLIENT_DRIVER_NAME + suffix);
+        peerComms_ = new NativePeerCommsDriver(PEER_COMMS_DRIVER_NAME + suffix);
+        storageDriver_ = new NativePrefsDriver(STORAGE_DRIVER_NAME + suffix);
+
+        DriverConfig config = {
+            {DISPLAY_DRIVER_NAME, displayDriver_},
+            {PRIMARY_BUTTON_DRIVER_NAME, primaryButton_},
+            {SECONDARY_BUTTON_DRIVER_NAME, secondaryButton_},
+            {LIGHT_DRIVER_NAME, lightDriver_},
+            {HAPTICS_DRIVER_NAME, hapticsDriver_},
+            {SERIAL_OUT_DRIVER_NAME, serialOut_},
+            {SERIAL_IN_DRIVER_NAME, serialIn_},
+            {HTTP_CLIENT_DRIVER_NAME, httpClient_},
+            {PEER_COMMS_DRIVER_NAME, peerComms_},
+            {PLATFORM_CLOCK_DRIVER_NAME, globalClock_},
+            {LOGGER_DRIVER_NAME, globalLogger_},
+            {STORAGE_DRIVER_NAME, storageDriver_},
+        };
+
+        pdn_ = PDN::createPDN(config);
+        pdn_->begin();
+        pdn_->setActiveComms(SerialIdentifier::OUTPUT_JACK);
+
+        game_ = new ChallengeGame(pdn_, GameType::SIGNAL_ECHO, KonamiButton::START);
+        game_->initialize();
+    }
+
+    void TearDown() override {
+        delete game_;
+        // Note: drivers are owned by DriverManager via PDN, so they're
+        // deleted when PDN is deleted. Don't double-delete globalClock_/globalLogger_.
+        SimpleTimer::setPlatformClock(nullptr);
+        g_logger = nullptr;
+        delete pdn_;
+    }
+
+    // Helper: run N loop cycles
+    void runLoops(int n) {
+        for (int i = 0; i < n; i++) {
+            pdn_->loop();
+            game_->loop();
+        }
+    }
+
+    NativeClockDriver* globalClock_;
+    NativeLoggerDriver* globalLogger_;
+    NativeDisplayDriver* displayDriver_;
+    NativeButtonDriver* primaryButton_;
+    NativeButtonDriver* secondaryButton_;
+    NativeLightStripDriver* lightDriver_;
+    NativeHapticsDriver* hapticsDriver_;
+    NativeSerialDriver* serialOut_;
+    NativeSerialDriver* serialIn_;
+    NativeHttpClientDriver* httpClient_;
+    NativePeerCommsDriver* peerComms_;
+    NativePrefsDriver* storageDriver_;
+    PDN* pdn_;
+    ChallengeGame* game_;
+};
+
+// Test: NpcIdle sends "cdev:" message periodically via serial
+void npcIdleBroadcastsCdev(ChallengeGameTestSuite* suite) {
+    // Game starts in NpcIdle (state 0)
+    State* state = suite->game_->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), NPC_IDLE);
+
+    // Advance clock past broadcast interval (500ms) and run loops
+    suite->globalClock_->advance(600);
+    suite->runLoops(5);
+
+    // Check serial output for "cdev:" message
+    const auto& sentHistory = suite->serialOut_->getSentHistory();
+    bool foundCdev = false;
+    for (const auto& msg : sentHistory) {
+        if (msg.rfind("cdev:", 0) == 0) {
+            foundCdev = true;
+            // Verify format: "cdev:7:6" for Signal Echo
+            ASSERT_EQ(msg, "cdev:7:6");
+            break;
+        }
+    }
+    ASSERT_TRUE(foundCdev) << "NpcIdle should broadcast cdev: messages";
+}
+
+// Test: NpcIdle renders game name + Konami button to display
+void npcIdleDisplaysGameName(ChallengeGameTestSuite* suite) {
+    State* state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), NPC_IDLE);
+
+    // Check display text history for game name
+    const auto& textHistory = suite->displayDriver_->getTextHistory();
+    bool foundGameName = false;
+    for (const auto& text : textHistory) {
+        if (text.find("SIGNAL ECHO") != std::string::npos) {
+            foundGameName = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(foundGameName) << "NpcIdle should display the game name";
+}
+
+// Test: Receiving "smac<MAC>" transitions NpcIdle -> NpcHandshake
+void npcIdleTransitionsOnMac(ChallengeGameTestSuite* suite) {
+    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), NPC_IDLE);
+
+    // Inject a MAC address message via serial
+    suite->serialOut_->injectInput("smac02:00:00:00:00:99");
+
+    suite->runLoops(5);
+
+    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), NPC_HANDSHAKE);
+}
+
+// Test: NpcHandshake sends "cack" via serial
+void npcHandshakeSendsCack(ChallengeGameTestSuite* suite) {
+    // Transition to NpcHandshake first
+    suite->serialOut_->injectInput("smac02:00:00:00:00:99");
+    suite->runLoops(5);
+    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), NPC_HANDSHAKE);
+
+    // Inject MAC again (handshake reads it)
+    suite->serialOut_->injectInput("smac02:00:00:00:00:99");
+    suite->runLoops(5);
+
+    // Check for "cack" in serial output
+    const auto& sentHistory = suite->serialOut_->getSentHistory();
+    bool foundCack = false;
+    for (const auto& msg : sentHistory) {
+        if (msg == "cack") {
+            foundCack = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(foundCack) << "NpcHandshake should send cack after receiving MAC";
+}
+
+// Test: NpcReceiveResult displays "PLAYER WON" or "PLAYER LOST"
+void npcReceiveResultShowsOutcome(ChallengeGameTestSuite* suite) {
+    // Manually set last result and skip to NpcReceiveResult
+    suite->game_->setLastResult(true);
+    suite->game_->setLastScore(300);
+    suite->game_->skipToState(NPC_RECEIVE_RESULT);
+
+    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), NPC_RECEIVE_RESULT);
+
+    const auto& textHistory = suite->displayDriver_->getTextHistory();
+    bool foundWon = false;
+    for (const auto& text : textHistory) {
+        if (text.find("PLAYER WON") != std::string::npos) {
+            foundWon = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(foundWon) << "NpcReceiveResult should display PLAYER WON";
+}
+
+// Test: NpcReceiveResult caches result in NVS
+void npcReceiveResultCachesResult(ChallengeGameTestSuite* suite) {
+    suite->game_->setLastResult(true);
+    suite->game_->setLastScore(500);
+    suite->game_->skipToState(NPC_RECEIVE_RESULT);
+
+    // Check NVS for cached result
+    uint8_t count = suite->storageDriver_->readUChar(NPC_RESULT_COUNT_KEY, 0);
+    ASSERT_GE(count, 1u) << "Result should be cached in NVS";
+
+    std::string result = suite->storageDriver_->read(std::string(NPC_RESULT_KEY) + "0", "");
+    ASSERT_FALSE(result.empty());
+    // Format: "7:1:500" (gameType:won:score)
+    ASSERT_EQ(result, "7:1:500");
+}
+
+// Test: NpcReceiveResult transitions back to NpcIdle after delay
+void npcReceiveResultTransitions(ChallengeGameTestSuite* suite) {
+    suite->game_->setLastResult(false);
+    suite->game_->setLastScore(0);
+    suite->game_->skipToState(NPC_RECEIVE_RESULT);
+
+    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), NPC_RECEIVE_RESULT);
+
+    // Advance time past display duration (3000ms)
+    // SimpleTimer uses the platform clock — advance it
+    suite->globalClock_->advance(3500);
+    suite->runLoops(5);
+
+    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), NPC_IDLE);
+}
+
+// Test: NpcIdle LED animation is active
+void npcLedAnimationPlays(ChallengeGameTestSuite* suite) {
+    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), NPC_IDLE);
+
+    // LightManager should have an active animation
+    ASSERT_TRUE(suite->pdn_->getLightManager()->isAnimating());
+}

--- a/test/test_cli/challenge-protocol-tests.hpp
+++ b/test/test_cli/challenge-protocol-tests.hpp
@@ -1,0 +1,103 @@
+//
+// Challenge Protocol Tests — device-types.hpp parsing and lookup functions
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include "device/device-types.hpp"
+#include "device/device-constants.hpp"
+
+// ============================================
+// CHALLENGE PROTOCOL TEST SUITE
+// ============================================
+
+class ChallengeProtocolTestSuite : public testing::Test {
+public:
+    // No setup needed — all functions under test are stateless
+};
+
+// Test: Parse a valid "cdev:7:6" message
+void protocolParseCdevMessage(ChallengeProtocolTestSuite* /*suite*/) {
+    GameType gameType;
+    KonamiButton reward;
+    bool ok = parseCdevMessage("cdev:7:6", gameType, reward);
+
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(gameType, GameType::SIGNAL_ECHO);
+    ASSERT_EQ(reward, KonamiButton::START);
+}
+
+// Test: Malformed "cdev:" messages return false
+void protocolParseCdevInvalid(ChallengeProtocolTestSuite* /*suite*/) {
+    GameType gameType;
+    KonamiButton reward;
+
+    ASSERT_FALSE(parseCdevMessage("", gameType, reward));
+    ASSERT_FALSE(parseCdevMessage("cdev:", gameType, reward));
+    ASSERT_FALSE(parseCdevMessage("cdev:99:99", gameType, reward));
+    ASSERT_FALSE(parseCdevMessage("heartbeat", gameType, reward));
+    ASSERT_FALSE(parseCdevMessage("cdev:abc:def", gameType, reward));
+}
+
+// Test: Parse a valid "gres:1:850" message
+void protocolParseGresMessage(ChallengeProtocolTestSuite* /*suite*/) {
+    bool won;
+    int score;
+    bool ok = parseGresMessage("gres:1:850", won, score);
+
+    ASSERT_TRUE(ok);
+    ASSERT_TRUE(won);
+    ASSERT_EQ(score, 850);
+
+    ok = parseGresMessage("gres:0:0", won, score);
+    ASSERT_TRUE(ok);
+    ASSERT_FALSE(won);
+    ASSERT_EQ(score, 0);
+}
+
+// Test: Game type lookup functions return correct values
+void protocolGameTypeLookup(ChallengeProtocolTestSuite* /*suite*/) {
+    ASSERT_STREQ(getGameDisplayName(GameType::SIGNAL_ECHO), "SIGNAL ECHO");
+    ASSERT_STREQ(getGameDisplayName(GameType::GHOST_RUNNER), "GHOST RUNNER");
+    ASSERT_STREQ(getGameDisplayName(GameType::QUICKDRAW), "QUICKDRAW");
+
+    ASSERT_EQ(getRewardForGame(GameType::SIGNAL_ECHO), KonamiButton::START);
+    ASSERT_EQ(getRewardForGame(GameType::GHOST_RUNNER), KonamiButton::UP);
+    ASSERT_EQ(getRewardForGame(GameType::BREACH_DEFENSE), KonamiButton::A);
+
+    ASSERT_STREQ(getKonamiButtonName(KonamiButton::START), "START");
+    ASSERT_STREQ(getKonamiButtonName(KonamiButton::UP), "UP");
+}
+
+// Test: isChallengeDeviceCode("7007") returns true
+void magicCodeDetectsChallenge(ChallengeProtocolTestSuite* /*suite*/) {
+    ASSERT_TRUE(isChallengeDeviceCode("7001"));
+    ASSERT_TRUE(isChallengeDeviceCode("7002"));
+    ASSERT_TRUE(isChallengeDeviceCode("7003"));
+    ASSERT_TRUE(isChallengeDeviceCode("7004"));
+    ASSERT_TRUE(isChallengeDeviceCode("7005"));
+    ASSERT_TRUE(isChallengeDeviceCode("7006"));
+    ASSERT_TRUE(isChallengeDeviceCode("7007"));
+}
+
+// Test: isChallengeDeviceCode("0010") returns false
+void magicCodeRejectsPlayer(ChallengeProtocolTestSuite* /*suite*/) {
+    ASSERT_FALSE(isChallengeDeviceCode("0010"));
+    ASSERT_FALSE(isChallengeDeviceCode("9999"));
+    ASSERT_FALSE(isChallengeDeviceCode("8888"));
+    ASSERT_FALSE(isChallengeDeviceCode("1111"));
+    ASSERT_FALSE(isChallengeDeviceCode("6969"));
+    ASSERT_FALSE(isChallengeDeviceCode("7000"));
+    ASSERT_FALSE(isChallengeDeviceCode("7008"));
+    ASSERT_FALSE(isChallengeDeviceCode(""));
+}
+
+// Test: getGameTypeFromCode("7007") returns SIGNAL_ECHO
+void magicCodeMapsToGameType(ChallengeProtocolTestSuite* /*suite*/) {
+    ASSERT_EQ(getGameTypeFromCode("7007"), GameType::SIGNAL_ECHO);
+    ASSERT_EQ(getGameTypeFromCode("7001"), GameType::GHOST_RUNNER);
+    ASSERT_EQ(getGameTypeFromCode("7003"), GameType::FIREWALL_DECRYPT);
+    ASSERT_EQ(getGameTypeFromCode("0010"), GameType::QUICKDRAW);  // Not a challenge code
+    ASSERT_EQ(getGameTypeFromCode("9999"), GameType::QUICKDRAW);  // Not a challenge code
+}

--- a/test/test_cli/cli-automation-tests.hpp
+++ b/test/test_cli/cli-automation-tests.hpp
@@ -1,0 +1,301 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include "cli/cli-event-logger.hpp"
+#include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "device/drivers/native/native-peer-broker.hpp"
+
+// ============================================================
+// EventLogger Test Suite
+// ============================================================
+
+class EventLoggerTestSuite : public testing::Test {
+public:
+    cli::EventLogger logger;
+
+    void SetUp() override {
+        logger.clear();
+    }
+};
+
+// --- EventLogger unit tests ---
+
+void eventLoggerLogAndRetrieve(EventLoggerTestSuite* suite) {
+    cli::Event e;
+    e.timestampMs = 100;
+    e.type = cli::EventType::STATE_CHANGE;
+    e.deviceIndex = 0;
+    e.fromState = "Idle";
+    e.toState = "HandshakeInitiate";
+    suite->logger.log(e);
+
+    ASSERT_EQ(suite->logger.size(), 1u);
+    auto all = suite->logger.getAll();
+    ASSERT_EQ(all[0].fromState, "Idle");
+    ASSERT_EQ(all[0].toState, "HandshakeInitiate");
+}
+
+void eventLoggerFilterByType(EventLoggerTestSuite* suite) {
+    cli::Event e1;
+    e1.type = cli::EventType::SERIAL_TX;
+    e1.deviceIndex = 0;
+    e1.message = "cdev:7:6";
+    suite->logger.log(e1);
+
+    cli::Event e2;
+    e2.type = cli::EventType::SERIAL_RX;
+    e2.deviceIndex = 1;
+    e2.message = "cdev:7:6";
+    suite->logger.log(e2);
+
+    cli::Event e3;
+    e3.type = cli::EventType::SERIAL_TX;
+    e3.deviceIndex = 0;
+    e3.message = "hb";
+    suite->logger.log(e3);
+
+    auto txEvents = suite->logger.getByType(cli::EventType::SERIAL_TX);
+    ASSERT_EQ(txEvents.size(), 2u);
+
+    auto rxEvents = suite->logger.getByType(cli::EventType::SERIAL_RX);
+    ASSERT_EQ(rxEvents.size(), 1u);
+}
+
+void eventLoggerFilterByDevice(EventLoggerTestSuite* suite) {
+    cli::Event e1;
+    e1.type = cli::EventType::DISPLAY_TEXT;
+    e1.deviceIndex = 0;
+    e1.message = "READY";
+    suite->logger.log(e1);
+
+    cli::Event e2;
+    e2.type = cli::EventType::DISPLAY_TEXT;
+    e2.deviceIndex = 1;
+    e2.message = "SIGNAL ECHO";
+    suite->logger.log(e2);
+
+    auto dev0 = suite->logger.getByDevice(0);
+    ASSERT_EQ(dev0.size(), 1u);
+    ASSERT_EQ(dev0[0].message, "READY");
+}
+
+void eventLoggerFilterByTypeAndDevice(EventLoggerTestSuite* suite) {
+    cli::Event e1{0, cli::EventType::SERIAL_TX, 0, "", "", "", "cdev:7:6", ""};
+    cli::Event e2{0, cli::EventType::SERIAL_TX, 1, "", "", "", "hb", ""};
+    cli::Event e3{0, cli::EventType::SERIAL_RX, 0, "", "", "", "cdev:7:6", ""};
+    suite->logger.log(e1);
+    suite->logger.log(e2);
+    suite->logger.log(e3);
+
+    auto result = suite->logger.getByTypeAndDevice(cli::EventType::SERIAL_TX, 0);
+    ASSERT_EQ(result.size(), 1u);
+    ASSERT_EQ(result[0].message, "cdev:7:6");
+}
+
+void eventLoggerGetLast(EventLoggerTestSuite* suite) {
+    cli::Event e1;
+    e1.type = cli::EventType::STATE_CHANGE;
+    e1.deviceIndex = 0;
+    e1.toState = "Idle";
+    suite->logger.log(e1);
+
+    cli::Event e2;
+    e2.type = cli::EventType::STATE_CHANGE;
+    e2.deviceIndex = 0;
+    e2.toState = "HandshakeInitiate";
+    suite->logger.log(e2);
+
+    auto last = suite->logger.getLast(cli::EventType::STATE_CHANGE);
+    ASSERT_EQ(last.toState, "HandshakeInitiate");
+
+    auto lastDev0 = suite->logger.getLast(cli::EventType::STATE_CHANGE, 0);
+    ASSERT_EQ(lastDev0.toState, "HandshakeInitiate");
+}
+
+void eventLoggerHasEvent(EventLoggerTestSuite* suite) {
+    cli::Event e;
+    e.type = cli::EventType::SERIAL_TX;
+    e.deviceIndex = 0;
+    e.message = "cdev:7:6";
+    suite->logger.log(e);
+
+    ASSERT_TRUE(suite->logger.hasEvent(cli::EventType::SERIAL_TX, "cdev:"));
+    ASSERT_FALSE(suite->logger.hasEvent(cli::EventType::SERIAL_TX, "hb"));
+    ASSERT_FALSE(suite->logger.hasEvent(cli::EventType::SERIAL_RX, "cdev:"));
+}
+
+void eventLoggerCount(EventLoggerTestSuite* suite) {
+    for (int i = 0; i < 3; i++) {
+        cli::Event e;
+        e.type = cli::EventType::DISPLAY_TEXT;
+        e.deviceIndex = 0;
+        suite->logger.log(e);
+    }
+    cli::Event e2;
+    e2.type = cli::EventType::DISPLAY_TEXT;
+    e2.deviceIndex = 1;
+    suite->logger.log(e2);
+
+    ASSERT_EQ(suite->logger.count(cli::EventType::DISPLAY_TEXT), 4u);
+    ASSERT_EQ(suite->logger.count(cli::EventType::DISPLAY_TEXT, 0), 3u);
+    ASSERT_EQ(suite->logger.count(cli::EventType::DISPLAY_TEXT, 1), 1u);
+}
+
+void eventLoggerClear(EventLoggerTestSuite* suite) {
+    cli::Event e;
+    e.type = cli::EventType::STATE_CHANGE;
+    suite->logger.log(e);
+    ASSERT_EQ(suite->logger.size(), 1u);
+
+    suite->logger.clear();
+    ASSERT_EQ(suite->logger.size(), 0u);
+}
+
+void eventLoggerFormatEvent(EventLoggerTestSuite* suite) {
+    cli::Event e;
+    e.timestampMs = 33;
+    e.type = cli::EventType::SERIAL_TX;
+    e.deviceIndex = 1;
+    e.message = "cdev:7:6";
+
+    std::string formatted = suite->logger.formatEvent(e);
+    ASSERT_TRUE(formatted.find("0033ms") != std::string::npos);
+    ASSERT_TRUE(formatted.find("SERIAL_TX") != std::string::npos);
+    ASSERT_TRUE(formatted.find("dev=1") != std::string::npos);
+    ASSERT_TRUE(formatted.find("cdev:7:6") != std::string::npos);
+}
+
+void eventLoggerWriteToFile(EventLoggerTestSuite* suite) {
+    cli::Event e;
+    e.timestampMs = 100;
+    e.type = cli::EventType::STATE_CHANGE;
+    e.deviceIndex = 0;
+    e.fromState = "Idle";
+    e.toState = "HandshakeInitiate";
+    suite->logger.log(e);
+
+    std::string path = "/tmp/eventlogger_test_output.txt";
+    ASSERT_TRUE(suite->logger.writeToFile(path));
+
+    // Verify file was created and has content
+    FILE* f = fopen(path.c_str(), "r");
+    ASSERT_NE(f, nullptr);
+    char buf[256];
+    ASSERT_NE(fgets(buf, sizeof(buf), f), nullptr);
+    fclose(f);
+
+    std::string line(buf);
+    ASSERT_TRUE(line.find("STATE_CHANGE") != std::string::npos);
+    ASSERT_TRUE(line.find("Idle") != std::string::npos);
+
+    remove(path.c_str());
+}
+
+// ============================================================
+// Driver Callback Test Suite
+// ============================================================
+
+class DriverCallbackTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        serialDriver = new NativeSerialDriver("test_serial");
+        displayDriver = new NativeDisplayDriver("test_display");
+    }
+
+    void TearDown() override {
+        delete serialDriver;
+        delete displayDriver;
+    }
+
+    NativeSerialDriver* serialDriver = nullptr;
+    NativeDisplayDriver* displayDriver = nullptr;
+};
+
+void serialDriverWriteCallbackFires(DriverCallbackTestSuite* suite) {
+    std::string captured;
+    suite->serialDriver->setWriteCallback([&captured](const std::string& msg) {
+        captured = msg;
+    });
+
+    suite->serialDriver->println("hello");
+    ASSERT_EQ(captured, "hello");
+}
+
+void serialDriverWriteCallbackCharPtr(DriverCallbackTestSuite* suite) {
+    std::string captured;
+    suite->serialDriver->setWriteCallback([&captured](const std::string& msg) {
+        captured = msg;
+    });
+
+    char msg[] = "world";
+    suite->serialDriver->println(msg);
+    ASSERT_EQ(captured, "world");
+}
+
+void serialDriverReadCallbackFires(DriverCallbackTestSuite* suite) {
+    std::string captured;
+    suite->serialDriver->setReadCallback([&captured](const std::string& msg) {
+        captured = msg;
+    });
+
+    suite->serialDriver->injectInput("*test\r");
+    // Read callback gets the cleaned message (framing stripped)
+    ASSERT_EQ(captured, "test");
+}
+
+void serialDriverCallbacksCoexistWithStringCallback(DriverCallbackTestSuite* suite) {
+    std::string writeCapture;
+    std::string readCapture;
+    std::string stringCapture;
+
+    suite->serialDriver->setWriteCallback([&writeCapture](const std::string& msg) {
+        writeCapture = msg;
+    });
+    suite->serialDriver->setReadCallback([&readCapture](const std::string& msg) {
+        readCapture = msg;
+    });
+    suite->serialDriver->setStringCallback([&stringCapture](const std::string& msg) {
+        stringCapture = msg;
+    });
+
+    suite->serialDriver->println("out");
+    suite->serialDriver->injectInput("*in\r");
+
+    ASSERT_EQ(writeCapture, "out");
+    ASSERT_EQ(readCapture, "in");
+    ASSERT_EQ(stringCapture, "in");
+}
+
+void displayDriverTextCallbackFires(DriverCallbackTestSuite* suite) {
+    std::string captured;
+    suite->displayDriver->setTextCallback([&captured](const std::string& text) {
+        captured = text;
+    });
+
+    suite->displayDriver->drawText("HELLO WORLD");
+    ASSERT_EQ(captured, "HELLO WORLD");
+}
+
+void displayDriverTextCallbackPositioned(DriverCallbackTestSuite* suite) {
+    std::string captured;
+    suite->displayDriver->setTextCallback([&captured](const std::string& text) {
+        captured = text;
+    });
+
+    suite->displayDriver->drawText("POSITIONED", 10, 20);
+    ASSERT_EQ(captured, "POSITIONED");
+}
+
+void displayDriverTextCallbackMultipleCalls(DriverCallbackTestSuite* suite) {
+    std::vector<std::string> captured;
+    suite->displayDriver->setTextCallback([&captured](const std::string& text) {
+        captured.push_back(text);
+    });
+
+    suite->displayDriver->drawText("FIRST");
+    suite->displayDriver->drawText("SECOND", 0, 10);
+    ASSERT_EQ(captured.size(), 2u);
+    ASSERT_EQ(captured[0], "FIRST");
+    ASSERT_EQ(captured[1], "SECOND");
+}

--- a/test/test_cli/cli-challenge-tests.hpp
+++ b/test/test_cli/cli-challenge-tests.hpp
@@ -1,0 +1,89 @@
+//
+// CLI Challenge Tests — factory and spawn command
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <set>
+#include "device/drivers/native/native-logger-driver.hpp"
+#include "device/drivers/native/native-clock-driver.hpp"
+#include "cli/cli-device.hpp"
+#include "cli/cli-commands.hpp"
+#include "game/challenge-game.hpp"
+#include "game/challenge-states.hpp"
+#include "utils/simple-timer.hpp"
+
+// ============================================
+// CLI CHALLENGE TEST SUITE
+// ============================================
+
+class CliChallengeTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        globalClock_ = new NativeClockDriver("cli_ch_test_clock");
+        globalLogger_ = new NativeLoggerDriver("cli_ch_test_logger");
+        globalLogger_->setSuppressOutput(true);
+        g_logger = globalLogger_;
+        SimpleTimer::setPlatformClock(globalClock_);
+    }
+
+    void TearDown() override {
+        for (auto& dev : devices_) {
+            cli::DeviceFactory::destroyDevice(dev);
+        }
+        devices_.clear();
+        SimpleTimer::setPlatformClock(nullptr);
+        g_logger = nullptr;
+        delete globalLogger_;
+        delete globalClock_;
+    }
+
+    std::vector<cli::DeviceInstance> devices_;
+    NativeClockDriver* globalClock_;
+    NativeLoggerDriver* globalLogger_;
+};
+
+// Test: createChallengeDevice() produces DeviceInstance with CHALLENGE type
+void cliFactoryCreatesChallenge(CliChallengeTestSuite* suite) {
+    auto device = cli::DeviceFactory::createChallengeDevice(0, GameType::SIGNAL_ECHO);
+    suite->devices_.push_back(device);
+
+    ASSERT_EQ(device.deviceType, DeviceType::CHALLENGE);
+    ASSERT_EQ(device.gameType, GameType::SIGNAL_ECHO);
+    ASSERT_NE(device.game, nullptr);
+    ASSERT_NE(device.pdn, nullptr);
+    ASSERT_EQ(device.player, nullptr);  // NPC has no player
+}
+
+// Test: Created NPC device runs ChallengeGame (not Quickdraw)
+void cliFactoryChallengeHasCorrectGame(CliChallengeTestSuite* suite) {
+    auto device = cli::DeviceFactory::createChallengeDevice(0, GameType::SIGNAL_ECHO);
+    suite->devices_.push_back(device);
+
+    // Verify it starts in NpcIdle (state 0 of ChallengeGame)
+    State* state = device.game->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), NPC_IDLE);
+
+    // Verify we can dynamic_cast to ChallengeGame
+    ChallengeGame* cg = dynamic_cast<ChallengeGame*>(device.game);
+    ASSERT_NE(cg, nullptr);
+    ASSERT_EQ(cg->getGameType(), GameType::SIGNAL_ECHO);
+    ASSERT_EQ(cg->getReward(), KonamiButton::START);
+}
+
+// Test: No two devices in a multi-device test share the same pairing code
+void uniqueCodesInTestFixture(CliChallengeTestSuite* suite) {
+    // Create a mix of player and NPC devices
+    suite->devices_.push_back(cli::DeviceFactory::createDevice(0, true));   // Hunter 0010
+    suite->devices_.push_back(cli::DeviceFactory::createDevice(1, false));  // Bounty 0011
+    suite->devices_.push_back(cli::DeviceFactory::createChallengeDevice(2, GameType::SIGNAL_ECHO));
+
+    std::set<std::string> ids;
+    for (const auto& dev : suite->devices_) {
+        ASSERT_TRUE(ids.insert(dev.deviceId).second)
+            << "Duplicate device ID: " << dev.deviceId;
+    }
+    ASSERT_EQ(ids.size(), 3u);
+}

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -12,6 +12,8 @@
 #include "native-driver-tests.hpp"
 #include "challenge-protocol-tests.hpp"
 #include "challenge-game-tests.hpp"
+#include "cli-challenge-tests.hpp"
+#include "device-mode-switch-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -451,6 +453,50 @@ TEST_F(ChallengeGameTestSuite, NpcReceiveResultTransitions) {
 
 TEST_F(ChallengeGameTestSuite, NpcLedAnimationPlays) {
     npcLedAnimationPlays(this);
+}
+
+// ============================================
+// CLI CHALLENGE FACTORY TESTS
+// ============================================
+
+TEST_F(CliChallengeTestSuite, CliFactoryCreatesChallenge) {
+    cliFactoryCreatesChallenge(this);
+}
+
+TEST_F(CliChallengeTestSuite, CliFactoryChallengeHasCorrectGame) {
+    cliFactoryChallengeHasCorrectGame(this);
+}
+
+TEST_F(CliChallengeTestSuite, UniqueCodesInTestFixture) {
+    uniqueCodesInTestFixture(this);
+}
+
+// ============================================
+// DEVICE MODE SWITCH TESTS
+// ============================================
+
+TEST_F(DeviceModeSwitchTestSuite, NpcModePersistsAcrossReboot) {
+    npcModePersistsAcrossReboot(this);
+}
+
+TEST_F(DeviceModeSwitchTestSuite, ClearedModeFallsBackToQuickdraw) {
+    clearedModeFallsBackToQuickdraw(this);
+}
+
+TEST_F(DeviceModeSwitchTestSuite, SpecialCodesStillWork) {
+    specialCodesStillWork(this);
+}
+
+TEST_F(DeviceModeSwitchTestSuite, NpcToPlayerToNpc) {
+    npcToPlayerToNpc(this);
+}
+
+TEST_F(DeviceModeSwitchTestSuite, PlayerToNpcToPlayer) {
+    playerToNpcToPlayer(this);
+}
+
+TEST_F(DeviceModeSwitchTestSuite, FetchUserDetectsChallengeCode) {
+    fetchUserDetectsChallengeCode(this);
 }
 
 // ============================================

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -19,6 +19,7 @@
 #include "profile-portability-tests.hpp"
 #include "signal-echo-tests.hpp"
 #include "minigame-base-tests.hpp"
+#include "cli-automation-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -778,6 +779,82 @@ TEST_F(ColorProfileTestSuite, ErrorStateIsRed) {
 
 TEST_F(ColorProfileTestSuite, CorrectStateIsGreen) {
     colorProfileCorrectStateIsGreen(this);
+}
+
+// ============================================
+// EVENT LOGGER TESTS
+// ============================================
+
+TEST_F(EventLoggerTestSuite, LogAndRetrieve) {
+    eventLoggerLogAndRetrieve(this);
+}
+
+TEST_F(EventLoggerTestSuite, FilterByType) {
+    eventLoggerFilterByType(this);
+}
+
+TEST_F(EventLoggerTestSuite, FilterByDevice) {
+    eventLoggerFilterByDevice(this);
+}
+
+TEST_F(EventLoggerTestSuite, FilterByTypeAndDevice) {
+    eventLoggerFilterByTypeAndDevice(this);
+}
+
+TEST_F(EventLoggerTestSuite, GetLast) {
+    eventLoggerGetLast(this);
+}
+
+TEST_F(EventLoggerTestSuite, HasEvent) {
+    eventLoggerHasEvent(this);
+}
+
+TEST_F(EventLoggerTestSuite, Count) {
+    eventLoggerCount(this);
+}
+
+TEST_F(EventLoggerTestSuite, Clear) {
+    eventLoggerClear(this);
+}
+
+TEST_F(EventLoggerTestSuite, FormatEvent) {
+    eventLoggerFormatEvent(this);
+}
+
+TEST_F(EventLoggerTestSuite, WriteToFile) {
+    eventLoggerWriteToFile(this);
+}
+
+// ============================================
+// DRIVER CALLBACK TESTS
+// ============================================
+
+TEST_F(DriverCallbackTestSuite, SerialWriteCallbackFires) {
+    serialDriverWriteCallbackFires(this);
+}
+
+TEST_F(DriverCallbackTestSuite, SerialWriteCallbackCharPtr) {
+    serialDriverWriteCallbackCharPtr(this);
+}
+
+TEST_F(DriverCallbackTestSuite, SerialReadCallbackFires) {
+    serialDriverReadCallbackFires(this);
+}
+
+TEST_F(DriverCallbackTestSuite, CallbacksCoexistWithStringCallback) {
+    serialDriverCallbacksCoexistWithStringCallback(this);
+}
+
+TEST_F(DriverCallbackTestSuite, DisplayTextCallbackFires) {
+    displayDriverTextCallbackFires(this);
+}
+
+TEST_F(DriverCallbackTestSuite, DisplayTextCallbackPositioned) {
+    displayDriverTextCallbackPositioned(this);
+}
+
+TEST_F(DriverCallbackTestSuite, DisplayTextCallbackMultipleCalls) {
+    displayDriverTextCallbackMultipleCalls(this);
 }
 
 // ============================================

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -14,6 +14,7 @@
 #include "challenge-game-tests.hpp"
 #include "cli-challenge-tests.hpp"
 #include "device-mode-switch-tests.hpp"
+#include "konami-progress-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -497,6 +498,46 @@ TEST_F(DeviceModeSwitchTestSuite, PlayerToNpcToPlayer) {
 
 TEST_F(DeviceModeSwitchTestSuite, FetchUserDetectsChallengeCode) {
     fetchUserDetectsChallengeCode(this);
+}
+
+// ============================================
+// KONAMI PROGRESS TESTS
+// ============================================
+
+TEST_F(KonamiProgressTestSuite, UnlockSingleButton) {
+    konamiUnlockSingleButton(this);
+}
+
+TEST_F(KonamiProgressTestSuite, UnlockMultipleButtons) {
+    konamiUnlockMultipleButtons(this);
+}
+
+TEST_F(KonamiProgressTestSuite, HasUnlockedButtonTrue) {
+    konamiHasUnlockedButtonTrue(this);
+}
+
+TEST_F(KonamiProgressTestSuite, HasUnlockedButtonFalse) {
+    konamiHasUnlockedButtonFalse(this);
+}
+
+TEST_F(KonamiProgressTestSuite, AllButtonsUnlocked) {
+    konamiAllButtonsUnlocked(this);
+}
+
+TEST_F(KonamiProgressTestSuite, DuplicateUnlockIdempotent) {
+    konamiDuplicateUnlockIdempotent(this);
+}
+
+TEST_F(KonamiProgressTestSuite, ProgressSerializesToJson) {
+    konamiProgressSerializesToJson(this);
+}
+
+TEST_F(KonamiProgressTestSuite, ProgressDeserializesFromJson) {
+    konamiProgressDeserializesFromJson(this);
+}
+
+TEST_F(KonamiProgressTestSuite, ProgressDeserializeMissingField) {
+    konamiProgressDeserializeMissingField(this);
 }
 
 // ============================================

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -16,6 +16,7 @@
 #include "device-mode-switch-tests.hpp"
 #include "konami-progress-tests.hpp"
 #include "profile-sync-tests.hpp"
+#include "profile-portability-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -567,6 +568,38 @@ TEST_F(KonamiProgressTestSuite, ProgressDeserializesFromJson) {
 
 TEST_F(KonamiProgressTestSuite, ProgressDeserializeMissingField) {
     konamiProgressDeserializeMissingField(this);
+}
+
+// ============================================
+// PROFILE PORTABILITY TESTS
+// ============================================
+
+TEST_F(ProfilePortabilityTestSuite, LoginFetchesProfile) {
+    portabilityLoginFetchesProfile(this);
+}
+
+TEST_F(ProfilePortabilityTestSuite, LoginSameDeviceSameProfile) {
+    portabilityLoginSameDeviceSameProfile(this);
+}
+
+TEST_F(ProfilePortabilityTestSuite, LoginDifferentDeviceSameProfile) {
+    portabilityLoginDifferentDeviceSameProfile(this);
+}
+
+TEST_F(ProfilePortabilityTestSuite, LoginNewProfileOnReassignedDevice) {
+    portabilityLoginNewProfileOnReassignedDevice(this);
+}
+
+TEST_F(ProfilePortabilityTestSuite, BoothCheckInOutChain) {
+    portabilityBoothCheckInOutChain(this);
+}
+
+TEST_F(ProfilePortabilityTestSuite, OfflineFallbackToLocalProgress) {
+    portabilityOfflineFallbackToLocalProgress(this);
+}
+
+TEST_F(ProfilePortabilityTestSuite, ProgressSurvivesRestart) {
+    portabilityProgressSurvivesRestart(this);
 }
 
 // ============================================

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -11,6 +11,7 @@
 #include "cli-http-server-tests.hpp"
 #include "native-driver-tests.hpp"
 #include "challenge-protocol-tests.hpp"
+#include "challenge-game-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -414,6 +415,42 @@ TEST_F(ChallengeProtocolTestSuite, MagicCodeRejectsPlayer) {
 
 TEST_F(ChallengeProtocolTestSuite, MagicCodeMapsToGameType) {
     magicCodeMapsToGameType(this);
+}
+
+// ============================================
+// CHALLENGE GAME TESTS
+// ============================================
+
+TEST_F(ChallengeGameTestSuite, NpcIdleBroadcastsCdev) {
+    npcIdleBroadcastsCdev(this);
+}
+
+TEST_F(ChallengeGameTestSuite, NpcIdleDisplaysGameName) {
+    npcIdleDisplaysGameName(this);
+}
+
+TEST_F(ChallengeGameTestSuite, NpcIdleTransitionsOnMac) {
+    npcIdleTransitionsOnMac(this);
+}
+
+TEST_F(ChallengeGameTestSuite, NpcHandshakeSendsCack) {
+    npcHandshakeSendsCack(this);
+}
+
+TEST_F(ChallengeGameTestSuite, NpcReceiveResultShowsOutcome) {
+    npcReceiveResultShowsOutcome(this);
+}
+
+TEST_F(ChallengeGameTestSuite, NpcReceiveResultCachesResult) {
+    npcReceiveResultCachesResult(this);
+}
+
+TEST_F(ChallengeGameTestSuite, NpcReceiveResultTransitions) {
+    npcReceiveResultTransitions(this);
+}
+
+TEST_F(ChallengeGameTestSuite, NpcLedAnimationPlays) {
+    npcLedAnimationPlays(this);
 }
 
 // ============================================

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -21,6 +21,7 @@
 #include "minigame-base-tests.hpp"
 #include "cli-automation-tests.hpp"
 #include "sm-manager-tests.hpp"
+#include "integration-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -968,6 +969,58 @@ TEST_F(ScriptRunnerTestSuite, FeatureB_SignalEchoStandaloneLose) {
 
 TEST_F(ScriptRunnerTestSuite, FeatureE_KonamiProgressTracking) {
     featureE_KonamiProgressTracking(this);
+}
+
+// ============================================
+// INTEGRATION TESTS
+// ============================================
+
+TEST_F(IntegrationTestSuite, CdevTriggersTransition) {
+    integrationCdevTriggersTransition(this);
+}
+
+TEST_F(IntegrationTestSuite, ChallengeDetectedSendsMac) {
+    integrationChallengeDetectedSendsMac(this);
+}
+
+TEST_F(IntegrationTestSuite, SwapsOnCack) {
+    integrationSwapsOnCack(this);
+}
+
+TEST_F(IntegrationTestSuite, TimeoutToIdle) {
+    integrationTimeoutToIdle(this);
+}
+
+TEST_F(IntegrationTestSuite, InvalidCdevToIdle) {
+    integrationInvalidCdevToIdle(this);
+}
+
+TEST_F(IntegrationTestSuite, ChallengeCompleteWinToIdle) {
+    integrationChallengeCompleteWinToIdle(this);
+}
+
+TEST_F(IntegrationTestSuite, ChallengeCompleteUnlocksKonami) {
+    integrationChallengeCompleteUnlocksKonami(this);
+}
+
+TEST_F(IntegrationTestSuite, NoUnlockOnLoss) {
+    integrationNoUnlockOnLoss(this);
+}
+
+TEST_F(IntegrationTestSuite, SavesProgress) {
+    integrationSavesProgress(this);
+}
+
+TEST_F(IntegrationTestSuite, SmManagerWired) {
+    integrationSmManagerWired(this);
+}
+
+TEST_F(IntegrationTestSuite, PlayerPendingChallenge) {
+    integrationPlayerPendingChallenge(this);
+}
+
+TEST_F(IntegrationTestSuite, NormalHandshakeStillWorks) {
+    integrationNormalHandshakeStillWorks(this);
 }
 
 // ============================================

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -740,12 +740,8 @@ TEST_F(SignalEchoDifficultyTestSuite, HardModeWinUnlocksColorProfile) {
     echoDiffHardModeWinUnlocksColorProfile(this);
 }
 
-TEST_F(SignalEchoDifficultyTestSuite, LedFlashesRedOnMistake) {
-    echoDiffLedFlashesRedOnMistake(this);
-}
-
-TEST_F(SignalEchoDifficultyTestSuite, HapticBuzzOnMistake) {
-    echoDiffHapticBuzzOnMistake(this);
+TEST_F(SignalEchoDifficultyTestSuite, MistakeIsRegistered) {
+    echoDiffMistakeIsRegistered(this);
 }
 
 // ============================================

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -858,6 +858,58 @@ TEST_F(DriverCallbackTestSuite, DisplayTextCallbackMultipleCalls) {
 }
 
 // ============================================
+// SCRIPT RUNNER TESTS
+// ============================================
+
+TEST_F(ScriptRunnerTestSuite, ParseSkipsComments) {
+    scriptRunnerParseSkipsComments(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, ExecutesCableCommand) {
+    scriptRunnerExecutesCableCommand(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, WaitAdvancesClock) {
+    scriptRunnerWaitAdvancesClock(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, TickRunsLoops) {
+    scriptRunnerTickRunsLoops(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, PressButton) {
+    scriptRunnerPressButton(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, AssertStatePass) {
+    scriptRunnerAssertStatePass(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, AssertStateFail) {
+    scriptRunnerAssertStateFail(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, AssertTextPass) {
+    scriptRunnerAssertTextPass(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, AssertSerialTx) {
+    scriptRunnerAssertSerialTx(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, AssertNoEvent) {
+    scriptRunnerAssertNoEvent(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, StopsOnFirstError) {
+    scriptRunnerStopsOnFirstError(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, ReportsLineNumber) {
+    scriptRunnerReportsLineNumber(this);
+}
+
+// ============================================
 // MAIN
 // ============================================
 

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -15,6 +15,7 @@
 #include "cli-challenge-tests.hpp"
 #include "device-mode-switch-tests.hpp"
 #include "konami-progress-tests.hpp"
+#include "profile-sync-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -498,6 +499,34 @@ TEST_F(DeviceModeSwitchTestSuite, PlayerToNpcToPlayer) {
 
 TEST_F(DeviceModeSwitchTestSuite, FetchUserDetectsChallengeCode) {
     fetchUserDetectsChallengeCode(this);
+}
+
+// ============================================
+// PROFILE SYNC TESTS
+// ============================================
+
+TEST_F(ProfileSyncTestSuite, ServerReturnsProgress) {
+    profileSyncServerReturnsProgress(this);
+}
+
+TEST_F(ProfileSyncTestSuite, FetchUserDataParsesProgress) {
+    profileSyncFetchUserDataParsesProgress(this);
+}
+
+TEST_F(ProfileSyncTestSuite, FetchUserDataMissingProgress) {
+    profileSyncFetchUserDataMissingProgress(this);
+}
+
+TEST_F(ProfileSyncTestSuite, ProgressSavedToNVS) {
+    profileSyncProgressSavedToNVS(this);
+}
+
+TEST_F(ProfileSyncTestSuite, ProgressLoadedFromNVS) {
+    profileSyncProgressLoadedFromNVS(this);
+}
+
+TEST_F(ProfileSyncTestSuite, ProgressUploadSendsCorrectJson) {
+    profileSyncProgressUploadSendsCorrectJson(this);
 }
 
 // ============================================

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -20,6 +20,7 @@
 #include "signal-echo-tests.hpp"
 #include "minigame-base-tests.hpp"
 #include "cli-automation-tests.hpp"
+#include "sm-manager-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -907,6 +908,42 @@ TEST_F(ScriptRunnerTestSuite, StopsOnFirstError) {
 
 TEST_F(ScriptRunnerTestSuite, ReportsLineNumber) {
     scriptRunnerReportsLineNumber(this);
+}
+
+// ============================================
+// SM MANAGER TESTS
+// ============================================
+
+TEST_F(SmManagerTestSuite, smManagerDefaultLoop) {
+    smManagerDefaultLoop(this);
+}
+
+TEST_F(SmManagerTestSuite, smManagerPauseAndLoad) {
+    smManagerPauseAndLoad(this);
+}
+
+TEST_F(SmManagerTestSuite, smManagerAutoResume) {
+    smManagerAutoResume(this);
+}
+
+TEST_F(SmManagerTestSuite, smManagerOutcomeStored) {
+    smManagerOutcomeStored(this);
+}
+
+TEST_F(SmManagerTestSuite, smManagerResumeToCorrectState) {
+    smManagerResumeToCorrectState(this);
+}
+
+TEST_F(SmManagerTestSuite, smManagerDeletesSwappedGame) {
+    smManagerDeletesSwappedGame(this);
+}
+
+TEST_F(SmManagerTestSuite, smManagerPauseAndLoadWon) {
+    smManagerPauseAndLoadWon(this);
+}
+
+TEST_F(SmManagerTestSuite, smManagerPauseAndLoadLost) {
+    smManagerPauseAndLoadLost(this);
 }
 
 // ============================================

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -910,6 +910,30 @@ TEST_F(ScriptRunnerTestSuite, ReportsLineNumber) {
 }
 
 // ============================================
+// FEATURE A/B/E VALIDATION TESTS
+// ============================================
+
+TEST_F(ScriptRunnerTestSuite, FeatureA_NpcBroadcastsCdev) {
+    featureA_NpcBroadcastsCdev(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, FeatureA_CdevMessageFormat) {
+    featureA_CdevMessageFormat(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, FeatureB_SignalEchoStandaloneWin) {
+    featureB_SignalEchoStandaloneWin(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, FeatureB_SignalEchoStandaloneLose) {
+    featureB_SignalEchoStandaloneLose(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, FeatureE_KonamiProgressTracking) {
+    featureE_KonamiProgressTracking(this);
+}
+
+// ============================================
 // MAIN
 // ============================================
 

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -17,6 +17,8 @@
 #include "konami-progress-tests.hpp"
 #include "profile-sync-tests.hpp"
 #include "profile-portability-tests.hpp"
+#include "signal-echo-tests.hpp"
+#include "minigame-base-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -600,6 +602,186 @@ TEST_F(ProfilePortabilityTestSuite, OfflineFallbackToLocalProgress) {
 
 TEST_F(ProfilePortabilityTestSuite, ProgressSurvivesRestart) {
     portabilityProgressSurvivesRestart(this);
+}
+
+// ============================================
+// MINIGAME BASE CLASS TESTS
+// ============================================
+
+TEST_F(MiniGameTestSuite, MiniGameBaseIdentity) {
+    miniGameBaseIdentity(this);
+}
+
+TEST_F(MiniGameTestSuite, MiniGameBaseOutcomeDefault) {
+    miniGameBaseOutcomeDefault(this);
+}
+
+// ============================================
+// SIGNAL ECHO TESTS
+// ============================================
+
+TEST_F(SignalEchoTestSuite, SequenceGenerationLength) {
+    echoSequenceGenerationLength(this);
+}
+
+TEST_F(SignalEchoTestSuite, SequenceGenerationMixed) {
+    echoSequenceGenerationMixed(this);
+}
+
+TEST_F(SignalEchoTestSuite, IntroTransitionsToShow) {
+    echoIntroTransitionsToShow(this);
+}
+
+TEST_F(SignalEchoTestSuite, ShowSequenceTimingPerSignal) {
+    echoShowSequenceTimingPerSignal(this);
+}
+
+TEST_F(SignalEchoTestSuite, ShowTransitionsToInput) {
+    echoShowTransitionsToInput(this);
+}
+
+TEST_F(SignalEchoTestSuite, CorrectInputAdvancesIndex) {
+    echoCorrectInputAdvancesIndex(this);
+}
+
+TEST_F(SignalEchoTestSuite, WrongInputCountsMistake) {
+    echoWrongInputCountsMistake(this);
+}
+
+TEST_F(SignalEchoTestSuite, AllCorrectInputsNextRound) {
+    echoAllCorrectInputsNextRound(this);
+}
+
+TEST_F(SignalEchoTestSuite, MistakesExhaustedLose) {
+    echoMistakesExhaustedLose(this);
+}
+
+TEST_F(SignalEchoTestSuite, AllRoundsCompletedWin) {
+    echoAllRoundsCompletedWin(this);
+}
+
+TEST_F(SignalEchoTestSuite, CumulativeModeAppends) {
+    echoCumulativeModeAppends(this);
+}
+
+TEST_F(SignalEchoTestSuite, FreshModeNewSequence) {
+    echoFreshModeNewSequence(this);
+}
+
+TEST_F(SignalEchoTestSuite, WinSetsOutcome) {
+    echoWinSetsOutcome(this);
+}
+
+TEST_F(SignalEchoTestSuite, LoseSetsOutcome) {
+    echoLoseSetsOutcome(this);
+}
+
+TEST_F(SignalEchoTestSuite, IsGameCompleteAfterWin) {
+    echoIsGameCompleteAfterWin(this);
+}
+
+TEST_F(SignalEchoTestSuite, ResetGameClearsOutcome) {
+    echoResetGameClearsOutcome(this);
+}
+
+TEST_F(SignalEchoTestSuite, StandaloneRestartAfterWin) {
+    echoStandaloneRestartAfterWin(this);
+}
+
+// ============================================
+// SIGNAL ECHO DIFFICULTY TESTS
+// ============================================
+
+TEST_F(SignalEchoDifficultyTestSuite, EasyModeSequenceLength4) {
+    echoDiffEasyModeSequenceLength4(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, EasyMode3MistakesAllowed) {
+    echoDiffEasyMode3MistakesAllowed(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, HardModeSequenceLength8) {
+    echoDiffHardModeSequenceLength8(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, HardMode1MistakeAllowed) {
+    echoDiffHardMode1MistakeAllowed(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, WrongInputShowsErrorMarker) {
+    echoDiffWrongInputShowsErrorMarker(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, WrongInputAdvancesToNext) {
+    echoDiffWrongInputAdvancesToNext(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, LifeIndicatorStartsFull) {
+    echoDiffLifeIndicatorStartsFull(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, LifeIndicatorDecrementsOnMistake) {
+    echoDiffLifeIndicatorDecrementsOnMistake(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, LifeIndicatorCorrectCount) {
+    echoDiffLifeIndicatorCorrectCount(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, FullResetOnLose) {
+    echoDiffFullResetOnLose(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, EasyModeWinUnlocksKonami) {
+    echoDiffEasyModeWinUnlocksKonami(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, HardModeWinUnlocksColorProfile) {
+    echoDiffHardModeWinUnlocksColorProfile(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, LedFlashesRedOnMistake) {
+    echoDiffLedFlashesRedOnMistake(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, HapticBuzzOnMistake) {
+    echoDiffHapticBuzzOnMistake(this);
+}
+
+// ============================================
+// COLOR PROFILE TESTS
+// ============================================
+
+TEST_F(ColorProfileTestSuite, SignalEchoPaletteValues) {
+    colorProfileSignalEchoPaletteValues(this);
+}
+
+TEST_F(ColorProfileTestSuite, IdlePaletteSize) {
+    colorProfileIdlePaletteSize(this);
+}
+
+TEST_F(ColorProfileTestSuite, DefaultPaletteValues) {
+    colorProfileDefaultPaletteValues(this);
+}
+
+TEST_F(ColorProfileTestSuite, IdleStateHasBrightness) {
+    colorProfileIdleStateHasBrightness(this);
+}
+
+TEST_F(ColorProfileTestSuite, WinStateIsRainbow) {
+    colorProfileWinStateIsRainbow(this);
+}
+
+TEST_F(ColorProfileTestSuite, LoseStateIsRed) {
+    colorProfileLoseStateIsRed(this);
+}
+
+TEST_F(ColorProfileTestSuite, ErrorStateIsRed) {
+    colorProfileErrorStateIsRed(this);
+}
+
+TEST_F(ColorProfileTestSuite, CorrectStateIsGreen) {
+    colorProfileCorrectStateIsGreen(this);
 }
 
 // ============================================

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -10,6 +10,7 @@
 #include "cli-broker-tests.hpp"
 #include "cli-http-server-tests.hpp"
 #include "native-driver-tests.hpp"
+#include "challenge-protocol-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -381,6 +382,38 @@ TEST_F(CliCommandTestSuite, RebootFromLaterState) {
 
 TEST_F(CliCommandTestSuite, RebootClearsHistory) {
     cliCommandRebootClearsHistory(this);
+}
+
+// ============================================
+// CHALLENGE PROTOCOL TESTS
+// ============================================
+
+TEST_F(ChallengeProtocolTestSuite, ProtocolParseCdevMessage) {
+    protocolParseCdevMessage(this);
+}
+
+TEST_F(ChallengeProtocolTestSuite, ProtocolParseCdevInvalid) {
+    protocolParseCdevInvalid(this);
+}
+
+TEST_F(ChallengeProtocolTestSuite, ProtocolParseGresMessage) {
+    protocolParseGresMessage(this);
+}
+
+TEST_F(ChallengeProtocolTestSuite, ProtocolGameTypeLookup) {
+    protocolGameTypeLookup(this);
+}
+
+TEST_F(ChallengeProtocolTestSuite, MagicCodeDetectsChallenge) {
+    magicCodeDetectsChallenge(this);
+}
+
+TEST_F(ChallengeProtocolTestSuite, MagicCodeRejectsPlayer) {
+    magicCodeRejectsPlayer(this);
+}
+
+TEST_F(ChallengeProtocolTestSuite, MagicCodeMapsToGameType) {
+    magicCodeMapsToGameType(this);
 }
 
 // ============================================

--- a/test/test_cli/device-mode-switch-tests.hpp
+++ b/test/test_cli/device-mode-switch-tests.hpp
@@ -1,0 +1,256 @@
+//
+// Device Mode Switch Tests — NVS-based player/NPC mode switching
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include "device/drivers/native/native-logger-driver.hpp"
+#include "device/drivers/native/native-clock-driver.hpp"
+#include "device/drivers/native/native-display-driver.hpp"
+#include "device/drivers/native/native-button-driver.hpp"
+#include "device/drivers/native/native-light-strip-driver.hpp"
+#include "device/drivers/native/native-haptics-driver.hpp"
+#include "device/drivers/native/native-serial-driver.hpp"
+#include "device/drivers/native/native-http-client-driver.hpp"
+#include "device/drivers/native/native-peer-comms-driver.hpp"
+#include "device/drivers/native/native-prefs-driver.hpp"
+#include "device/pdn.hpp"
+#include "game/quickdraw.hpp"
+#include "game/challenge-game.hpp"
+#include "game/challenge-states.hpp"
+#include "game/quickdraw-states.hpp"
+#include "device/device-types.hpp"
+#include "device/device-constants.hpp"
+#include "utils/simple-timer.hpp"
+#include "wireless/quickdraw-wireless-manager.hpp"
+
+// ============================================
+// DEVICE MODE SWITCH TEST SUITE
+// ============================================
+
+class DeviceModeSwitchTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        globalClock_ = new NativeClockDriver("dms_test_clock");
+        globalLogger_ = new NativeLoggerDriver("dms_test_logger");
+        globalLogger_->setSuppressOutput(true);
+        g_logger = globalLogger_;
+        SimpleTimer::setPlatformClock(globalClock_);
+
+        // Create drivers (shared across "reboots")
+        std::string suffix = "_dms_test";
+        displayDriver_ = new NativeDisplayDriver(DISPLAY_DRIVER_NAME + suffix);
+        primaryButton_ = new NativeButtonDriver(PRIMARY_BUTTON_DRIVER_NAME + suffix, 0);
+        secondaryButton_ = new NativeButtonDriver(SECONDARY_BUTTON_DRIVER_NAME + suffix, 1);
+        lightDriver_ = new NativeLightStripDriver(LIGHT_DRIVER_NAME + suffix);
+        hapticsDriver_ = new NativeHapticsDriver(HAPTICS_DRIVER_NAME + suffix, 0);
+        serialOut_ = new NativeSerialDriver(SERIAL_OUT_DRIVER_NAME + suffix);
+        serialIn_ = new NativeSerialDriver(SERIAL_IN_DRIVER_NAME + suffix);
+        httpClient_ = new NativeHttpClientDriver(HTTP_CLIENT_DRIVER_NAME + suffix);
+        httpClient_->setMockServerEnabled(true);
+        httpClient_->setConnected(true);
+        peerComms_ = new NativePeerCommsDriver(PEER_COMMS_DRIVER_NAME + suffix);
+        storage_ = new NativePrefsDriver(STORAGE_DRIVER_NAME + suffix);
+
+        buildPDN();
+
+        // Start as player (Quickdraw)
+        player_ = new Player();
+        player_->setUserID("0010");
+        player_->setIsHunter(true);
+        qwm_ = new QuickdrawWirelessManager();
+        qwm_->initialize(player_, pdn_->getWirelessManager(), 1000);
+
+        game_ = new Quickdraw(player_, pdn_, qwm_, nullptr);
+        game_->initialize();
+    }
+
+    void TearDown() override {
+        delete game_;
+        if (qwm_) delete qwm_;
+        if (player_) delete player_;
+        // Note: drivers are owned by DriverManager via PDN
+        SimpleTimer::setPlatformClock(nullptr);
+        g_logger = nullptr;
+        delete pdn_;
+    }
+
+    void buildPDN() {
+        DriverConfig config = {
+            {DISPLAY_DRIVER_NAME, displayDriver_},
+            {PRIMARY_BUTTON_DRIVER_NAME, primaryButton_},
+            {SECONDARY_BUTTON_DRIVER_NAME, secondaryButton_},
+            {LIGHT_DRIVER_NAME, lightDriver_},
+            {HAPTICS_DRIVER_NAME, hapticsDriver_},
+            {SERIAL_OUT_DRIVER_NAME, serialOut_},
+            {SERIAL_IN_DRIVER_NAME, serialIn_},
+            {HTTP_CLIENT_DRIVER_NAME, httpClient_},
+            {PEER_COMMS_DRIVER_NAME, peerComms_},
+            {PLATFORM_CLOCK_DRIVER_NAME, globalClock_},
+            {LOGGER_DRIVER_NAME, globalLogger_},
+            {STORAGE_DRIVER_NAME, storage_},
+        };
+        pdn_ = PDN::createPDN(config);
+        pdn_->begin();
+    }
+
+    /*
+     * Simulate entering a magic code and "rebooting":
+     * 1. Write code to NVS
+     * 2. Destroy current game (and player/qwm if switching to NPC)
+     * 3. Check NVS and create appropriate StateMachine
+     * 4. Initialize
+     */
+    void enterCodeAndReboot(const std::string& code) {
+        storage_->write(DEVICE_MODE_KEY, code);
+
+        delete game_;
+        game_ = nullptr;
+
+        if (isChallengeDeviceCode(code)) {
+            // Switching to NPC mode — no player needed
+            if (qwm_) { delete qwm_; qwm_ = nullptr; }
+            if (player_) { delete player_; player_ = nullptr; }
+
+            GameType gt = getGameTypeFromCode(code);
+            game_ = new ChallengeGame(pdn_, gt, getRewardForGame(gt));
+        } else {
+            // Switching to player mode
+            if (!player_) {
+                player_ = new Player();
+                player_->setUserID("0010");
+                player_->setIsHunter(true);
+            }
+            if (!qwm_) {
+                qwm_ = new QuickdrawWirelessManager();
+                qwm_->initialize(player_, pdn_->getWirelessManager(), 1000);
+            }
+            game_ = new Quickdraw(player_, pdn_, qwm_, nullptr);
+        }
+        game_->initialize();
+    }
+
+    /*
+     * Clear NVS mode and "reboot" back to Quickdraw.
+     */
+    void clearModeAndReboot() {
+        storage_->remove(DEVICE_MODE_KEY);
+        enterCodeAndReboot("");  // Empty code = Quickdraw
+    }
+
+    bool isRunningQuickdraw() {
+        return dynamic_cast<Quickdraw*>(game_) != nullptr;
+    }
+
+    bool isRunningChallengeGame(GameType expectedType) {
+        ChallengeGame* cg = dynamic_cast<ChallengeGame*>(game_);
+        if (!cg) return false;
+        return cg->getGameType() == expectedType;
+    }
+
+    NativeClockDriver* globalClock_;
+    NativeLoggerDriver* globalLogger_;
+    NativeDisplayDriver* displayDriver_;
+    NativeButtonDriver* primaryButton_;
+    NativeButtonDriver* secondaryButton_;
+    NativeLightStripDriver* lightDriver_;
+    NativeHapticsDriver* hapticsDriver_;
+    NativeSerialDriver* serialOut_;
+    NativeSerialDriver* serialIn_;
+    NativeHttpClientDriver* httpClient_;
+    NativePeerCommsDriver* peerComms_;
+    NativePrefsDriver* storage_;
+    PDN* pdn_;
+    Player* player_;
+    QuickdrawWirelessManager* qwm_;
+    StateMachine* game_;
+};
+
+// Test: NPC mode persists — write "7007" to NVS, create device, verify ChallengeGame
+void npcModePersistsAcrossReboot(DeviceModeSwitchTestSuite* suite) {
+    ASSERT_TRUE(suite->isRunningQuickdraw());
+
+    suite->enterCodeAndReboot("7007");
+    ASSERT_TRUE(suite->isRunningChallengeGame(GameType::SIGNAL_ECHO));
+
+    // Verify state is NpcIdle
+    State* state = suite->game_->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), NPC_IDLE);
+}
+
+// Test: Cleared mode falls back to Quickdraw
+void clearedModeFallsBackToQuickdraw(DeviceModeSwitchTestSuite* suite) {
+    // Start as NPC
+    suite->enterCodeAndReboot("7007");
+    ASSERT_TRUE(suite->isRunningChallengeGame(GameType::SIGNAL_ECHO));
+
+    // Clear and reboot
+    suite->clearModeAndReboot();
+    ASSERT_TRUE(suite->isRunningQuickdraw());
+}
+
+// Test: Special codes (9999, 8888, etc.) still work alongside 7xxx range
+void specialCodesStillWork(DeviceModeSwitchTestSuite* suite) {
+    // These should NOT be treated as challenge codes
+    ASSERT_FALSE(isChallengeDeviceCode("9999"));
+    ASSERT_FALSE(isChallengeDeviceCode("8888"));
+    ASSERT_FALSE(isChallengeDeviceCode("1111"));
+    ASSERT_FALSE(isChallengeDeviceCode("6969"));
+
+    // The existing special code behavior is tested elsewhere;
+    // here we just verify they don't accidentally trigger NPC mode
+    ASSERT_EQ(getGameTypeFromCode("9999"), GameType::QUICKDRAW);
+}
+
+// Test: Full cycle NPC -> clear -> player -> enter 7003 -> NPC (different game)
+void npcToPlayerToNpc(DeviceModeSwitchTestSuite* suite) {
+    // Start as Signal Echo NPC
+    suite->enterCodeAndReboot("7007");
+    ASSERT_TRUE(suite->isRunningChallengeGame(GameType::SIGNAL_ECHO));
+
+    // Clear and become player
+    suite->clearModeAndReboot();
+    ASSERT_TRUE(suite->isRunningQuickdraw());
+
+    // Enter different NPC code
+    suite->enterCodeAndReboot("7003");
+    ASSERT_TRUE(suite->isRunningChallengeGame(GameType::FIREWALL_DECRYPT));
+}
+
+// Test: Full cycle player -> enter 7007 -> NPC -> clear -> player
+void playerToNpcToPlayer(DeviceModeSwitchTestSuite* suite) {
+    ASSERT_TRUE(suite->isRunningQuickdraw());
+
+    suite->enterCodeAndReboot("7007");
+    ASSERT_TRUE(suite->isRunningChallengeGame(GameType::SIGNAL_ECHO));
+
+    suite->clearModeAndReboot();
+    ASSERT_TRUE(suite->isRunningQuickdraw());
+}
+
+// Test: FetchUserData detects challenge code and writes to NVS
+void fetchUserDetectsChallengeCode(DeviceModeSwitchTestSuite* suite) {
+    // This test verifies the NVS write path in FetchUserDataState.
+    // Set the player ID to a challenge code, then run FetchUserData.
+    ASSERT_TRUE(suite->isRunningQuickdraw());
+
+    suite->player_->setUserID("7007");
+
+    // Configure mock server to NOT have this ID (it's a magic code, not a real player)
+    // The FetchUserDataState should detect the challenge code BEFORE making an HTTP request
+
+    // Skip to FetchUserData (state index 1)
+    suite->game_->skipToState(1);
+
+    // Run a few loops
+    for (int i = 0; i < 10; i++) {
+        suite->pdn_->loop();
+        suite->game_->loop();
+    }
+
+    // Check that the NVS was written with the challenge code
+    std::string mode = suite->storage_->read(DEVICE_MODE_KEY, "");
+    ASSERT_EQ(mode, "7007");
+}

--- a/test/test_cli/integration-tests.hpp
+++ b/test/test_cli/integration-tests.hpp
@@ -1,0 +1,331 @@
+//
+// Integration Tests -- ChallengeDetected + ChallengeComplete states + SM Manager wiring
+//
+
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "state/state-machine-manager.hpp"
+#include "game/progress-manager.hpp"
+#include "device/device-types.hpp"
+#include "device/drivers/native/native-peer-broker.hpp"
+#include "game/test-minigame.hpp"
+
+// ============================================
+// INTEGRATION TEST SUITE
+// ============================================
+
+class IntegrationTestSuite : public testing::Test {
+public:
+    cli::DeviceInstance player_;
+    NativeClockDriver* globalClock_ = nullptr;
+    NativeLoggerDriver* globalLogger_ = nullptr;
+
+    void SetUp() override {
+        // Set up global clock and logger (required for SimpleTimer)
+        globalClock_ = new NativeClockDriver("integration_test_clock");
+        globalLogger_ = new NativeLoggerDriver("integration_test_logger");
+        globalLogger_->setSuppressOutput(true);
+        g_logger = globalLogger_;
+        SimpleTimer::setPlatformClock(globalClock_);
+
+        // Create player (hunter)
+        player_ = cli::DeviceFactory::createDevice(0, true);
+
+        // Run initial loops to get devices past setup states
+        for (int i = 0; i < 5; i++) {
+            player_.pdn->loop();
+            if (player_.smManager) {
+                player_.smManager->loop();
+            } else {
+                player_.game->loop();
+            }
+        }
+
+        // Skip player to Idle (stateMap index 7)
+        player_.game->skipToState(7);
+    }
+
+    void TearDown() override {
+        cli::SerialCableBroker::getInstance().disconnectDevice(0);
+        cli::DeviceFactory::destroyDevice(player_);
+        SimpleTimer::setPlatformClock(nullptr);
+        g_logger = nullptr;
+        delete globalLogger_;
+        delete globalClock_;
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            NativePeerBroker::getInstance().deliverPackets();
+            cli::SerialCableBroker::getInstance().transferData();
+            player_.pdn->loop();
+            if (player_.smManager) {
+                player_.smManager->loop();
+            } else {
+                player_.game->loop();
+            }
+        }
+    }
+
+    void advance(int ms) {
+        globalClock_->advance(ms);
+        tick();
+    }
+};
+
+// Test: ChallengeDetected transitions from Idle when cdev message arrives
+void integrationCdevTriggersTransition(IntegrationTestSuite* suite) {
+    // Verify we start in Idle (stateId = IDLE = 8)
+    State* state = suite->player_.game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), IDLE);
+
+    // Inject a cdev message via serial input (simulates NPC broadcast)
+    suite->player_.serialOutDriver->injectInput("*cdev:7:6\r");
+    suite->tick(3);
+
+    // Player should now be in ChallengeDetected (stateId 21)
+    state = suite->player_.game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), CHALLENGE_DETECTED)
+        << "Player should transition to ChallengeDetected after cdev received";
+}
+
+// Test: ChallengeDetected sends MAC address to NPC
+void integrationChallengeDetectedSendsMac(IntegrationTestSuite* suite) {
+    // Inject cdev message
+    suite->player_.serialOutDriver->injectInput("*cdev:7:6\r");
+    suite->tick(3);
+
+    // Verify ChallengeDetected is active
+    State* state = suite->player_.game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), CHALLENGE_DETECTED);
+
+    // Check that a MAC address message was sent via serial output
+    auto& history = suite->player_.serialOutDriver->getSentHistory();
+    bool macSent = false;
+    for (const auto& msg : history) {
+        if (msg.find("smac") != std::string::npos) {
+            macSent = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(macSent) << "ChallengeDetected should send MAC address via serial";
+}
+
+// Test: ChallengeDetected receives cack and loads minigame via SM Manager
+void integrationSwapsOnCack(IntegrationTestSuite* suite) {
+    // Inject cdev message
+    suite->player_.serialOutDriver->injectInput("*cdev:7:6\r");
+    suite->tick(3);
+
+    // Verify in ChallengeDetected
+    State* state = suite->player_.game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), CHALLENGE_DETECTED);
+
+    // Inject cack from NPC
+    suite->player_.serialOutDriver->injectInput("*cack\r");
+    suite->tick(3);
+
+    // After cack, the SM Manager should be swapped to the minigame
+    ASSERT_TRUE(suite->player_.smManager->isSwapped())
+        << "SM Manager should be swapped to minigame after cack";
+}
+
+// Test: Timeout returns to Idle when no cack received
+void integrationTimeoutToIdle(IntegrationTestSuite* suite) {
+    // Inject cdev message to trigger ChallengeDetected
+    suite->player_.serialOutDriver->injectInput("*cdev:7:6\r");
+    suite->tick(3);
+
+    // Verify in ChallengeDetected
+    State* state = suite->player_.game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), CHALLENGE_DETECTED);
+
+    // Advance past timeout (10 seconds) — need multiple ticks for
+    // timer update + transition check + commit cycle
+    suite->globalClock_->advance(11000);
+    suite->tick(5);
+
+    // Should be back in Idle
+    state = suite->player_.game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), IDLE)
+        << "Player should return to Idle after ChallengeDetected timeout";
+}
+
+// Test: Invalid cdev message causes immediate transition back to Idle
+void integrationInvalidCdevToIdle(IntegrationTestSuite* suite) {
+    // Inject an invalid cdev message (missing reward field)
+    suite->player_.serialOutDriver->injectInput("*cdev:bad\r");
+    suite->tick(3);
+
+    // Should transition to ChallengeDetected first, then back to Idle
+    // because the parse fails and sets transitionToIdleState = true
+    State* state = suite->player_.game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), IDLE)
+        << "Invalid cdev message should result in return to Idle";
+}
+
+// Test: ChallengeComplete shows win result and transitions to Idle
+void integrationChallengeCompleteWinToIdle(IntegrationTestSuite* suite) {
+    #ifdef UNIT_TEST
+    // Use TestMiniGame to simulate a completed minigame
+    auto* miniGame = new TestMiniGame(suite->player_.pdn, MiniGameResult::WON);
+    // Resume to ChallengeComplete (stateMap index 22)
+    suite->player_.smManager->pauseAndLoad(miniGame, 22);
+
+    // Trigger the test minigame to complete
+    miniGame->triggerComplete();
+
+    // Loop until SM Manager auto-resumes to ChallengeComplete
+    for (int i = 0; i < 5; i++) {
+        suite->player_.smManager->loop();
+        if (!suite->player_.smManager->isSwapped()) break;
+    }
+
+    // Should be in ChallengeComplete now (stateId 22)
+    State* state = suite->player_.game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), CHALLENGE_COMPLETE)
+        << "Should be in ChallengeComplete after minigame win";
+
+    // Advance past display timer (3 seconds) — need multiple ticks for
+    // timer update + transition check + commit cycle
+    suite->globalClock_->advance(4000);
+    suite->tick(5);
+
+    // Should transition to Idle
+    state = suite->player_.game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), IDLE)
+        << "Should return to Idle after ChallengeComplete display";
+    #endif
+}
+
+// Test: ChallengeComplete unlocks Konami button on win
+void integrationChallengeCompleteUnlocksKonami(IntegrationTestSuite* suite) {
+    #ifdef UNIT_TEST
+    // Verify player has no Konami progress initially
+    ASSERT_EQ(suite->player_.player->getKonamiProgress(), 0);
+
+    auto* miniGame = new TestMiniGame(suite->player_.pdn, MiniGameResult::WON);
+    suite->player_.smManager->pauseAndLoad(miniGame, 22);
+    miniGame->triggerComplete();
+
+    for (int i = 0; i < 5; i++) {
+        suite->player_.smManager->loop();
+        if (!suite->player_.smManager->isSwapped()) break;
+    }
+
+    // ChallengeComplete should have unlocked the Konami button for SIGNAL_ECHO
+    KonamiButton reward = getRewardForGame(GameType::SIGNAL_ECHO);
+    ASSERT_TRUE(suite->player_.player->hasUnlockedButton(reward))
+        << "Signal Echo reward button should be unlocked after win";
+    #endif
+}
+
+// Test: ChallengeComplete does NOT unlock Konami on loss
+void integrationNoUnlockOnLoss(IntegrationTestSuite* suite) {
+    #ifdef UNIT_TEST
+    ASSERT_EQ(suite->player_.player->getKonamiProgress(), 0);
+
+    auto* miniGame = new TestMiniGame(suite->player_.pdn, MiniGameResult::LOST);
+    suite->player_.smManager->pauseAndLoad(miniGame, 22);
+    miniGame->triggerComplete();
+
+    for (int i = 0; i < 5; i++) {
+        suite->player_.smManager->loop();
+        if (!suite->player_.smManager->isSwapped()) break;
+    }
+
+    // ChallengeComplete should process loss
+    State* state = suite->player_.game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), CHALLENGE_COMPLETE);
+
+    // Advance past display
+    suite->advance(4000);
+    suite->tick(3);
+
+    // Verify NO Konami unlock
+    ASSERT_EQ(suite->player_.player->getKonamiProgress(), 0)
+        << "No Konami buttons should be unlocked on loss";
+    #endif
+}
+
+// Test: Progress is saved to NVS after a win
+void integrationSavesProgress(IntegrationTestSuite* suite) {
+    #ifdef UNIT_TEST
+    auto* miniGame = new TestMiniGame(suite->player_.pdn, MiniGameResult::WON);
+    suite->player_.smManager->pauseAndLoad(miniGame, 22);
+    miniGame->triggerComplete();
+
+    for (int i = 0; i < 5; i++) {
+        suite->player_.smManager->loop();
+        if (!suite->player_.smManager->isSwapped()) break;
+    }
+
+    // Wait for ChallengeComplete to process and transition to Idle
+    suite->globalClock_->advance(4000);
+    suite->tick(5);
+
+    // Verify progress was saved to storage
+    KonamiButton reward = getRewardForGame(GameType::SIGNAL_ECHO);
+    ASSERT_TRUE(suite->player_.player->hasUnlockedButton(reward));
+
+    // The progress manager should have saved to NVS (uses writeUChar)
+    uint8_t storedProgress = suite->player_.storageDriver->readUChar("konami", 0);
+    uint8_t expectedBit = static_cast<uint8_t>(1 << static_cast<uint8_t>(reward));
+    ASSERT_TRUE((storedProgress & expectedBit) != 0)
+        << "Konami progress should be saved to storage";
+    #endif
+}
+
+// Test: SM Manager wiring is correct for player devices
+void integrationSmManagerWired(IntegrationTestSuite* suite) {
+    ASSERT_NE(suite->player_.smManager, nullptr)
+        << "SM Manager should be created for player devices";
+    ASSERT_FALSE(suite->player_.smManager->isSwapped())
+        << "SM Manager should not be swapped initially";
+    ASSERT_EQ(suite->player_.smManager->getActive(), suite->player_.game)
+        << "SM Manager should delegate to Quickdraw by default";
+}
+
+// Test: Player pending challenge fields work correctly
+void integrationPlayerPendingChallenge(IntegrationTestSuite* suite) {
+    ASSERT_FALSE(suite->player_.player->hasPendingChallenge());
+
+    suite->player_.player->setPendingChallenge("cdev:7:6");
+    ASSERT_TRUE(suite->player_.player->hasPendingChallenge());
+    ASSERT_EQ(suite->player_.player->getPendingCdevMessage(), "cdev:7:6");
+
+    suite->player_.player->clearPendingChallenge();
+    ASSERT_FALSE(suite->player_.player->hasPendingChallenge());
+    ASSERT_TRUE(suite->player_.player->getPendingCdevMessage().empty());
+}
+
+// Test: Normal handshake (heartbeat) still works when no cdev detected
+void integrationNormalHandshakeStillWorks(IntegrationTestSuite* suite) {
+    // Verify we start in Idle
+    State* state = suite->player_.game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), IDLE);
+
+    // Inject a normal heartbeat message (from another player device)
+    suite->player_.serialOutDriver->injectInput("*hb\r");
+    suite->tick(3);
+
+    // Should have left Idle and entered the handshake flow.
+    // With multiple ticks, the device may progress past HandshakeInitiate
+    // into later handshake states (e.g., HunterSendId = 11)
+    state = suite->player_.game->getCurrentState();
+    int stateId = state->getStateId();
+    ASSERT_NE(stateId, IDLE)
+        << "Normal heartbeat should trigger transition out of Idle";
+    ASSERT_GE(stateId, HANDSHAKE_INITIATE_STATE)
+        << "Should be in handshake flow (stateId >= 9)";
+    ASSERT_LE(stateId, HUNTER_SEND_ID_STATE)
+        << "Should be in handshake flow (stateId <= 11)";
+}
+
+#endif // NATIVE_BUILD

--- a/test/test_cli/konami-progress-tests.hpp
+++ b/test/test_cli/konami-progress-tests.hpp
@@ -1,0 +1,148 @@
+//
+// Konami Progress Tests — Player bitmask operations and serialization
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include "game/player.hpp"
+#include "device/device-types.hpp"
+#include <ArduinoJson.h>
+
+// ============================================
+// KONAMI PROGRESS TEST SUITE
+// ============================================
+
+class KonamiProgressTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        player_ = new Player("0010", Allegiance::RESISTANCE, true);
+    }
+
+    void TearDown() override {
+        delete player_;
+    }
+
+    Player* player_;
+};
+
+// Test: Unlocking a single button sets the correct bit
+void konamiUnlockSingleButton(KonamiProgressTestSuite* suite) {
+    suite->player_->unlockKonamiButton(KonamiButton::START);
+
+    // START = bit 6 = 0b01000000 = 64
+    ASSERT_EQ(suite->player_->getKonamiProgress(), 64);
+    ASSERT_TRUE(suite->player_->hasUnlockedButton(KonamiButton::START));
+}
+
+// Test: Unlocking multiple buttons produces correct composite bitmask
+void konamiUnlockMultipleButtons(KonamiProgressTestSuite* suite) {
+    suite->player_->unlockKonamiButton(KonamiButton::UP);     // bit 0
+    suite->player_->unlockKonamiButton(KonamiButton::DOWN);   // bit 1
+    suite->player_->unlockKonamiButton(KonamiButton::START);  // bit 6
+
+    // 0b01000011 = 67
+    ASSERT_EQ(suite->player_->getKonamiProgress(), 67);
+    ASSERT_EQ(suite->player_->getUnlockedButtonCount(), 3);
+}
+
+// Test: hasUnlockedButton returns true for unlocked buttons
+void konamiHasUnlockedButtonTrue(KonamiProgressTestSuite* suite) {
+    suite->player_->unlockKonamiButton(KonamiButton::LEFT);   // bit 2
+    suite->player_->unlockKonamiButton(KonamiButton::A);      // bit 5
+
+    ASSERT_TRUE(suite->player_->hasUnlockedButton(KonamiButton::LEFT));
+    ASSERT_TRUE(suite->player_->hasUnlockedButton(KonamiButton::A));
+}
+
+// Test: hasUnlockedButton returns false for locked buttons
+void konamiHasUnlockedButtonFalse(KonamiProgressTestSuite* suite) {
+    suite->player_->unlockKonamiButton(KonamiButton::UP);
+
+    ASSERT_FALSE(suite->player_->hasUnlockedButton(KonamiButton::DOWN));
+    ASSERT_FALSE(suite->player_->hasUnlockedButton(KonamiButton::START));
+    ASSERT_FALSE(suite->player_->hasUnlockedButton(KonamiButton::B));
+}
+
+// Test: Unlocking all 7 buttons triggers hasAllKonamiButtons
+void konamiAllButtonsUnlocked(KonamiProgressTestSuite* suite) {
+    ASSERT_FALSE(suite->player_->hasAllKonamiButtons());
+
+    suite->player_->unlockKonamiButton(KonamiButton::UP);
+    suite->player_->unlockKonamiButton(KonamiButton::DOWN);
+    suite->player_->unlockKonamiButton(KonamiButton::LEFT);
+    suite->player_->unlockKonamiButton(KonamiButton::RIGHT);
+    suite->player_->unlockKonamiButton(KonamiButton::B);
+    suite->player_->unlockKonamiButton(KonamiButton::A);
+    suite->player_->unlockKonamiButton(KonamiButton::START);
+
+    ASSERT_TRUE(suite->player_->hasAllKonamiButtons());
+    ASSERT_EQ(suite->player_->getKonamiProgress(), KONAMI_ALL_UNLOCKED);
+    ASSERT_EQ(suite->player_->getUnlockedButtonCount(), 7);
+}
+
+// Test: Unlocking the same button twice is idempotent
+void konamiDuplicateUnlockIdempotent(KonamiProgressTestSuite* suite) {
+    suite->player_->unlockKonamiButton(KonamiButton::START);
+    uint8_t afterFirst = suite->player_->getKonamiProgress();
+
+    suite->player_->unlockKonamiButton(KonamiButton::START);
+    uint8_t afterSecond = suite->player_->getKonamiProgress();
+
+    ASSERT_EQ(afterFirst, afterSecond);
+    ASSERT_EQ(suite->player_->getUnlockedButtonCount(), 1);
+}
+
+// Test: toJson includes konami_progress field
+void konamiProgressSerializesToJson(KonamiProgressTestSuite* suite) {
+    suite->player_->unlockKonamiButton(KonamiButton::UP);    // bit 0
+    suite->player_->unlockKonamiButton(KonamiButton::LEFT);  // bit 2
+
+    std::string json = suite->player_->toJson();
+
+    // Parse and verify
+    JsonDocument doc;
+    deserializeJson(doc, json);
+    ASSERT_TRUE(doc.containsKey("konami_progress"));
+    ASSERT_EQ(doc["konami_progress"].as<uint8_t>(), 5);  // 0b00000101
+
+    // Color profile defaults
+    ASSERT_TRUE(doc.containsKey("equipped_color_profile"));
+    ASSERT_EQ(doc["equipped_color_profile"].as<uint8_t>(), 0);  // QUICKDRAW
+}
+
+// Test: fromJson restores konami_progress correctly
+void konamiProgressDeserializesFromJson(KonamiProgressTestSuite* suite) {
+    // Serialize a player with progress
+    suite->player_->unlockKonamiButton(KonamiButton::UP);
+    suite->player_->unlockKonamiButton(KonamiButton::START);
+    suite->player_->setEquippedColorProfile(GameType::SIGNAL_ECHO);
+    suite->player_->addColorProfileEligibility(GameType::SIGNAL_ECHO);
+
+    std::string json = suite->player_->toJson();
+
+    // Deserialize into a fresh player
+    Player restored;
+    restored.fromJson(json);
+
+    ASSERT_EQ(restored.getKonamiProgress(), suite->player_->getKonamiProgress());
+    ASSERT_TRUE(restored.hasUnlockedButton(KonamiButton::UP));
+    ASSERT_TRUE(restored.hasUnlockedButton(KonamiButton::START));
+    ASSERT_FALSE(restored.hasUnlockedButton(KonamiButton::DOWN));
+    ASSERT_EQ(restored.getEquippedColorProfile(), GameType::SIGNAL_ECHO);
+    ASSERT_TRUE(restored.hasColorProfileEligibility(GameType::SIGNAL_ECHO));
+}
+
+// Test: fromJson with missing konami_progress defaults to 0 (backward compat)
+void konamiProgressDeserializeMissingField(KonamiProgressTestSuite* suite) {
+    // JSON without konami_progress (old server format)
+    std::string oldJson = R"({"id":"0010","name":"Test","allegiance":"none","faction":"Guild","hunter":true})";
+
+    Player restored;
+    restored.fromJson(oldJson);
+
+    ASSERT_EQ(restored.getKonamiProgress(), 0);
+    ASSERT_EQ(restored.getEquippedColorProfile(), GameType::QUICKDRAW);
+    ASSERT_FALSE(restored.hasAllKonamiButtons());
+    ASSERT_EQ(restored.getUnlockedButtonCount(), 0);
+}

--- a/test/test_cli/minigame-base-tests.hpp
+++ b/test/test_cli/minigame-base-tests.hpp
@@ -1,0 +1,165 @@
+//
+// MiniGame Base Class Tests + Color Profile Tests
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "game/minigame.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+// ============================================
+// MINIGAME TEST SUITE
+// ============================================
+
+class MiniGameTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        globalClock_ = new NativeClockDriver("test_mg_clock");
+        globalLogger_ = new NativeLoggerDriver("test_mg_logger");
+        globalLogger_->setSuppressOutput(true);
+        g_logger = globalLogger_;
+        SimpleTimer::setPlatformClock(globalClock_);
+
+        device_ = cli::DeviceFactory::createGameDevice(0, "signal-echo");
+        game_ = dynamic_cast<SignalEcho*>(device_.game);
+    }
+
+    void TearDown() override {
+        cli::DeviceFactory::destroyDevice(device_);
+        SimpleTimer::setPlatformClock(nullptr);
+        g_logger = nullptr;
+        delete globalLogger_;
+        delete globalClock_;
+    }
+
+    cli::DeviceInstance device_;
+    SignalEcho* game_ = nullptr;
+    NativeClockDriver* globalClock_ = nullptr;
+    NativeLoggerDriver* globalLogger_ = nullptr;
+};
+
+// Test: getGameType and getDisplayName return correct values
+void miniGameBaseIdentity(MiniGameTestSuite* suite) {
+    ASSERT_EQ(suite->game_->getGameType(), GameType::SIGNAL_ECHO);
+    ASSERT_STREQ(suite->game_->getDisplayName(), "SIGNAL ECHO");
+}
+
+// Test: Fresh MiniGame has outcome IN_PROGRESS, isGameComplete false
+void miniGameBaseOutcomeDefault(MiniGameTestSuite* suite) {
+    // Reset to ensure clean state
+    suite->game_->resetGame();
+
+    const MiniGameOutcome& outcome = suite->game_->getOutcome();
+    ASSERT_EQ(outcome.result, MiniGameResult::IN_PROGRESS);
+    ASSERT_EQ(outcome.score, 0);
+    ASSERT_FALSE(outcome.hardMode);
+    ASSERT_FALSE(suite->game_->isGameComplete());
+}
+
+// ============================================
+// COLOR PROFILE TEST SUITE
+// ============================================
+
+class ColorProfileTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        globalClock_ = new NativeClockDriver("test_cp_clock");
+        globalLogger_ = new NativeLoggerDriver("test_cp_logger");
+        globalLogger_->setSuppressOutput(true);
+        g_logger = globalLogger_;
+        SimpleTimer::setPlatformClock(globalClock_);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        g_logger = nullptr;
+        delete globalLogger_;
+        delete globalClock_;
+    }
+
+    NativeClockDriver* globalClock_ = nullptr;
+    NativeLoggerDriver* globalLogger_ = nullptr;
+};
+
+// Test: Signal Echo palette has correct magenta colors
+void colorProfileSignalEchoPaletteValues(ColorProfileTestSuite* suite) {
+    // Verify the primary palette
+    ASSERT_EQ(signalEchoColors[0].red, 255);
+    ASSERT_EQ(signalEchoColors[0].green, 0);
+    ASSERT_EQ(signalEchoColors[0].blue, 255);
+
+    ASSERT_EQ(signalEchoColors[3].red, 180);
+    ASSERT_EQ(signalEchoColors[3].green, 0);
+    ASSERT_EQ(signalEchoColors[3].blue, 255);
+}
+
+// Test: Idle palette has 8 entries
+void colorProfileIdlePaletteSize(ColorProfileTestSuite* suite) {
+    // signalEchoIdleColors should have 8 entries
+    ASSERT_EQ(sizeof(signalEchoIdleColors) / sizeof(LEDColor), 8u);
+    ASSERT_EQ(sizeof(defaultProfileIdleColors) / sizeof(LEDColor), 8u);
+}
+
+// Test: Default palette has warm yellow/white values
+void colorProfileDefaultPaletteValues(ColorProfileTestSuite* suite) {
+    ASSERT_EQ(defaultProfileColors[0].red, 255);
+    ASSERT_EQ(defaultProfileColors[0].green, 255);
+    ASSERT_EQ(defaultProfileColors[0].blue, 100);
+
+    ASSERT_EQ(defaultProfileColors[2].red, 255);
+    ASSERT_EQ(defaultProfileColors[2].green, 255);
+    ASSERT_EQ(defaultProfileColors[2].blue, 255);
+}
+
+// Test: SIGNAL_ECHO_IDLE_STATE has non-zero brightness
+void colorProfileIdleStateHasBrightness(ColorProfileTestSuite* suite) {
+    ASSERT_GT(SIGNAL_ECHO_IDLE_STATE.leftLights[0].brightness, 0);
+    ASSERT_GT(SIGNAL_ECHO_IDLE_STATE.rightLights[0].brightness, 0);
+}
+
+// Test: Win state uses rainbow colors
+void colorProfileWinStateIsRainbow(ColorProfileTestSuite* suite) {
+    // First LED should be red
+    ASSERT_EQ(SIGNAL_ECHO_WIN_STATE.leftLights[0].color.red, 255);
+    ASSERT_EQ(SIGNAL_ECHO_WIN_STATE.leftLights[0].color.green, 0);
+    ASSERT_EQ(SIGNAL_ECHO_WIN_STATE.leftLights[0].color.blue, 0);
+
+    // Last LED should be magenta
+    ASSERT_EQ(SIGNAL_ECHO_WIN_STATE.leftLights[8].color.red, 255);
+    ASSERT_EQ(SIGNAL_ECHO_WIN_STATE.leftLights[8].color.green, 0);
+    ASSERT_EQ(SIGNAL_ECHO_WIN_STATE.leftLights[8].color.blue, 255);
+
+    // All LEDs should be at full brightness
+    for (int i = 0; i < 9; i++) {
+        ASSERT_EQ(SIGNAL_ECHO_WIN_STATE.leftLights[i].brightness, 255);
+    }
+}
+
+// Test: Lose state uses red colors
+void colorProfileLoseStateIsRed(ColorProfileTestSuite* suite) {
+    for (int i = 0; i < 9; i++) {
+        ASSERT_EQ(SIGNAL_ECHO_LOSE_STATE.leftLights[i].color.red, 255);
+        ASSERT_EQ(SIGNAL_ECHO_LOSE_STATE.leftLights[i].color.green, 0);
+        ASSERT_EQ(SIGNAL_ECHO_LOSE_STATE.leftLights[i].color.blue, 0);
+    }
+}
+
+// Test: Error state is all red at full brightness
+void colorProfileErrorStateIsRed(ColorProfileTestSuite* suite) {
+    for (int i = 0; i < 9; i++) {
+        ASSERT_EQ(SIGNAL_ECHO_ERROR_STATE.leftLights[i].color.red, 255);
+        ASSERT_EQ(SIGNAL_ECHO_ERROR_STATE.leftLights[i].brightness, 255);
+    }
+}
+
+// Test: Correct state is all green at full brightness
+void colorProfileCorrectStateIsGreen(ColorProfileTestSuite* suite) {
+    for (int i = 0; i < 9; i++) {
+        ASSERT_EQ(SIGNAL_ECHO_CORRECT_STATE.leftLights[i].color.green, 255);
+        ASSERT_EQ(SIGNAL_ECHO_CORRECT_STATE.leftLights[i].color.red, 0);
+        ASSERT_EQ(SIGNAL_ECHO_CORRECT_STATE.leftLights[i].brightness, 255);
+    }
+}

--- a/test/test_cli/profile-portability-tests.hpp
+++ b/test/test_cli/profile-portability-tests.hpp
@@ -1,0 +1,255 @@
+//
+// Profile Portability Tests — Player state survives device reassignment
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include "game/player.hpp"
+#include "device/device-types.hpp"
+#include "game/quickdraw-requests.hpp"
+#include "game/progress-manager.hpp"
+#include "cli/cli-http-server.hpp"
+#include "device/drivers/native/native-prefs-driver.hpp"
+#include "device/drivers/native/native-http-client-driver.hpp"
+
+// ============================================
+// PROFILE PORTABILITY TEST SUITE
+// ============================================
+
+class ProfilePortabilityTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        server_ = &cli::MockHttpServer::getInstance();
+        server_->clearHistory();
+        server_->setOffline(false);
+
+        // Player A: has some Konami progress
+        cli::MockPlayerConfig configA;
+        configA.id = "0010";
+        configA.name = "PlayerA";
+        configA.isHunter = true;
+        configA.allegiance = 1;
+        configA.faction = "Guild";
+        configA.konamiProgress = 5;  // UP + LEFT unlocked
+        configA.equippedColorProfile = 7;  // SIGNAL_ECHO
+        configA.colorProfileEligibility = {7};
+        server_->configurePlayer("0010", configA);
+
+        // Player B: fresh player, no progress
+        cli::MockPlayerConfig configB;
+        configB.id = "0020";
+        configB.name = "PlayerB";
+        configB.isHunter = false;
+        configB.allegiance = 2;
+        configB.faction = "Rebels";
+        configB.konamiProgress = 0;
+        configB.equippedColorProfile = 0;
+        server_->configurePlayer("0020", configB);
+
+        // Player C: advanced player with lots of progress
+        cli::MockPlayerConfig configC;
+        configC.id = "0030";
+        configC.name = "PlayerC";
+        configC.isHunter = true;
+        configC.allegiance = 1;
+        configC.faction = "Guild";
+        configC.konamiProgress = 127;  // All buttons unlocked
+        configC.equippedColorProfile = 7;
+        configC.colorProfileEligibility = {7};
+        server_->configurePlayer("0030", configC);
+    }
+
+    void TearDown() override {
+        server_->clearHistory();
+        server_->setOffline(false);
+        server_->removePlayer("0010");
+        server_->removePlayer("0020");
+        server_->removePlayer("0030");
+    }
+
+    /*
+     * Helper: simulate login — fetch player data from mock server and
+     * apply it to the Player object (same logic as FetchUserData state).
+     */
+    void loginPlayer(Player* player, const std::string& playerId) {
+        std::string response;
+        int status = server_->handleRequest("GET", "/api/players/" + playerId, "", response);
+        ASSERT_EQ(status, 200);
+
+        PlayerResponse parsed;
+        bool ok = parsed.parseFromJson(response);
+        ASSERT_TRUE(ok);
+
+        char* idBuf = new char[playerId.size() + 1];
+        strcpy(idBuf, playerId.c_str());
+        player->setUserID(idBuf);
+        delete[] idBuf;
+
+        player->setName(parsed.name.c_str());
+        player->setIsHunter(parsed.isHunter);
+        player->setAllegiance(parsed.allegiance);
+        player->setFaction(parsed.faction.c_str());
+        player->setKonamiProgress(parsed.konamiProgress);
+        player->setEquippedColorProfile(
+            static_cast<GameType>(parsed.equippedColorProfile));
+        for (uint8_t g : parsed.colorProfileEligibility) {
+            player->addColorProfileEligibility(static_cast<GameType>(g));
+        }
+    }
+
+    cli::MockHttpServer* server_;
+};
+
+// Test: Login fetches complete profile including Konami progress
+void portabilityLoginFetchesProfile(ProfilePortabilityTestSuite* suite) {
+    Player player;
+    suite->loginPlayer(&player, "0010");
+
+    ASSERT_EQ(player.getName(), "PlayerA");
+    ASSERT_EQ(player.getKonamiProgress(), 5);
+    ASSERT_TRUE(player.hasUnlockedButton(KonamiButton::UP));
+    ASSERT_TRUE(player.hasUnlockedButton(KonamiButton::LEFT));
+    ASSERT_FALSE(player.hasUnlockedButton(KonamiButton::START));
+    ASSERT_EQ(player.getEquippedColorProfile(), GameType::SIGNAL_ECHO);
+    ASSERT_TRUE(player.hasColorProfileEligibility(GameType::SIGNAL_ECHO));
+}
+
+// Test: Same device, same player, same profile on re-login
+void portabilityLoginSameDeviceSameProfile(ProfilePortabilityTestSuite* suite) {
+    Player player;
+
+    // First login
+    suite->loginPlayer(&player, "0010");
+    ASSERT_EQ(player.getKonamiProgress(), 5);
+
+    // Simulate "restart" — create a fresh Player on same device
+    Player player2;
+    suite->loginPlayer(&player2, "0010");
+
+    ASSERT_EQ(player2.getName(), "PlayerA");
+    ASSERT_EQ(player2.getKonamiProgress(), 5);
+    ASSERT_EQ(player2.getEquippedColorProfile(), GameType::SIGNAL_ECHO);
+}
+
+// Test: Different device, same player, same progress
+void portabilityLoginDifferentDeviceSameProfile(ProfilePortabilityTestSuite* suite) {
+    // Device 0: login as player A
+    Player playerOnDevice0;
+    suite->loginPlayer(&playerOnDevice0, "0010");
+    ASSERT_EQ(playerOnDevice0.getKonamiProgress(), 5);
+
+    // Device 1: login as same player A
+    Player playerOnDevice1;
+    suite->loginPlayer(&playerOnDevice1, "0010");
+
+    // Same progress on different device
+    ASSERT_EQ(playerOnDevice1.getKonamiProgress(), 5);
+    ASSERT_EQ(playerOnDevice1.getEquippedColorProfile(), GameType::SIGNAL_ECHO);
+    ASSERT_TRUE(playerOnDevice1.hasUnlockedButton(KonamiButton::UP));
+    ASSERT_TRUE(playerOnDevice1.hasUnlockedButton(KonamiButton::LEFT));
+}
+
+// Test: Device reassignment — new player gets their own profile, not previous player's
+void portabilityLoginNewProfileOnReassignedDevice(ProfilePortabilityTestSuite* suite) {
+    // Login as Player A on device
+    Player player;
+    suite->loginPlayer(&player, "0010");
+    ASSERT_EQ(player.getKonamiProgress(), 5);
+    ASSERT_EQ(player.getEquippedColorProfile(), GameType::SIGNAL_ECHO);
+
+    // "Reassign" device — login as Player B
+    Player player2;
+    suite->loginPlayer(&player2, "0020");
+
+    // Player B has their own (empty) progress
+    ASSERT_EQ(player2.getName(), "PlayerB");
+    ASSERT_EQ(player2.getKonamiProgress(), 0);
+    ASSERT_EQ(player2.getEquippedColorProfile(), GameType::QUICKDRAW);
+    ASSERT_FALSE(player2.hasUnlockedButton(KonamiButton::UP));
+}
+
+// Test: Full booth scenario — check-in, play, check-out chain
+void portabilityBoothCheckInOutChain(ProfilePortabilityTestSuite* suite) {
+    // Player A checks in on device 0
+    Player playerA_d0;
+    suite->loginPlayer(&playerA_d0, "0010");
+    ASSERT_EQ(playerA_d0.getKonamiProgress(), 5);
+
+    // Player A "plays" (simulate unlocking another button locally)
+    playerA_d0.unlockKonamiButton(KonamiButton::START);
+    ASSERT_EQ(playerA_d0.getKonamiProgress(), 69);  // 5 + 64 = 69
+
+    // Player A checks out. Player B checks in on same device.
+    Player playerB_d0;
+    suite->loginPlayer(&playerB_d0, "0020");
+    ASSERT_EQ(playerB_d0.getName(), "PlayerB");
+    ASSERT_EQ(playerB_d0.getKonamiProgress(), 0);
+
+    // Player B plays, no progress changes.
+    // Player B checks out. Player A checks in on device 1.
+    // Server still has Player A's old progress (5, not 69 — upload hasn't happened yet).
+    Player playerA_d1;
+    suite->loginPlayer(&playerA_d1, "0010");
+    ASSERT_EQ(playerA_d1.getKonamiProgress(), 5);  // Server has old progress
+    ASSERT_EQ(playerA_d1.getName(), "PlayerA");
+}
+
+// Test: Offline fallback — load Konami progress from NVS when server unreachable
+void portabilityOfflineFallbackToLocalProgress(ProfilePortabilityTestSuite* suite) {
+    // First: save progress to NVS (simulating a previous session)
+    NativePrefsDriver storage("TestPortabilityStorage");
+    Player player("0010", Allegiance::RESISTANCE, true);
+    ProgressManager pm;
+    pm.initialize(&player, &storage);
+
+    player.setKonamiProgress(21);  // UP + LEFT + B
+    pm.saveProgress();
+
+    // Now simulate offline login — server unreachable
+    Player offlinePlayer("0010", Allegiance::RESISTANCE, true);
+    ProgressManager offlinePM;
+    offlinePM.initialize(&offlinePlayer, &storage);
+
+    // Player starts with 0 progress (no server fetch)
+    ASSERT_EQ(offlinePlayer.getKonamiProgress(), 0);
+
+    // Load from NVS fallback
+    offlinePM.loadProgress();
+
+    ASSERT_EQ(offlinePlayer.getKonamiProgress(), 21);
+    ASSERT_TRUE(offlinePlayer.hasUnlockedButton(KonamiButton::UP));
+    ASSERT_TRUE(offlinePlayer.hasUnlockedButton(KonamiButton::LEFT));
+    ASSERT_TRUE(offlinePlayer.hasUnlockedButton(KonamiButton::B));
+}
+
+// Test: Progress survives device restart via NVS persistence
+void portabilityProgressSurvivesRestart(ProfilePortabilityTestSuite* suite) {
+    // Session 1: Player logs in, unlocks a button, progress saved to NVS
+    NativePrefsDriver storage("TestRestartStorage");
+    Player player1("0010", Allegiance::RESISTANCE, true);
+    ProgressManager pm1;
+    pm1.initialize(&player1, &storage);
+
+    suite->loginPlayer(&player1, "0010");  // Gets progress=5 from server
+    player1.unlockKonamiButton(KonamiButton::START);  // Now 69
+    pm1.saveProgress();
+
+    // Verify NVS has updated progress
+    uint8_t stored = storage.readUChar("konami", 0);
+    ASSERT_EQ(stored, 69);
+
+    // Session 2: "Device restart" — new Player and ProgressManager, same storage
+    Player player2("0010", Allegiance::RESISTANCE, true);
+    ProgressManager pm2;
+    pm2.initialize(&player2, &storage);
+
+    // Before server fetch, load from NVS
+    pm2.loadProgress();
+    ASSERT_EQ(player2.getKonamiProgress(), 69);
+
+    // Verify the new progress includes both server-fetched and locally-earned buttons
+    ASSERT_TRUE(player2.hasUnlockedButton(KonamiButton::UP));     // from server (bit 0)
+    ASSERT_TRUE(player2.hasUnlockedButton(KonamiButton::LEFT));   // from server (bit 2)
+    ASSERT_TRUE(player2.hasUnlockedButton(KonamiButton::START));  // earned locally (bit 6)
+}

--- a/test/test_cli/profile-sync-tests.hpp
+++ b/test/test_cli/profile-sync-tests.hpp
@@ -1,0 +1,180 @@
+//
+// Profile Sync Tests — Server response parsing, NVS persistence, upload
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include "game/player.hpp"
+#include "device/device-types.hpp"
+#include "game/quickdraw-requests.hpp"
+#include "game/progress-manager.hpp"
+#include "cli/cli-http-server.hpp"
+#include "device/drivers/native/native-http-client-driver.hpp"
+#include "device/drivers/native/native-prefs-driver.hpp"
+
+// ============================================
+// PROFILE SYNC TEST SUITE
+// ============================================
+
+class ProfileSyncTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        player_ = new Player("0010", Allegiance::RESISTANCE, true);
+        storage_ = new NativePrefsDriver("TestProgressStorage");
+        progressManager_ = new ProgressManager();
+        progressManager_->initialize(player_, storage_);
+
+        server_ = &cli::MockHttpServer::getInstance();
+        server_->clearHistory();
+        server_->setOffline(false);
+    }
+
+    void TearDown() override {
+        server_->clearHistory();
+        server_->setOffline(false);
+        server_->removePlayer("0010");
+
+        delete progressManager_;
+        delete storage_;
+        delete player_;
+    }
+
+    Player* player_;
+    NativePrefsDriver* storage_;
+    ProgressManager* progressManager_;
+    cli::MockHttpServer* server_;
+};
+
+// Test: MockHttpServer returns konami_progress in GET response
+void profileSyncServerReturnsProgress(ProfileSyncTestSuite* suite) {
+    cli::MockPlayerConfig config;
+    config.id = "0010";
+    config.name = "TestPlayer";
+    config.isHunter = true;
+    config.allegiance = 1;
+    config.faction = "Guild";
+    config.konamiProgress = 37;  // 0b00100101 = UP + LEFT + A
+    config.equippedColorProfile = 7;  // SIGNAL_ECHO
+    config.colorProfileEligibility = {7};
+
+    suite->server_->configurePlayer("0010", config);
+
+    std::string response;
+    int status = suite->server_->handleRequest("GET", "/api/players/0010", "", response);
+
+    ASSERT_EQ(status, 200);
+    ASSERT_TRUE(response.find("\"konami_progress\":37") != std::string::npos);
+    ASSERT_TRUE(response.find("\"equipped_color_profile\":7") != std::string::npos);
+    ASSERT_TRUE(response.find("\"color_profile_eligibility\":[7]") != std::string::npos);
+}
+
+// Test: PlayerResponse::parseFromJson correctly parses Konami fields
+void profileSyncFetchUserDataParsesProgress(ProfileSyncTestSuite* suite) {
+    std::string json = R"({"data":{"id":"0010","name":"TestPlayer","hunter":true,"allegiance":1,"faction":"Guild","konami_progress":5,"equipped_color_profile":7,"color_profile_eligibility":[7]}})";
+
+    PlayerResponse response;
+    bool ok = response.parseFromJson(json);
+
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(response.konamiProgress, 5);
+    ASSERT_EQ(response.equippedColorProfile, 7);
+    ASSERT_EQ(response.colorProfileEligibility.size(), 1);
+    ASSERT_EQ(response.colorProfileEligibility[0], 7);
+
+    // Simulate what FetchUserData does: set on player
+    suite->player_->setKonamiProgress(response.konamiProgress);
+    suite->player_->setEquippedColorProfile(
+        static_cast<GameType>(response.equippedColorProfile));
+    for (uint8_t g : response.colorProfileEligibility) {
+        suite->player_->addColorProfileEligibility(static_cast<GameType>(g));
+    }
+
+    ASSERT_EQ(suite->player_->getKonamiProgress(), 5);
+    ASSERT_TRUE(suite->player_->hasUnlockedButton(KonamiButton::UP));
+    ASSERT_TRUE(suite->player_->hasUnlockedButton(KonamiButton::LEFT));
+    ASSERT_FALSE(suite->player_->hasUnlockedButton(KonamiButton::START));
+    ASSERT_EQ(suite->player_->getEquippedColorProfile(), GameType::SIGNAL_ECHO);
+}
+
+// Test: Missing Konami fields in server response defaults to zero (no crash)
+void profileSyncFetchUserDataMissingProgress(ProfileSyncTestSuite* suite) {
+    // Old-format server response without Konami fields
+    std::string json = R"({"data":{"id":"0010","name":"TestPlayer","hunter":true,"allegiance":1,"faction":"Guild"}})";
+
+    PlayerResponse response;
+    bool ok = response.parseFromJson(json);
+
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(response.konamiProgress, 0);
+    ASSERT_EQ(response.equippedColorProfile, 0);
+    ASSERT_TRUE(response.colorProfileEligibility.empty());
+}
+
+// Test: saveProgress writes konami bitmask to NVS storage
+void profileSyncProgressSavedToNVS(ProfileSyncTestSuite* suite) {
+    suite->player_->unlockKonamiButton(KonamiButton::UP);     // bit 0
+    suite->player_->unlockKonamiButton(KonamiButton::START);  // bit 6
+
+    suite->progressManager_->saveProgress();
+
+    // Verify NVS contains the progress
+    uint8_t stored = suite->storage_->readUChar("konami", 0);
+    ASSERT_EQ(stored, 65);  // 0b01000001
+
+    // Verify it's marked as unsynced
+    uint8_t synced = suite->storage_->readUChar("synced", 1);
+    ASSERT_EQ(synced, 0);
+    ASSERT_TRUE(suite->progressManager_->hasUnsyncedProgress());
+}
+
+// Test: loadProgress reads konami bitmask from NVS into Player
+void profileSyncProgressLoadedFromNVS(ProfileSyncTestSuite* suite) {
+    // Manually write progress to NVS (simulate a previous save)
+    suite->storage_->writeUChar("konami", 21);  // 0b00010101 = UP + LEFT + B
+
+    // Create a fresh player and progress manager
+    Player freshPlayer("0010", Allegiance::RESISTANCE, true);
+    ProgressManager freshPM;
+    freshPM.initialize(&freshPlayer, suite->storage_);
+
+    ASSERT_EQ(freshPlayer.getKonamiProgress(), 0);  // Not loaded yet
+
+    freshPM.loadProgress();
+
+    ASSERT_EQ(freshPlayer.getKonamiProgress(), 21);
+    ASSERT_TRUE(freshPlayer.hasUnlockedButton(KonamiButton::UP));
+    ASSERT_TRUE(freshPlayer.hasUnlockedButton(KonamiButton::LEFT));
+    ASSERT_TRUE(freshPlayer.hasUnlockedButton(KonamiButton::B));
+    ASSERT_FALSE(freshPlayer.hasUnlockedButton(KonamiButton::START));
+}
+
+// Test: uploadProgress sends correct JSON body to PUT endpoint
+void profileSyncProgressUploadSendsCorrectJson(ProfileSyncTestSuite* suite) {
+    suite->player_->unlockKonamiButton(KonamiButton::UP);
+    suite->player_->unlockKonamiButton(KonamiButton::LEFT);
+    suite->progressManager_->saveProgress();
+
+    // Configure mock server to accept the progress
+    cli::MockPlayerConfig config;
+    config.id = "0010";
+    config.name = "TestPlayer";
+    config.isHunter = true;
+    config.allegiance = 1;
+    config.faction = "Guild";
+    suite->server_->configurePlayer("0010", config);
+
+    // Verify the PUT endpoint accepts progress JSON directly
+    std::string progressBody = R"({"konami_progress":5})";
+    std::string response;
+    int status = suite->server_->handleRequest(
+        "PUT", "/api/players/0010/progress", progressBody, response);
+
+    ASSERT_EQ(status, 200);
+    ASSERT_TRUE(response.find("success") != std::string::npos);
+
+    // Verify the server updated the player config
+    std::string getResponse;
+    suite->server_->handleRequest("GET", "/api/players/0010", "", getResponse);
+    ASSERT_TRUE(getResponse.find("\"konami_progress\":5") != std::string::npos);
+}

--- a/test/test_cli/signal-echo-tests.hpp
+++ b/test/test_cli/signal-echo-tests.hpp
@@ -1,0 +1,853 @@
+//
+// Signal Echo Tests — test functions for Signal Echo game states
+// and difficulty mode behavior.
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <thread>
+#include <chrono>
+#include "cli/cli-device.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+// ============================================
+// SIGNAL ECHO TEST SUITE
+// ============================================
+
+class SignalEchoTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        globalClock_ = new NativeClockDriver("test_echo_clock");
+        globalLogger_ = new NativeLoggerDriver("test_echo_logger");
+        globalLogger_->setSuppressOutput(true);
+        g_logger = globalLogger_;
+        SimpleTimer::setPlatformClock(globalClock_);
+
+        // Create a device using the game factory with a test config
+        device_ = cli::DeviceFactory::createGameDevice(0, "signal-echo");
+
+        // Get the SignalEcho game instance
+        game_ = dynamic_cast<SignalEcho*>(device_.game);
+    }
+
+    void TearDown() override {
+        cli::DeviceFactory::destroyDevice(device_);
+        SimpleTimer::setPlatformClock(nullptr);
+        g_logger = nullptr;
+        delete globalLogger_;
+        delete globalClock_;
+    }
+
+    // Helper: run N loop cycles on device + game
+    void runLoops(int count) {
+        for (int i = 0; i < count; i++) {
+            device_.pdn->loop();
+            device_.game->loop();
+        }
+    }
+
+    // Helper: run loops with time advancement to get past timed transitions
+    void runLoopsWithDelay(int count, int delayMs) {
+        for (int i = 0; i < count; i++) {
+            device_.pdn->loop();
+            device_.game->loop();
+            std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+        }
+    }
+
+    // Helper: create a SignalEcho with a custom config
+    SignalEcho* createCustomGame(SignalEchoConfig config) {
+        SignalEcho* customGame = new SignalEcho(device_.pdn, config);
+        customGame->initialize();
+        return customGame;
+    }
+
+    cli::DeviceInstance device_;
+    SignalEcho* game_ = nullptr;
+    NativeClockDriver* globalClock_ = nullptr;
+    NativeLoggerDriver* globalLogger_ = nullptr;
+};
+
+// ============================================
+// SIGNAL ECHO TESTS — Sequence Generation
+// ============================================
+
+// Test: Generated sequence has correct length
+void echoSequenceGenerationLength(SignalEchoTestSuite* suite) {
+    SignalEchoConfig config;
+    config.sequenceLength = 6;
+    config.rngSeed = 42;
+
+    SignalEcho tempGame(suite->device_.pdn, config);
+    tempGame.seedRng();
+    std::vector<bool> seq = tempGame.generateSequence(6);
+    ASSERT_EQ(static_cast<int>(seq.size()), 6);
+
+    std::vector<bool> seq2 = tempGame.generateSequence(10);
+    ASSERT_EQ(static_cast<int>(seq2.size()), 10);
+}
+
+// Test: Sequence contains both UP and DOWN (statistical)
+void echoSequenceGenerationMixed(SignalEchoTestSuite* suite) {
+    SignalEchoConfig config;
+    config.rngSeed = 42;
+
+    SignalEcho tempGame(suite->device_.pdn, config);
+    tempGame.seedRng();
+
+    // Generate a long sequence to ensure both values appear
+    std::vector<bool> seq = tempGame.generateSequence(100);
+    int ups = 0, downs = 0;
+    for (bool val : seq) {
+        if (val) ups++;
+        else downs++;
+    }
+    ASSERT_GT(ups, 0) << "Expected at least one UP in 100 elements";
+    ASSERT_GT(downs, 0) << "Expected at least one DOWN in 100 elements";
+}
+
+// ============================================
+// SIGNAL ECHO TESTS — State Transitions
+// ============================================
+
+// Test: EchoIntro transitions to EchoShowSequence after timer
+void echoIntroTransitionsToShow(SignalEchoTestSuite* suite) {
+    // Game starts at EchoIntro (state index 0)
+    State* state = suite->game_->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), ECHO_INTRO);
+
+    // Run loops with enough delay for the 2s intro timer
+    suite->runLoopsWithDelay(30, 100);  // 3 seconds total
+
+    state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_SHOW_SEQUENCE);
+}
+
+// Test: ShowSequence displays each signal for displaySpeedMs
+void echoShowSequenceTimingPerSignal(SignalEchoTestSuite* suite) {
+    // Skip to ShowSequence state (index 1)
+    suite->game_->skipToState(1);
+
+    State* state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_SHOW_SEQUENCE);
+
+    // Generate a known sequence
+    suite->game_->getSession().currentSequence = {true, false, true, false};
+
+    // Run one loop — should display first signal
+    suite->runLoops(1);
+    state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_SHOW_SEQUENCE);  // Still showing
+
+    // Wait less than displaySpeedMs — should still be showing
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    suite->runLoops(1);
+    state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_SHOW_SEQUENCE);
+}
+
+// Test: ShowSequence transitions to PlayerInput after all signals
+void echoShowTransitionsToInput(SignalEchoTestSuite* suite) {
+    // Set a very short display speed for testing
+    suite->game_->getConfig().displaySpeedMs = 50;
+    suite->game_->getSession().currentSequence = {true, false};
+
+    suite->game_->skipToState(1);  // EchoShowSequence
+
+    // Run enough loops with delays to display both signals
+    suite->runLoopsWithDelay(20, 50);  // 1 second total
+
+    State* state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_PLAYER_INPUT);
+}
+
+// ============================================
+// SIGNAL ECHO TESTS — Player Input
+// ============================================
+
+// Test: Correct button press advances inputIndex
+void echoCorrectInputAdvancesIndex(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().displaySpeedMs = 10;
+    suite->game_->getSession().currentSequence = {true, false, true, false};
+    suite->game_->getSession().inputIndex = 0;
+
+    suite->game_->skipToState(2);  // EchoPlayerInput
+    suite->runLoops(1);  // Let it mount and set up callbacks
+
+    // Sequence is: UP, DOWN, UP, DOWN
+    // Press UP (primary button) — correct for position 0
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->runLoops(1);
+
+    ASSERT_EQ(suite->game_->getSession().inputIndex, 1);
+    ASSERT_EQ(suite->game_->getSession().mistakes, 0);
+}
+
+// Test: Wrong button press increments mistakes
+void echoWrongInputCountsMistake(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().displaySpeedMs = 10;
+    suite->game_->getSession().currentSequence = {true, false, true, false};
+    suite->game_->getSession().inputIndex = 0;
+
+    suite->game_->skipToState(2);  // EchoPlayerInput
+    suite->runLoops(1);
+
+    // Sequence starts with UP, but we press DOWN (secondary) — wrong
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->runLoops(1);
+
+    ASSERT_EQ(suite->game_->getSession().inputIndex, 1);  // Still advances
+    ASSERT_EQ(suite->game_->getSession().mistakes, 1);
+}
+
+// Test: Completing all inputs correctly leads to next round via Evaluate
+void echoAllCorrectInputsNextRound(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().displaySpeedMs = 10;
+    suite->game_->getConfig().numSequences = 3;
+    suite->game_->getConfig().sequenceLength = 2;
+    suite->game_->getConfig().allowedMistakes = 3;
+    suite->game_->getSession().currentSequence = {true, false};
+    suite->game_->getSession().currentRound = 0;
+    suite->game_->getSession().inputIndex = 0;
+
+    suite->game_->skipToState(2);  // EchoPlayerInput
+    suite->runLoops(1);
+
+    // Press correct buttons: UP then DOWN
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->runLoops(1);
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->runLoops(2);  // Extra loop to process transition
+
+    // Should transition to EchoEvaluate then to EchoShowSequence
+    // Evaluate is instantaneous — it sets its transition in onStateMounted
+    suite->runLoops(2);
+
+    State* state = suite->game_->getCurrentState();
+    // Should be at ShowSequence for next round, or Evaluate
+    ASSERT_TRUE(state->getStateId() == ECHO_EVALUATE ||
+                state->getStateId() == ECHO_SHOW_SEQUENCE);
+}
+
+// Test: Exceeding allowed mistakes leads to EchoLose
+void echoMistakesExhaustedLose(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().displaySpeedMs = 10;
+    suite->game_->getConfig().allowedMistakes = 1;
+    suite->game_->getConfig().sequenceLength = 4;
+    suite->game_->getSession().currentSequence = {true, true, true, true};
+    suite->game_->getSession().inputIndex = 0;
+    suite->game_->getSession().mistakes = 0;
+
+    suite->game_->skipToState(2);  // EchoPlayerInput
+    suite->runLoops(1);
+
+    // Press wrong button twice (allowedMistakes = 1, so 2nd exceeds)
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);  // Wrong
+    suite->runLoops(1);
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);  // Wrong
+    suite->runLoops(5);  // Process transition through Evaluate to Lose
+
+    State* state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_LOSE);
+}
+
+// Test: All rounds completed successfully leads to EchoWin
+void echoAllRoundsCompletedWin(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().displaySpeedMs = 10;
+    suite->game_->getConfig().numSequences = 1;  // Just 1 round
+    suite->game_->getConfig().sequenceLength = 2;
+    suite->game_->getConfig().allowedMistakes = 3;
+    suite->game_->getSession().currentSequence = {true, false};
+    suite->game_->getSession().currentRound = 0;
+    suite->game_->getSession().inputIndex = 0;
+
+    suite->game_->skipToState(2);  // EchoPlayerInput
+    suite->runLoops(1);
+
+    // Enter correct sequence
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);   // UP
+    suite->runLoops(1);
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK); // DOWN
+    suite->runLoops(5);  // Process through Evaluate to Win
+
+    State* state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_WIN);
+}
+
+// ============================================
+// SIGNAL ECHO TESTS — Cumulative & Fresh Mode
+// ============================================
+
+// Test: Cumulative mode appends one element each round
+void echoCumulativeModeAppends(SignalEchoTestSuite* suite) {
+    SignalEchoConfig config;
+    config.sequenceLength = 3;
+    config.numSequences = 3;
+    config.cumulative = true;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    config.allowedMistakes = 10;  // High tolerance for testing
+
+    SignalEcho* customGame = new SignalEcho(suite->device_.pdn, config);
+    customGame->initialize();
+
+    // First round sequence should be length 3
+    int firstLen = static_cast<int>(customGame->getSession().currentSequence.size());
+    ASSERT_EQ(firstLen, 3);
+
+    // Simulate completing a round by manually advancing
+    auto& session = customGame->getSession();
+    // Fill in all correct inputs
+    session.inputIndex = firstLen;
+    session.currentRound = 0;
+
+    // Trigger evaluate logic
+    customGame->skipToState(3);  // EchoEvaluate
+    // After evaluate, currentRound should be 1 and sequence should be length 4
+    ASSERT_EQ(session.currentRound, 1);
+    ASSERT_EQ(static_cast<int>(session.currentSequence.size()), 4);
+
+    delete customGame;
+}
+
+// Test: Fresh mode generates new sequence each round
+void echoFreshModeNewSequence(SignalEchoTestSuite* suite) {
+    SignalEchoConfig config;
+    config.sequenceLength = 4;
+    config.numSequences = 3;
+    config.cumulative = false;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    config.allowedMistakes = 10;
+
+    SignalEcho* customGame = new SignalEcho(suite->device_.pdn, config);
+    customGame->initialize();
+
+    auto& session = customGame->getSession();
+    std::vector<bool> firstSequence = session.currentSequence;
+
+    // Simulate completing round 0
+    session.inputIndex = 4;
+    session.currentRound = 0;
+
+    customGame->skipToState(3);  // EchoEvaluate
+    ASSERT_EQ(session.currentRound, 1);
+    ASSERT_EQ(static_cast<int>(session.currentSequence.size()), 4);
+    // Fresh sequence — length stays the same (unlike cumulative)
+
+    delete customGame;
+}
+
+// ============================================
+// SIGNAL ECHO TESTS — Outcome & Game Complete
+// ============================================
+
+// Test: EchoWin sets outcome to WON with score
+void echoWinSetsOutcome(SignalEchoTestSuite* suite) {
+    suite->game_->getSession().score = 400;
+    suite->game_->skipToState(4);  // EchoWin
+
+    const MiniGameOutcome& outcome = suite->game_->getOutcome();
+    ASSERT_EQ(outcome.result, MiniGameResult::WON);
+    ASSERT_EQ(outcome.score, 400);
+}
+
+// Test: EchoLose sets outcome to LOST
+void echoLoseSetsOutcome(SignalEchoTestSuite* suite) {
+    suite->game_->getSession().score = 200;
+    suite->game_->skipToState(5);  // EchoLose
+
+    const MiniGameOutcome& outcome = suite->game_->getOutcome();
+    ASSERT_EQ(outcome.result, MiniGameResult::LOST);
+    ASSERT_EQ(outcome.score, 200);
+}
+
+// Test: isGameComplete returns true after win
+void echoIsGameCompleteAfterWin(SignalEchoTestSuite* suite) {
+    ASSERT_FALSE(suite->game_->isGameComplete());
+
+    suite->game_->skipToState(4);  // EchoWin
+    ASSERT_TRUE(suite->game_->isGameComplete());
+}
+
+// Test: resetGame clears outcome back to IN_PROGRESS
+void echoResetGameClearsOutcome(SignalEchoTestSuite* suite) {
+    suite->game_->skipToState(4);  // EchoWin — sets outcome
+    ASSERT_TRUE(suite->game_->isGameComplete());
+
+    suite->game_->resetGame();
+    ASSERT_FALSE(suite->game_->isGameComplete());
+    ASSERT_EQ(suite->game_->getOutcome().result, MiniGameResult::IN_PROGRESS);
+}
+
+// Test: In standalone mode, EchoWin loops back to EchoIntro
+void echoStandaloneRestartAfterWin(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().managedMode = false;
+    suite->game_->skipToState(4);  // EchoWin
+
+    // Wait for win display timer
+    suite->runLoopsWithDelay(40, 100);  // 4 seconds
+
+    State* state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_INTRO);
+}
+
+// ============================================
+// SIGNAL ECHO DIFFICULTY TEST SUITE
+// ============================================
+
+class SignalEchoDifficultyTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        globalClock_ = new NativeClockDriver("test_diff_clock");
+        globalLogger_ = new NativeLoggerDriver("test_diff_logger");
+        globalLogger_->setSuppressOutput(true);
+        g_logger = globalLogger_;
+        SimpleTimer::setPlatformClock(globalClock_);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        g_logger = nullptr;
+        delete globalLogger_;
+        delete globalClock_;
+    }
+
+    // Helper: create a device running Signal Echo with a given config
+    cli::DeviceInstance createDevice(SignalEchoConfig config) {
+        cli::DeviceInstance instance;
+        instance.deviceIndex = 0;
+        instance.isHunter = false;
+
+        char idBuffer[5];
+        snprintf(idBuffer, sizeof(idBuffer), "%04d", 10);
+        instance.deviceId = idBuffer;
+
+        std::string suffix = "_diff_0";
+
+        instance.loggerDriver = new NativeLoggerDriver(LOGGER_DRIVER_NAME + suffix);
+        instance.loggerDriver->setSuppressOutput(true);
+        instance.clockDriver = new NativeClockDriver(PLATFORM_CLOCK_DRIVER_NAME + suffix);
+        instance.displayDriver = new NativeDisplayDriver(DISPLAY_DRIVER_NAME + suffix);
+        instance.primaryButtonDriver = new NativeButtonDriver(PRIMARY_BUTTON_DRIVER_NAME + suffix, 0);
+        instance.secondaryButtonDriver = new NativeButtonDriver(SECONDARY_BUTTON_DRIVER_NAME + suffix, 1);
+        instance.lightDriver = new NativeLightStripDriver(LIGHT_DRIVER_NAME + suffix);
+        instance.hapticsDriver = new NativeHapticsDriver(HAPTICS_DRIVER_NAME + suffix, 0);
+        instance.serialOutDriver = new NativeSerialDriver(SERIAL_OUT_DRIVER_NAME + suffix);
+        instance.serialInDriver = new NativeSerialDriver(SERIAL_IN_DRIVER_NAME + suffix);
+        instance.httpClientDriver = new NativeHttpClientDriver(HTTP_CLIENT_DRIVER_NAME + suffix);
+        instance.httpClientDriver->setMockServerEnabled(true);
+        instance.httpClientDriver->setConnected(true);
+        instance.peerCommsDriver = new NativePeerCommsDriver(PEER_COMMS_DRIVER_NAME + suffix);
+        instance.storageDriver = new NativePrefsDriver(STORAGE_DRIVER_NAME + suffix);
+
+        DriverConfig pdnConfig = {
+            {DISPLAY_DRIVER_NAME, instance.displayDriver},
+            {PRIMARY_BUTTON_DRIVER_NAME, instance.primaryButtonDriver},
+            {SECONDARY_BUTTON_DRIVER_NAME, instance.secondaryButtonDriver},
+            {LIGHT_DRIVER_NAME, instance.lightDriver},
+            {HAPTICS_DRIVER_NAME, instance.hapticsDriver},
+            {SERIAL_OUT_DRIVER_NAME, instance.serialOutDriver},
+            {SERIAL_IN_DRIVER_NAME, instance.serialInDriver},
+            {HTTP_CLIENT_DRIVER_NAME, instance.httpClientDriver},
+            {PEER_COMMS_DRIVER_NAME, instance.peerCommsDriver},
+            {PLATFORM_CLOCK_DRIVER_NAME, instance.clockDriver},
+            {LOGGER_DRIVER_NAME, instance.loggerDriver},
+            {STORAGE_DRIVER_NAME, instance.storageDriver},
+        };
+
+        instance.pdn = PDN::createPDN(pdnConfig);
+        instance.pdn->begin();
+
+        instance.game = new SignalEcho(instance.pdn, config);
+        instance.game->initialize();
+
+        return instance;
+    }
+
+    void destroyDevice(cli::DeviceInstance& device) {
+        delete device.game;
+        delete device.pdn;
+    }
+
+    NativeClockDriver* globalClock_ = nullptr;
+    NativeLoggerDriver* globalLogger_ = nullptr;
+};
+
+// Test: Easy config generates 4-element sequences
+void echoDiffEasyModeSequenceLength4(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    ASSERT_EQ(static_cast<int>(game->getSession().currentSequence.size()),
+              config.sequenceLength);
+    ASSERT_EQ(config.sequenceLength, 4);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Easy mode allows 3 mistakes before losing
+void echoDiffEasyMode3MistakesAllowed(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    // Set up a sequence of all UPs
+    game->getSession().currentSequence = {true, true, true, true};
+    game->getSession().inputIndex = 0;
+
+    game->skipToState(2);  // EchoPlayerInput
+    device.pdn->loop();
+    device.game->loop();
+
+    // Press wrong 3 times — should still be in game (3 allowed)
+    for (int i = 0; i < 3; i++) {
+        device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+        device.pdn->loop();
+        device.game->loop();
+    }
+    ASSERT_EQ(game->getSession().mistakes, 3);
+
+    // State should still be PlayerInput (3 mistakes = exactly the limit, not exceeded)
+    // The 4th wrong press would exceed
+    State* state = game->getCurrentState();
+    // After 3 mistakes with allowedMistakes=3, we have NOT exceeded yet
+    // because the check is mistakes > allowedMistakes
+    ASSERT_EQ(state->getStateId(), ECHO_PLAYER_INPUT);
+
+    // 4th wrong press exceeds the limit
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    for (int i = 0; i < 5; i++) {
+        device.pdn->loop();
+        device.game->loop();
+    }
+
+    state = game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_LOSE);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Hard config generates 8-element sequences
+void echoDiffHardModeSequenceLength8(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_HARD;
+    config.rngSeed = 42;
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    ASSERT_EQ(static_cast<int>(game->getSession().currentSequence.size()),
+              config.sequenceLength);
+    ASSERT_EQ(config.sequenceLength, 8);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Hard mode — 1st wrong press causes immediate lose
+void echoDiffHardMode1MistakeAllowed(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_HARD;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    game->getSession().currentSequence = {true, true, true, true, true, true, true, true};
+    game->getSession().inputIndex = 0;
+
+    game->skipToState(2);  // EchoPlayerInput
+    device.pdn->loop();
+    device.game->loop();
+
+    // First wrong press
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    device.pdn->loop();
+    device.game->loop();
+
+    ASSERT_EQ(game->getSession().mistakes, 1);
+
+    // Second wrong press exceeds allowedMistakes (1)
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    for (int i = 0; i < 5; i++) {
+        device.pdn->loop();
+        device.game->loop();
+    }
+
+    State* state = game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_LOSE);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Wrong input shows error marker on display
+void echoDiffWrongInputShowsErrorMarker(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    game->getSession().currentSequence = {true, false, true, false};
+    game->getSession().inputIndex = 0;
+
+    game->skipToState(2);  // EchoPlayerInput
+    device.pdn->loop();
+    device.game->loop();
+
+    // Press wrong button
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    device.pdn->loop();
+    device.game->loop();
+
+    // Verify display was updated (text history should have "YOUR TURN" content)
+    const auto& textHistory = device.displayDriver->getTextHistory();
+    ASSERT_GE(textHistory.size(), 1u);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Wrong input advances inputIndex (locked in)
+void echoDiffWrongInputAdvancesToNext(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    game->getSession().currentSequence = {true, false, true, false};
+    game->getSession().inputIndex = 0;
+
+    game->skipToState(2);
+    device.pdn->loop();
+    device.game->loop();
+
+    // Wrong press at position 0
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    device.pdn->loop();
+    device.game->loop();
+
+    ASSERT_EQ(game->getSession().inputIndex, 1);  // Advanced despite being wrong
+
+    suite->destroyDevice(device);
+}
+
+// Test: Life indicator starts at allowedMistakes
+void echoDiffLifeIndicatorStartsFull(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    ASSERT_EQ(game->getSession().mistakes, 0);
+    int livesRemaining = config.allowedMistakes - game->getSession().mistakes;
+    ASSERT_EQ(livesRemaining, 3);  // Easy mode: 3 lives
+
+    suite->destroyDevice(device);
+}
+
+// Test: Life indicator decrements on mistake
+void echoDiffLifeIndicatorDecrementsOnMistake(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    game->getSession().currentSequence = {true, true, true, true};
+    game->getSession().inputIndex = 0;
+
+    game->skipToState(2);
+    device.pdn->loop();
+    device.game->loop();
+
+    int livesBefore = config.allowedMistakes - game->getSession().mistakes;
+    ASSERT_EQ(livesBefore, 3);
+
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);  // Wrong
+    device.pdn->loop();
+    device.game->loop();
+
+    int livesAfter = config.allowedMistakes - game->getSession().mistakes;
+    ASSERT_EQ(livesAfter, 2);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Easy = 3 lives, Hard = 1 life
+void echoDiffLifeIndicatorCorrectCount(SignalEchoDifficultyTestSuite* suite) {
+    ASSERT_EQ(SIGNAL_ECHO_EASY.allowedMistakes, 3);
+    ASSERT_EQ(SIGNAL_ECHO_HARD.allowedMistakes, 1);
+}
+
+// Test: After EchoLose, session resets (currentRound=0, mistakes=0)
+void echoDiffFullResetOnLose(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    // Manually set some progress
+    game->getSession().currentRound = 2;
+    game->getSession().mistakes = 4;
+    game->getSession().score = 300;
+
+    // Go to Lose, then back to Intro
+    game->skipToState(5);  // EchoLose
+    // Wait for lose timer
+    std::this_thread::sleep_for(std::chrono::milliseconds(3500));
+    for (int i = 0; i < 5; i++) {
+        device.pdn->loop();
+        device.game->loop();
+    }
+
+    // Should be back at Intro, which resets the session
+    State* state = game->getCurrentState();
+    if (state->getStateId() == ECHO_INTRO) {
+        // Intro resets session and game outcome
+        ASSERT_EQ(game->getSession().currentRound, 0);
+        ASSERT_EQ(game->getSession().mistakes, 0);
+        ASSERT_EQ(game->getOutcome().result, MiniGameResult::IN_PROGRESS);
+    } else {
+        // If still at Lose (timer might not have expired in some environments),
+        // at least verify the lose outcome was set
+        ASSERT_EQ(game->getOutcome().result, MiniGameResult::LOST);
+    }
+
+    suite->destroyDevice(device);
+}
+
+// Test: Easy mode win unlocks Konami button (outcome.result = WON)
+void echoDiffEasyModeWinUnlocksKonami(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    config.numSequences = 1;
+    config.sequenceLength = 2;
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    game->getSession().currentSequence = {true, false};
+    game->getSession().inputIndex = 0;
+    game->getSession().currentRound = 0;
+
+    game->skipToState(2);  // PlayerInput
+    device.pdn->loop();
+    device.game->loop();
+
+    // Correct inputs
+    device.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    device.pdn->loop();
+    device.game->loop();
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    for (int i = 0; i < 5; i++) {
+        device.pdn->loop();
+        device.game->loop();
+    }
+
+    ASSERT_EQ(game->getOutcome().result, MiniGameResult::WON);
+    // Easy mode win — hardMode should be false
+    ASSERT_FALSE(game->getOutcome().hardMode);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Hard mode win sets hardMode flag
+void echoDiffHardModeWinUnlocksColorProfile(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_HARD;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    config.numSequences = 1;
+    // Keep sequenceLength = 8 (the hard mode default) so hardMode detection passes
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    // Set a known 8-element sequence
+    game->getSession().currentSequence = {true, false, true, false, true, false, true, false};
+    game->getSession().inputIndex = 0;
+    game->getSession().currentRound = 0;
+
+    game->skipToState(2);
+    device.pdn->loop();
+    device.game->loop();
+
+    // Enter all 8 correct inputs
+    for (int i = 0; i < 8; i++) {
+        bool expected = game->getSession().currentSequence[i];
+        if (expected) {
+            device.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+        } else {
+            device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+        }
+        device.pdn->loop();
+        device.game->loop();
+    }
+
+    // Process through Evaluate to Win
+    for (int i = 0; i < 5; i++) {
+        device.pdn->loop();
+        device.game->loop();
+    }
+
+    ASSERT_EQ(game->getOutcome().result, MiniGameResult::WON);
+    ASSERT_TRUE(game->getOutcome().hardMode);
+
+    suite->destroyDevice(device);
+}
+
+// Test: LED flashes red on mistake
+void echoDiffLedFlashesRedOnMistake(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    game->getSession().currentSequence = {true, true, true, true};
+    game->getSession().inputIndex = 0;
+
+    game->skipToState(2);
+    device.pdn->loop();
+    device.game->loop();
+
+    // Wrong press — should trigger red LED via LightManager
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    device.pdn->loop();
+    device.game->loop();
+
+    // Verify mistake was registered
+    ASSERT_EQ(game->getSession().mistakes, 1);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Haptic buzz on mistake
+void echoDiffHapticBuzzOnMistake(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    auto device = suite->createDevice(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    game->getSession().currentSequence = {true, true, true, true};
+    game->getSession().inputIndex = 0;
+
+    game->skipToState(2);
+    device.pdn->loop();
+    device.game->loop();
+
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    device.pdn->loop();
+    device.game->loop();
+
+    // Verify mistake was registered (haptics would be triggered in handleInput)
+    ASSERT_EQ(game->getSession().mistakes, 1);
+
+    suite->destroyDevice(device);
+}

--- a/test/test_cli/signal-echo-tests.hpp
+++ b/test/test_cli/signal-echo-tests.hpp
@@ -801,8 +801,8 @@ void echoDiffHardModeWinUnlocksColorProfile(SignalEchoDifficultyTestSuite* suite
     suite->destroyDevice(device);
 }
 
-// Test: LED flashes red on mistake
-void echoDiffLedFlashesRedOnMistake(SignalEchoDifficultyTestSuite* suite) {
+// Test: Wrong input registers a mistake
+void echoDiffMistakeIsRegistered(SignalEchoDifficultyTestSuite* suite) {
     SignalEchoConfig config = SIGNAL_ECHO_EASY;
     config.rngSeed = 42;
     config.displaySpeedMs = 10;
@@ -816,37 +816,12 @@ void echoDiffLedFlashesRedOnMistake(SignalEchoDifficultyTestSuite* suite) {
     device.pdn->loop();
     device.game->loop();
 
-    // Wrong press — should trigger red LED via LightManager
+    // Wrong press — should register mistake (triggers LED flash + haptic buzz)
     device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
     device.pdn->loop();
     device.game->loop();
 
     // Verify mistake was registered
-    ASSERT_EQ(game->getSession().mistakes, 1);
-
-    suite->destroyDevice(device);
-}
-
-// Test: Haptic buzz on mistake
-void echoDiffHapticBuzzOnMistake(SignalEchoDifficultyTestSuite* suite) {
-    SignalEchoConfig config = SIGNAL_ECHO_EASY;
-    config.rngSeed = 42;
-    config.displaySpeedMs = 10;
-    auto device = suite->createDevice(config);
-    auto* game = dynamic_cast<SignalEcho*>(device.game);
-
-    game->getSession().currentSequence = {true, true, true, true};
-    game->getSession().inputIndex = 0;
-
-    game->skipToState(2);
-    device.pdn->loop();
-    device.game->loop();
-
-    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
-    device.pdn->loop();
-    device.game->loop();
-
-    // Verify mistake was registered (haptics would be triggered in handleInput)
     ASSERT_EQ(game->getSession().mistakes, 1);
 
     suite->destroyDevice(device);

--- a/test/test_cli/sm-manager-tests.hpp
+++ b/test/test_cli/sm-manager-tests.hpp
@@ -1,0 +1,189 @@
+//
+// StateMachineManager Tests — verify pause/load/resume lifecycle
+// and outcome storage when swapping between Quickdraw and minigames.
+//
+
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "state/state-machine-manager.hpp"
+#include "game/test-minigame.hpp"
+
+// ============================================
+// SM MANAGER TEST SUITE
+// ============================================
+
+class SmManagerTestSuite : public testing::Test {
+public:
+    cli::DeviceInstance device_;
+
+    void SetUp() override {
+        device_ = cli::DeviceFactory::createDevice(0, true);
+        // Run a few loops to get past initial states
+        for (int i = 0; i < 5; i++) {
+            device_.pdn->loop();
+            device_.game->loop();
+        }
+        // Skip to Idle (stateMap index 7)
+        device_.game->skipToState(7);
+    }
+
+    void TearDown() override {
+        cli::DeviceFactory::destroyDevice(device_);
+    }
+};
+
+// Test: SM Manager delegates to default SM when no minigame is active
+void smManagerDefaultLoop(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    // Verify default SM is active
+    ASSERT_EQ(manager.getActive(), suite->device_.game);
+    ASSERT_FALSE(manager.isSwapped());
+
+    // Loop should delegate to default SM without crashing
+    manager.loop();
+
+    // Still on default SM
+    ASSERT_EQ(manager.getActive(), suite->device_.game);
+}
+
+// Test: pauseAndLoad swaps to minigame and sets isSwapped true
+void smManagerPauseAndLoad(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* miniGame = new TestMiniGame(suite->device_.pdn, MiniGameResult::WON);
+    manager.pauseAndLoad(miniGame, 7);
+
+    ASSERT_TRUE(manager.isSwapped());
+    ASSERT_EQ(manager.getActive(), miniGame);
+}
+
+// Test: Auto-resume happens when minigame signals readyForResume
+void smManagerAutoResume(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* miniGame = new TestMiniGame(suite->device_.pdn, MiniGameResult::WON);
+    manager.pauseAndLoad(miniGame, 7);
+
+    // Trigger the minigame to complete
+    miniGame->triggerComplete();
+
+    // One loop: transitions from Intro to Complete (sets readyForResume)
+    manager.loop();
+    // Another loop: the SM Manager detects readyForResume and auto-resumes
+    // (may happen in the same loop if the transition+mount+readyForResume
+    //  all fire in one cycle — but let's be safe and loop again)
+    if (manager.isSwapped()) {
+        manager.loop();
+    }
+
+    ASSERT_FALSE(manager.isSwapped());
+    ASSERT_EQ(manager.getActive(), suite->device_.game);
+}
+
+// Test: After auto-resume, outcome and gameType are stored
+void smManagerOutcomeStored(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* miniGame = new TestMiniGame(suite->device_.pdn, MiniGameResult::WON);
+    manager.pauseAndLoad(miniGame, 7);
+
+    miniGame->triggerComplete();
+    manager.loop();
+    if (manager.isSwapped()) {
+        manager.loop();
+    }
+
+    ASSERT_FALSE(manager.isSwapped());
+    ASSERT_EQ(manager.getLastOutcome().result, MiniGameResult::WON);
+    ASSERT_EQ(manager.getLastOutcome().score, 42);
+    ASSERT_EQ(manager.getLastGameType(), GameType::SIGNAL_ECHO);
+}
+
+// Test: After resume, default SM is at the resumeStateIndex
+void smManagerResumeToCorrectState(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    // Resume to stateMap index 7 (Idle, stateId = 8)
+    auto* miniGame = new TestMiniGame(suite->device_.pdn, MiniGameResult::WON);
+    manager.pauseAndLoad(miniGame, 7);
+
+    miniGame->triggerComplete();
+    manager.loop();
+    if (manager.isSwapped()) {
+        manager.loop();
+    }
+
+    ASSERT_FALSE(manager.isSwapped());
+    // Verify we're back at Idle (stateId 8 based on the Quickdraw state map)
+    State* currentState = suite->device_.game->getCurrentState();
+    ASSERT_NE(currentState, nullptr);
+    ASSERT_EQ(currentState->getStateId(), 8);
+}
+
+// Test: After resume, swapped flag is false (game was deleted)
+void smManagerDeletesSwappedGame(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* miniGame = new TestMiniGame(suite->device_.pdn, MiniGameResult::WON);
+    manager.pauseAndLoad(miniGame, 7);
+
+    miniGame->triggerComplete();
+    manager.loop();
+    if (manager.isSwapped()) {
+        manager.loop();
+    }
+
+    // The swapped game should be deleted — verify via isSwapped() == false
+    ASSERT_FALSE(manager.isSwapped());
+    // getActive() should return the default SM, not a dangling pointer
+    ASSERT_EQ(manager.getActive(), suite->device_.game);
+}
+
+// Test: Pause with WON result, verify outcome after resume
+void smManagerPauseAndLoadWon(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* miniGame = new TestMiniGame(suite->device_.pdn, MiniGameResult::WON);
+    manager.pauseAndLoad(miniGame, 7);
+
+    miniGame->triggerComplete();
+    manager.loop();
+    if (manager.isSwapped()) {
+        manager.loop();
+    }
+
+    ASSERT_EQ(manager.getLastOutcome().result, MiniGameResult::WON);
+    ASSERT_EQ(manager.getLastOutcome().score, 42);
+}
+
+// Test: Pause with LOST result, verify outcome after resume
+void smManagerPauseAndLoadLost(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* miniGame = new TestMiniGame(suite->device_.pdn, MiniGameResult::LOST);
+    manager.pauseAndLoad(miniGame, 7);
+
+    miniGame->triggerComplete();
+    manager.loop();
+    if (manager.isSwapped()) {
+        manager.loop();
+    }
+
+    ASSERT_EQ(manager.getLastOutcome().result, MiniGameResult::LOST);
+    ASSERT_EQ(manager.getLastOutcome().score, 42);
+}
+
+#endif // NATIVE_BUILD


### PR DESCRIPTION
## Summary

Implements the complete Challenge Device System for AlleyyCat PDN — all features from the master plan in issue #72.

### Deliverable 1: Features A/B/E (NPC + Signal Echo + Progress)

- **Feature A — NPC Device Infrastructure**: Device type enums, magic code detection (7001-7007), ChallengeGame state machine with 4 NPC states (Idle, Handshake, GameActive, ReceiveResult), NVS-based result caching, CLI integration with `--npc` flag and `spawn` command, Quickdraw idle-state `cdev:` detection, FetchUserData challenge code branching, main.cpp NVS mode check
- **Feature B — Signal Echo Game**: MiniGame base class, 6-state Signal Echo game (Intro, ShowSequence, PlayerInput, Evaluate, Win, Lose), difficulty presets (easy/hard), LED palettes and color profiles, CLI `--game` flag support
- **Feature E — Player Profile + Konami Progress**: Bitmask-based Konami button tracking on Player, color profile eligibility, server sync via PlayerResponse/FetchUserData/MockHttpServer, ProgressManager with NVS persistence and deferred upload

### Deliverable 2: CLI Automation + Features C/D (SM Manager + Integration)

- **CLI Automation Framework**: EventLogger (structured event capture with query API), ScriptRunner (text-file automation with assertions), CLI flags (`--script`, `--log`, `--headless`), debug commands (`advance`, `inspect`, `events`)
- **Feature C — StateMachineManager**: Thin orchestration layer that pauses Quickdraw, loads a MiniGame, auto-resumes on completion. Stores outcome and game type for the resume state. TestMiniGame for isolated unit testing.
- **Feature D — Player-Challenge Integration**: ChallengeDetected state (MAC handshake + cack protocol + minigame loading), ChallengeComplete state (win/loss display + Konami unlock + progress save), Idle state fix (cdev detection no longer triggers duel handshake), Player pending challenge fields, full SM Manager wiring in ESP32 main.cpp and CLI simulator

## Test plan

- [x] 220 CLI tests pass (`pio test -e native_cli_test`)
- [x] CLI simulator builds (`pio run -e native_cli`)
- [x] ESP32 build passes CI (`pio run -e esp32-s3_debug`)
- [x] CI green (build-cli, build-esp32, test)
- [x] Dead code audit: zero issues
- [x] Embedded perf review: no ESP32 blockers, <1% heap usage
- [ ] Manual CLI simulator testing with `--npc signal-echo`
- [ ] Hardware testing of full challenge flow

## Commits (15)

**Features A/B/E (original):**
1. Device type enums, protocol constants, magic code detection
2. ChallengeGame state machine + NPC states + result manager
3. CLI integration, Quickdraw detection, FetchUserData branching, main.cpp NVS check
4. Player Konami progress + color profile extensions
5. Server sync — PlayerResponse, FetchUserData, MockHttpServer, ProgressManager
6. ProgressManager wiring + portability tests
7. MiniGame base class + Signal Echo game + CLI --game flag + tests
8. Add missing cstdint include to StorageInterface (CI fix)
9. Audit cleanup: remove dead code, unused includes, and redundant tests

**CLI Automation + Features C/D (new):**
10. EventLogger + driver event callbacks
11. ScriptRunner + debug commands + CLI flags
12. Feature A/B/E validation tests + serial cable broker same-role fix
13. StateMachineManager + TestMiniGame + readyForResume
14. ChallengeDetected + ChallengeComplete states + SM Manager wiring

Fixes #72