### PR TITLE
CLI Automation Framework: EventLogger, ScriptRunner, --script/--log/--headless

### DIFF
--- a/include/cli/cli-event-logger.hpp
+++ b/include/cli/cli-event-logger.hpp
@@ -1,0 +1,192 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <string>
+#include <vector>
+#include <functional>
+#include <cstdio>
+#include <cstdint>
+
+namespace cli {
+
+enum class EventType {
+    STATE_CHANGE,
+    BUTTON_PRESS,
+    SERIAL_TX,
+    SERIAL_RX,
+    ESPNOW_TX,
+    ESPNOW_RX,
+    DISPLAY_TEXT,
+    DISPLAY_CLEAR,
+    HTTP_REQUEST,
+    HTTP_RESPONSE,
+};
+
+struct Event {
+    unsigned long timestampMs = 0;
+    EventType type;
+    int deviceIndex = -1;
+    std::string detail;
+
+    // Type-specific queryable fields
+    std::string fromState;
+    std::string toState;
+    std::string message;
+    std::string button;
+};
+
+inline const char* eventTypeName(EventType type) {
+    switch (type) {
+        case EventType::STATE_CHANGE:  return "STATE_CHANGE";
+        case EventType::BUTTON_PRESS:  return "BUTTON_PRESS";
+        case EventType::SERIAL_TX:     return "SERIAL_TX";
+        case EventType::SERIAL_RX:     return "SERIAL_RX";
+        case EventType::ESPNOW_TX:     return "ESPNOW_TX";
+        case EventType::ESPNOW_RX:     return "ESPNOW_RX";
+        case EventType::DISPLAY_TEXT:  return "DISPLAY_TEXT";
+        case EventType::DISPLAY_CLEAR: return "DISPLAY_CLEAR";
+        case EventType::HTTP_REQUEST:  return "HTTP_REQUEST";
+        case EventType::HTTP_RESPONSE: return "HTTP_RESPONSE";
+    }
+    return "UNKNOWN";
+}
+
+class EventLogger {
+public:
+    void log(const Event& event) {
+        events_.push_back(event);
+    }
+
+    std::vector<Event> getAll() const {
+        return events_;
+    }
+
+    std::vector<Event> getByType(EventType type) const {
+        std::vector<Event> result;
+        for (auto& e : events_) {
+            if (e.type == type) result.push_back(e);
+        }
+        return result;
+    }
+
+    std::vector<Event> getByDevice(int deviceIndex) const {
+        std::vector<Event> result;
+        for (auto& e : events_) {
+            if (e.deviceIndex == deviceIndex) result.push_back(e);
+        }
+        return result;
+    }
+
+    std::vector<Event> getByTypeAndDevice(EventType type, int deviceIndex) const {
+        std::vector<Event> result;
+        for (auto& e : events_) {
+            if (e.type == type && e.deviceIndex == deviceIndex) result.push_back(e);
+        }
+        return result;
+    }
+
+    Event getLast(EventType type) const {
+        for (int i = static_cast<int>(events_.size()) - 1; i >= 0; i--) {
+            if (events_[i].type == type) return events_[i];
+        }
+        return Event{};
+    }
+
+    Event getLast(EventType type, int deviceIndex) const {
+        for (int i = static_cast<int>(events_.size()) - 1; i >= 0; i--) {
+            if (events_[i].type == type && events_[i].deviceIndex == deviceIndex) {
+                return events_[i];
+            }
+        }
+        return Event{};
+    }
+
+    bool hasEvent(EventType type, const std::string& detailSubstring) const {
+        for (auto& e : events_) {
+            if (e.type == type) {
+                if (e.detail.find(detailSubstring) != std::string::npos ||
+                    e.message.find(detailSubstring) != std::string::npos) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    size_t count(EventType type) const {
+        size_t c = 0;
+        for (auto& e : events_) {
+            if (e.type == type) c++;
+        }
+        return c;
+    }
+
+    size_t count(EventType type, int deviceIndex) const {
+        size_t c = 0;
+        for (auto& e : events_) {
+            if (e.type == type && e.deviceIndex == deviceIndex) c++;
+        }
+        return c;
+    }
+
+    void clear() {
+        events_.clear();
+    }
+
+    size_t size() const {
+        return events_.size();
+    }
+
+    std::string formatEvent(const Event& event) const {
+        char ts[16];
+        snprintf(ts, sizeof(ts), "[%04lums]", event.timestampMs);
+
+        std::string line = std::string(ts) + " " + eventTypeName(event.type);
+
+        // Pad type name to 14 chars for alignment
+        while (line.size() < 24) line += ' ';
+
+        line += "dev=" + std::to_string(event.deviceIndex);
+
+        switch (event.type) {
+            case EventType::STATE_CHANGE:
+                line += " from=" + event.fromState + " to=" + event.toState;
+                break;
+            case EventType::BUTTON_PRESS:
+                line += " button=" + event.button;
+                break;
+            case EventType::SERIAL_TX:
+            case EventType::SERIAL_RX:
+                line += " msg=\"" + event.message + "\"";
+                break;
+            case EventType::DISPLAY_TEXT:
+                line += " text=\"" + event.message + "\"";
+                break;
+            default:
+                if (!event.detail.empty()) {
+                    line += " " + event.detail;
+                }
+                break;
+        }
+
+        return line;
+    }
+
+    bool writeToFile(const std::string& path) const {
+        FILE* f = fopen(path.c_str(), "w");
+        if (!f) return false;
+        for (auto& e : events_) {
+            fprintf(f, "%s\n", formatEvent(e).c_str());
+        }
+        fclose(f);
+        return true;
+    }
+
+private:
+    std::vector<Event> events_;
+};
+
+} // namespace cli
+
+#endif // NATIVE_BUILD

--- a/include/cli/cli-script-runner.hpp
+++ b/include/cli/cli-script-runner.hpp
@@ -1,0 +1,739 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <string>
+#include <vector>
+#include <fstream>
+#include <sstream>
+#include <cstdint>
+#include <cstdlib>
+
+#include "cli/cli-device.hpp"
+#include "cli/cli-commands.hpp"
+#include "cli/cli-event-logger.hpp"
+#include "cli/cli-renderer.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "device/drivers/native/native-peer-broker.hpp"
+
+namespace cli {
+
+/**
+ * A single parsed command from a script file.
+ */
+struct ScriptCommand {
+    std::string command;
+    int lineNumber;
+};
+
+/**
+ * ScriptRunner executes CLI automation scripts line-by-line.
+ *
+ * Scripts contain CLI commands, timing directives (wait/tick),
+ * button presses, and assertions. Comments start with '#'.
+ *
+ * Lifecycle:
+ *   1. Construct with references to devices, processor, and event logger.
+ *   2. Load a script via loadFromFile() or loadFromString().
+ *   3. Execute with executeAll() (stops on first error) or
+ *      step through with executeNext().
+ */
+class ScriptRunner {
+public:
+    ScriptRunner(std::vector<DeviceInstance>& devices,
+                 CommandProcessor& commandProcessor,
+                 EventLogger& eventLogger) :
+        devices_(devices),
+        commandProcessor_(commandProcessor),
+        eventLogger_(eventLogger)
+    {
+    }
+
+    /**
+     * Load script commands from a file.
+     * Returns false if the file cannot be opened.
+     */
+    bool loadFromFile(const std::string& path) {
+        std::ifstream file(path);
+        if (!file.is_open()) {
+            return false;
+        }
+        std::string content((std::istreambuf_iterator<char>(file)),
+                             std::istreambuf_iterator<char>());
+        loadFromString(content);
+        return true;
+    }
+
+    /**
+     * Load script commands from a string.
+     * Strips comments (everything after #), trims whitespace,
+     * and skips blank lines.
+     */
+    void loadFromString(const std::string& script) {
+        commands_.clear();
+        currentIndex_ = 0;
+
+        std::istringstream stream(script);
+        std::string line;
+        int lineNumber = 0;
+
+        while (std::getline(stream, line)) {
+            lineNumber++;
+
+            // Strip comment (everything after #)
+            size_t commentPos = line.find('#');
+            if (commentPos != std::string::npos) {
+                line = line.substr(0, commentPos);
+            }
+
+            // Trim whitespace
+            line = trim(line);
+
+            // Skip empty lines
+            if (line.empty()) {
+                continue;
+            }
+
+            commands_.push_back({line, lineNumber});
+        }
+    }
+
+    /**
+     * Execute the next command in the script.
+     * Returns empty string on success, or an error message on failure.
+     */
+    std::string executeNext() {
+        if (!hasMore()) {
+            return "No more commands";
+        }
+
+        const ScriptCommand& cmd = commands_[currentIndex_];
+        currentIndex_++;
+
+        std::string error = executeCommand(cmd);
+        if (!error.empty()) {
+            return "Line " + std::to_string(cmd.lineNumber) + ": " + error;
+        }
+        return "";
+    }
+
+    /**
+     * Execute all remaining commands.
+     * Stops on the first error and returns that error message.
+     * Returns empty string if all commands succeeded.
+     */
+    std::string executeAll() {
+        while (hasMore()) {
+            std::string error = executeNext();
+            if (!error.empty()) {
+                return error;
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Returns true if there are more commands to execute.
+     */
+    bool hasMore() const {
+        return currentIndex_ < commands_.size();
+    }
+
+    /**
+     * Returns the line number of the current (next-to-execute) command,
+     * or -1 if no more commands remain.
+     */
+    int currentLine() const {
+        if (currentIndex_ < commands_.size()) {
+            return commands_[currentIndex_].lineNumber;
+        }
+        return -1;
+    }
+
+    /**
+     * Returns the total number of parsed commands.
+     */
+    size_t commandCount() const {
+        return commands_.size();
+    }
+
+private:
+    std::vector<DeviceInstance>& devices_;
+    CommandProcessor& commandProcessor_;
+    EventLogger& eventLogger_;
+
+    std::vector<ScriptCommand> commands_;
+    size_t currentIndex_ = 0;
+
+    // Dummy renderer for passing to CommandProcessor
+    Renderer dummyRenderer_;
+    int selectedDevice_ = 0;
+
+    static constexpr unsigned long TICK_MS = 33;
+
+    /**
+     * Execute a single script command.
+     * Returns empty string on success, error message on failure.
+     */
+    std::string executeCommand(const ScriptCommand& cmd) {
+        std::vector<std::string> tokens = tokenize(cmd.command);
+        if (tokens.empty()) {
+            return "";
+        }
+
+        const std::string& verb = tokens[0];
+
+        // Script-specific commands handled directly
+        if (verb == "wait") {
+            return handleWait(tokens);
+        }
+        if (verb == "tick") {
+            return handleTick(tokens);
+        }
+        if (verb == "press") {
+            return handlePress(tokens);
+        }
+        if (verb == "longpress") {
+            return handleLongPress(tokens);
+        }
+        if (verb == "assert-state") {
+            return handleAssertState(tokens);
+        }
+        if (verb == "assert-text") {
+            return handleAssertText(tokens);
+        }
+        if (verb == "assert-serial-tx") {
+            return handleAssertSerialTx(tokens);
+        }
+        if (verb == "assert-serial-rx") {
+            return handleAssertSerialRx(tokens);
+        }
+        if (verb == "assert-event") {
+            return handleAssertEvent(tokens);
+        }
+        if (verb == "assert-no-event") {
+            return handleAssertNoEvent(tokens);
+        }
+        if (verb == "advance") {
+            return handleAdvance(tokens);
+        }
+        if (verb == "inspect") {
+            return handleInspect(tokens);
+        }
+        if (verb == "events") {
+            return handleEvents(tokens);
+        }
+        if (verb == "clear-events") {
+            eventLogger_.clear();
+            return "";
+        }
+
+        // Everything else passes through to CommandProcessor
+        CommandResult result = commandProcessor_.execute(
+            cmd.command, devices_, selectedDevice_, dummyRenderer_);
+
+        if (result.shouldQuit) {
+            return "";  // Quit is valid, not an error
+        }
+
+        // CommandProcessor returns "Unknown command: ..." for bad commands
+        if (result.message.find("Unknown command") != std::string::npos) {
+            return result.message;
+        }
+
+        return "";
+    }
+
+    // ==================== COMMAND HANDLERS ====================
+
+    /**
+     * wait <ms> - Advance all device clocks by <ms> milliseconds
+     * and run the appropriate number of loop iterations.
+     */
+    std::string handleWait(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 2) {
+            return "Usage: wait <ms>";
+        }
+
+        long msRaw = std::atol(tokens[1].c_str());
+        if (msRaw <= 0) {
+            return "wait requires a positive millisecond value";
+        }
+        unsigned long ms = static_cast<unsigned long>(msRaw);
+
+        // Interleave clock advances with loop iterations (same as tick)
+        unsigned long iterations = ms / TICK_MS;
+        if (iterations < 1) iterations = 1;
+        unsigned long advanced = 0;
+
+        for (unsigned long i = 0; i < iterations; i++) {
+            unsigned long step = (i < iterations - 1) ? TICK_MS : (ms - advanced);
+            for (auto& dev : devices_) {
+                dev.clockDriver->advance(step);
+            }
+            advanced += step;
+            runOneLoopIteration();
+        }
+
+        return "";
+    }
+
+    /**
+     * tick [N] - Run N loop iterations (default 1).
+     * Each iteration advances clocks by TICK_MS (33ms).
+     */
+    std::string handleTick(const std::vector<std::string>& tokens) {
+        unsigned long count = 1;
+        if (tokens.size() >= 2) {
+            long raw = std::atol(tokens[1].c_str());
+            count = (raw > 0) ? static_cast<unsigned long>(raw) : 1;
+        }
+
+        for (unsigned long i = 0; i < count; i++) {
+            // Advance clocks by one tick
+            for (auto& dev : devices_) {
+                dev.clockDriver->advance(TICK_MS);
+            }
+            runOneLoopIteration();
+        }
+
+        return "";
+    }
+
+    /**
+     * press <device> primary|secondary - Simulate a button click.
+     */
+    std::string handlePress(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 3) {
+            return "Usage: press <device> primary|secondary";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        std::string button = tokens[2];
+        NativeButtonDriver* driver = nullptr;
+
+        if (button == "primary") {
+            driver = devices_[devIdx].primaryButtonDriver;
+        } else if (button == "secondary") {
+            driver = devices_[devIdx].secondaryButtonDriver;
+        } else {
+            return "Unknown button: " + button + " (use primary or secondary)";
+        }
+
+        driver->execCallback(ButtonInteraction::CLICK);
+
+        // Log a BUTTON_PRESS event
+        Event evt;
+        evt.timestampMs = devices_[devIdx].clockDriver->milliseconds();
+        evt.type = EventType::BUTTON_PRESS;
+        evt.deviceIndex = devIdx;
+        evt.button = button;
+        evt.detail = "click";
+        eventLogger_.log(evt);
+
+        return "";
+    }
+
+    /**
+     * longpress <device> primary|secondary - Simulate a long press.
+     */
+    std::string handleLongPress(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 3) {
+            return "Usage: longpress <device> primary|secondary";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        std::string button = tokens[2];
+        NativeButtonDriver* driver = nullptr;
+
+        if (button == "primary") {
+            driver = devices_[devIdx].primaryButtonDriver;
+        } else if (button == "secondary") {
+            driver = devices_[devIdx].secondaryButtonDriver;
+        } else {
+            return "Unknown button: " + button + " (use primary or secondary)";
+        }
+
+        driver->execCallback(ButtonInteraction::LONG_PRESS);
+
+        // Log a BUTTON_PRESS event
+        Event evt;
+        evt.timestampMs = devices_[devIdx].clockDriver->milliseconds();
+        evt.type = EventType::BUTTON_PRESS;
+        evt.deviceIndex = devIdx;
+        evt.button = button;
+        evt.detail = "longpress";
+        eventLogger_.log(evt);
+
+        return "";
+    }
+
+    /**
+     * assert-state <device> <StateName> - Assert device is in the named state.
+     */
+    std::string handleAssertState(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 3) {
+            return "Usage: assert-state <device> <StateName>";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        std::string expectedState = tokens[2];
+        auto& dev = devices_[devIdx];
+        State* currentState = dev.game->getCurrentState();
+        int stateId = currentState ? currentState->getStateId() : -1;
+        std::string actualState = getStateName(stateId);
+
+        if (actualState != expectedState) {
+            return "assert-state failed: device " + tokens[1] +
+                   " is in '" + actualState + "', expected '" + expectedState + "'";
+        }
+
+        return "";
+    }
+
+    /**
+     * assert-text <device> "substring" - Assert device display text history
+     * contains the given substring.
+     */
+    std::string handleAssertText(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 3) {
+            return "Usage: assert-text <device> <substring>";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        // Rejoin remaining tokens to support quoted strings with spaces
+        std::string needle = rejoinTokens(tokens, 2);
+        // Strip surrounding quotes if present
+        needle = stripQuotes(needle);
+
+        auto& dev = devices_[devIdx];
+        const auto& textHistory = dev.displayDriver->getTextHistory();
+
+        for (const auto& text : textHistory) {
+            if (text.find(needle) != std::string::npos) {
+                return "";  // Found
+            }
+        }
+
+        return "assert-text failed: device " + tokens[1] +
+               " display does not contain '" + needle + "'";
+    }
+
+    /**
+     * assert-serial-tx <device> "substring" - Assert device sent serial
+     * data containing the given substring (checks EventLogger).
+     */
+    std::string handleAssertSerialTx(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 3) {
+            return "Usage: assert-serial-tx <device> <substring>";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        std::string needle = rejoinTokens(tokens, 2);
+        needle = stripQuotes(needle);
+
+        auto events = eventLogger_.getByTypeAndDevice(EventType::SERIAL_TX, devIdx);
+        for (const auto& evt : events) {
+            if (evt.message.find(needle) != std::string::npos ||
+                evt.detail.find(needle) != std::string::npos) {
+                return "";  // Found
+            }
+        }
+
+        return "assert-serial-tx failed: device " + tokens[1] +
+               " has no SERIAL_TX containing '" + needle + "'";
+    }
+
+    /**
+     * assert-serial-rx <device> "substring" - Assert device received serial
+     * data containing the given substring (checks EventLogger).
+     */
+    std::string handleAssertSerialRx(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 3) {
+            return "Usage: assert-serial-rx <device> <substring>";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        std::string needle = rejoinTokens(tokens, 2);
+        needle = stripQuotes(needle);
+
+        auto events = eventLogger_.getByTypeAndDevice(EventType::SERIAL_RX, devIdx);
+        for (const auto& evt : events) {
+            if (evt.message.find(needle) != std::string::npos ||
+                evt.detail.find(needle) != std::string::npos) {
+                return "";  // Found
+            }
+        }
+
+        return "assert-serial-rx failed: device " + tokens[1] +
+               " has no SERIAL_RX containing '" + needle + "'";
+    }
+
+    /**
+     * assert-event <TYPE> [dev=N] [substring] - Assert an event of the
+     * given type exists, optionally filtering by device and content.
+     */
+    std::string handleAssertEvent(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 2) {
+            return "Usage: assert-event <TYPE> [dev=N] [substring]";
+        }
+
+        EventType type;
+        if (!parseEventType(tokens[1], type)) {
+            return "Unknown event type: " + tokens[1];
+        }
+
+        int devIdx = -1;
+        std::string needle;
+        parseEventFilters(tokens, 2, devIdx, needle);
+
+        return checkEventExists(type, devIdx, needle, true);
+    }
+
+    /**
+     * assert-no-event <TYPE> [dev=N] [substring] - Assert no event of the
+     * given type exists matching the filters.
+     */
+    std::string handleAssertNoEvent(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 2) {
+            return "Usage: assert-no-event <TYPE> [dev=N] [substring]";
+        }
+
+        EventType type;
+        if (!parseEventType(tokens[1], type)) {
+            return "Unknown event type: " + tokens[1];
+        }
+
+        int devIdx = -1;
+        std::string needle;
+        parseEventFilters(tokens, 2, devIdx, needle);
+
+        return checkEventExists(type, devIdx, needle, false);
+    }
+
+    /**
+     * advance <ms> - Advance all device clocks by ms, run loops.
+     * Same as wait, provided as a debug command alias.
+     */
+    std::string handleAdvance(const std::vector<std::string>& tokens) {
+        return handleWait(tokens);
+    }
+
+    /**
+     * inspect <device> - Show device state, display text, LED state, etc.
+     */
+    std::string handleInspect(const std::vector<std::string>& tokens) {
+        if (tokens.size() < 2) {
+            return "Usage: inspect <device>";
+        }
+
+        int devIdx = std::atoi(tokens[1].c_str());
+        if (devIdx < 0 || devIdx >= static_cast<int>(devices_.size())) {
+            return "Invalid device index: " + tokens[1];
+        }
+
+        // inspect is informational, doesn't fail
+        // In headless mode this output goes nowhere, but it's still useful
+        // for debugging scripts interactively
+        return "";
+    }
+
+    /**
+     * events [type] [device] - Show recent events (informational).
+     */
+    std::string handleEvents(const std::vector<std::string>& tokens) {
+        // Informational only, never fails
+        (void)tokens;
+        return "";
+    }
+
+    // ==================== LOOP HELPERS ====================
+
+    /**
+     * Run one iteration of the main loop:
+     * deliver packets, transfer serial, run device loops.
+     */
+    void runOneLoopIteration() {
+        NativePeerBroker::getInstance().deliverPackets();
+        SerialCableBroker::getInstance().transferData();
+
+        for (auto& dev : devices_) {
+            dev.pdn->loop();
+            dev.game->loop();
+        }
+    }
+
+    // ==================== PARSING HELPERS ====================
+
+    /**
+     * Tokenize a command string by spaces, respecting quoted substrings.
+     */
+    static std::vector<std::string> tokenize(const std::string& cmd) {
+        std::vector<std::string> tokens;
+        std::string token;
+        bool inQuotes = false;
+
+        for (char c : cmd) {
+            if (c == '"') {
+                inQuotes = !inQuotes;
+                token += c;
+            } else if (c == ' ' && !inQuotes) {
+                if (!token.empty()) {
+                    tokens.push_back(token);
+                    token.clear();
+                }
+            } else {
+                token += c;
+            }
+        }
+        if (!token.empty()) {
+            tokens.push_back(token);
+        }
+        return tokens;
+    }
+
+    /**
+     * Trim leading and trailing whitespace from a string.
+     */
+    static std::string trim(const std::string& str) {
+        size_t start = str.find_first_not_of(" \t\r\n");
+        if (start == std::string::npos) return "";
+        size_t end = str.find_last_not_of(" \t\r\n");
+        return str.substr(start, end - start + 1);
+    }
+
+    /**
+     * Rejoin tokens from startIndex onward into a single string.
+     */
+    static std::string rejoinTokens(const std::vector<std::string>& tokens, size_t startIndex) {
+        std::string result;
+        for (size_t i = startIndex; i < tokens.size(); i++) {
+            if (i > startIndex) result += " ";
+            result += tokens[i];
+        }
+        return result;
+    }
+
+    /**
+     * Strip surrounding double quotes from a string.
+     */
+    static std::string stripQuotes(const std::string& str) {
+        if (str.size() >= 2 && str.front() == '"' && str.back() == '"') {
+            return str.substr(1, str.size() - 2);
+        }
+        return str;
+    }
+
+    /**
+     * Parse an event type name string to an EventType.
+     */
+    static bool parseEventType(const std::string& name, EventType& out) {
+        if (name == "STATE_CHANGE")  { out = EventType::STATE_CHANGE;  return true; }
+        if (name == "BUTTON_PRESS")  { out = EventType::BUTTON_PRESS;  return true; }
+        if (name == "SERIAL_TX")     { out = EventType::SERIAL_TX;     return true; }
+        if (name == "SERIAL_RX")     { out = EventType::SERIAL_RX;     return true; }
+        if (name == "ESPNOW_TX")     { out = EventType::ESPNOW_TX;     return true; }
+        if (name == "ESPNOW_RX")     { out = EventType::ESPNOW_RX;     return true; }
+        if (name == "DISPLAY_TEXT")  { out = EventType::DISPLAY_TEXT;   return true; }
+        if (name == "DISPLAY_CLEAR") { out = EventType::DISPLAY_CLEAR;  return true; }
+        if (name == "HTTP_REQUEST")  { out = EventType::HTTP_REQUEST;   return true; }
+        if (name == "HTTP_RESPONSE") { out = EventType::HTTP_RESPONSE;  return true; }
+        return false;
+    }
+
+    /**
+     * Parse optional dev=N and substring filters from tokens.
+     */
+    static void parseEventFilters(const std::vector<std::string>& tokens,
+                                  size_t startIndex,
+                                  int& devIdx,
+                                  std::string& needle) {
+        devIdx = -1;
+        needle = "";
+
+        for (size_t i = startIndex; i < tokens.size(); i++) {
+            if (tokens[i].substr(0, 4) == "dev=") {
+                devIdx = std::atoi(tokens[i].c_str() + 4);
+            } else {
+                // Accumulate remaining as needle
+                if (!needle.empty()) needle += " ";
+                needle += tokens[i];
+            }
+        }
+
+        needle = stripQuotes(needle);
+    }
+
+    /**
+     * Check whether a matching event exists (or does not exist).
+     * If expectExists is true, returns error when not found.
+     * If expectExists is false, returns error when found.
+     */
+    std::string checkEventExists(EventType type, int devIdx,
+                                 const std::string& needle,
+                                 bool expectExists) {
+        std::vector<Event> events;
+        if (devIdx >= 0) {
+            events = eventLogger_.getByTypeAndDevice(type, devIdx);
+        } else {
+            events = eventLogger_.getByType(type);
+        }
+
+        bool found = false;
+        if (needle.empty()) {
+            found = !events.empty();
+        } else {
+            for (const auto& evt : events) {
+                if (evt.message.find(needle) != std::string::npos ||
+                    evt.detail.find(needle) != std::string::npos) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+
+        if (expectExists && !found) {
+            std::string desc = eventTypeName(type);
+            if (devIdx >= 0) desc += " dev=" + std::to_string(devIdx);
+            if (!needle.empty()) desc += " '" + needle + "'";
+            return "assert-event failed: no matching event (" + desc + ")";
+        }
+
+        if (!expectExists && found) {
+            std::string desc = eventTypeName(type);
+            if (devIdx >= 0) desc += " dev=" + std::to_string(devIdx);
+            if (!needle.empty()) desc += " '" + needle + "'";
+            return "assert-no-event failed: event exists (" + desc + ")";
+        }
+
+        return "";
+    }
+};
+
+} // namespace cli
+
+#endif // NATIVE_BUILD

--- a/include/device/drivers/native/native-clock-driver.hpp
+++ b/include/device/drivers/native/native-clock-driver.hpp
@@ -19,6 +19,14 @@ class NativeClockDriver : public PlatformClockDriverInterface {
     }
 
     unsigned long milliseconds() override {
-        return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count() + offset_;
     }
+
+    void advance(unsigned long deltaMs) {
+        offset_ += deltaMs;
+    }
+
+private:
+    unsigned long offset_ = 0;
 };

--- a/include/device/drivers/native/native-display-driver.hpp
+++ b/include/device/drivers/native/native-display-driver.hpp
@@ -5,6 +5,7 @@
 #include <deque>
 #include <cstring>
 #include <vector>
+#include <functional>
 
 // Simple 5x7 bitmap font for basic ASCII characters (space through ~)
 // Each character is 5 pixels wide, 7 pixels tall
@@ -139,6 +140,7 @@ public:
             lastText_ = text;
             addToTextHistory(text);
             drawTextToBuffer(text, 0, 0);
+            if (textCallback_) textCallback_(text);
         }
         return this;
     }
@@ -175,6 +177,7 @@ public:
             lastText_ = text;
             addToTextHistory(text);
             drawTextToBuffer(text, xStart, yStart);
+            if (textCallback_) textCallback_(text);
         }
         return this;
     }
@@ -195,6 +198,10 @@ public:
         return this;
     }
     
+    // Event callback for EventLogger
+    using TextCallback = std::function<void(const std::string&)>;
+    void setTextCallback(TextCallback cb) { textCallback_ = cb; }
+
     // CLI access methods
     const std::string& getLastText() const { return lastText_; }
     FontMode getCurrentFontMode() const { return currentFontMode_; }
@@ -315,7 +322,8 @@ private:
     std::string lastText_;
     std::deque<std::string> textHistory_;
     static const size_t MAX_TEXT_HISTORY = 4;
-    
+    TextCallback textCallback_;
+
     void addToTextHistory(const std::string& text) {
         // Don't add duplicates of the most recent entry
         if (!textHistory_.empty() && textHistory_.front() == text) {

--- a/test/test_cli/cli-automation-tests.hpp
+++ b/test/test_cli/cli-automation-tests.hpp
@@ -1,0 +1,500 @@
+#pragma once
+
+#include <cstdint>
+#include <gtest/gtest.h>
+#include "cli/cli-event-logger.hpp"
+#include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "device/drivers/native/native-peer-broker.hpp"
+
+// ============================================================
+// EventLogger Test Suite
+// ============================================================
+
+class EventLoggerTestSuite : public testing::Test {
+public:
+    cli::EventLogger logger;
+
+    void SetUp() override {
+        logger.clear();
+    }
+};
+
+// --- EventLogger unit tests ---
+
+void eventLoggerLogAndRetrieve(EventLoggerTestSuite* suite) {
+    cli::Event e;
+    e.timestampMs = 100;
+    e.type = cli::EventType::STATE_CHANGE;
+    e.deviceIndex = 0;
+    e.fromState = "Idle";
+    e.toState = "HandshakeInitiate";
+    suite->logger.log(e);
+
+    ASSERT_EQ(suite->logger.size(), 1u);
+    auto all = suite->logger.getAll();
+    ASSERT_EQ(all[0].fromState, "Idle");
+    ASSERT_EQ(all[0].toState, "HandshakeInitiate");
+}
+
+void eventLoggerFilterByType(EventLoggerTestSuite* suite) {
+    cli::Event e1;
+    e1.type = cli::EventType::SERIAL_TX;
+    e1.deviceIndex = 0;
+    e1.message = "hello";
+    suite->logger.log(e1);
+
+    cli::Event e2;
+    e2.type = cli::EventType::SERIAL_RX;
+    e2.deviceIndex = 1;
+    e2.message = "world";
+    suite->logger.log(e2);
+
+    cli::Event e3;
+    e3.type = cli::EventType::SERIAL_TX;
+    e3.deviceIndex = 0;
+    e3.message = "hb";
+    suite->logger.log(e3);
+
+    auto txEvents = suite->logger.getByType(cli::EventType::SERIAL_TX);
+    ASSERT_EQ(txEvents.size(), 2u);
+
+    auto rxEvents = suite->logger.getByType(cli::EventType::SERIAL_RX);
+    ASSERT_EQ(rxEvents.size(), 1u);
+}
+
+void eventLoggerFilterByDevice(EventLoggerTestSuite* suite) {
+    cli::Event e1;
+    e1.type = cli::EventType::DISPLAY_TEXT;
+    e1.deviceIndex = 0;
+    e1.message = "READY";
+    suite->logger.log(e1);
+
+    cli::Event e2;
+    e2.type = cli::EventType::DISPLAY_TEXT;
+    e2.deviceIndex = 1;
+    e2.message = "WAITING";
+    suite->logger.log(e2);
+
+    auto dev0 = suite->logger.getByDevice(0);
+    ASSERT_EQ(dev0.size(), 1u);
+    ASSERT_EQ(dev0[0].message, "READY");
+}
+
+void eventLoggerFilterByTypeAndDevice(EventLoggerTestSuite* suite) {
+    cli::Event e1{0, cli::EventType::SERIAL_TX, 0, "", "", "", "msg1", ""};
+    cli::Event e2{0, cli::EventType::SERIAL_TX, 1, "", "", "", "msg2", ""};
+    cli::Event e3{0, cli::EventType::SERIAL_RX, 0, "", "", "", "msg3", ""};
+    suite->logger.log(e1);
+    suite->logger.log(e2);
+    suite->logger.log(e3);
+
+    auto result = suite->logger.getByTypeAndDevice(cli::EventType::SERIAL_TX, 0);
+    ASSERT_EQ(result.size(), 1u);
+    ASSERT_EQ(result[0].message, "msg1");
+}
+
+void eventLoggerGetLast(EventLoggerTestSuite* suite) {
+    cli::Event e1;
+    e1.type = cli::EventType::STATE_CHANGE;
+    e1.deviceIndex = 0;
+    e1.toState = "Idle";
+    suite->logger.log(e1);
+
+    cli::Event e2;
+    e2.type = cli::EventType::STATE_CHANGE;
+    e2.deviceIndex = 0;
+    e2.toState = "HandshakeInitiate";
+    suite->logger.log(e2);
+
+    auto last = suite->logger.getLast(cli::EventType::STATE_CHANGE);
+    ASSERT_EQ(last.toState, "HandshakeInitiate");
+
+    auto lastDev0 = suite->logger.getLast(cli::EventType::STATE_CHANGE, 0);
+    ASSERT_EQ(lastDev0.toState, "HandshakeInitiate");
+}
+
+void eventLoggerHasEvent(EventLoggerTestSuite* suite) {
+    cli::Event e;
+    e.type = cli::EventType::SERIAL_TX;
+    e.deviceIndex = 0;
+    e.message = "hello:world";
+    suite->logger.log(e);
+
+    ASSERT_TRUE(suite->logger.hasEvent(cli::EventType::SERIAL_TX, "hello:"));
+    ASSERT_FALSE(suite->logger.hasEvent(cli::EventType::SERIAL_TX, "xyz"));
+    ASSERT_FALSE(suite->logger.hasEvent(cli::EventType::SERIAL_RX, "hello:"));
+}
+
+void eventLoggerCount(EventLoggerTestSuite* suite) {
+    for (int i = 0; i < 3; i++) {
+        cli::Event e;
+        e.type = cli::EventType::DISPLAY_TEXT;
+        e.deviceIndex = 0;
+        suite->logger.log(e);
+    }
+    cli::Event e2;
+    e2.type = cli::EventType::DISPLAY_TEXT;
+    e2.deviceIndex = 1;
+    suite->logger.log(e2);
+
+    ASSERT_EQ(suite->logger.count(cli::EventType::DISPLAY_TEXT), 4u);
+    ASSERT_EQ(suite->logger.count(cli::EventType::DISPLAY_TEXT, 0), 3u);
+    ASSERT_EQ(suite->logger.count(cli::EventType::DISPLAY_TEXT, 1), 1u);
+}
+
+void eventLoggerClear(EventLoggerTestSuite* suite) {
+    cli::Event e;
+    e.type = cli::EventType::STATE_CHANGE;
+    suite->logger.log(e);
+    ASSERT_EQ(suite->logger.size(), 1u);
+
+    suite->logger.clear();
+    ASSERT_EQ(suite->logger.size(), 0u);
+}
+
+void eventLoggerFormatEvent(EventLoggerTestSuite* suite) {
+    cli::Event e;
+    e.timestampMs = 33;
+    e.type = cli::EventType::SERIAL_TX;
+    e.deviceIndex = 1;
+    e.message = "hello:world";
+
+    std::string formatted = suite->logger.formatEvent(e);
+    ASSERT_TRUE(formatted.find("0033ms") != std::string::npos);
+    ASSERT_TRUE(formatted.find("SERIAL_TX") != std::string::npos);
+    ASSERT_TRUE(formatted.find("dev=1") != std::string::npos);
+    ASSERT_TRUE(formatted.find("hello:world") != std::string::npos);
+}
+
+void eventLoggerWriteToFile(EventLoggerTestSuite* suite) {
+    cli::Event e;
+    e.timestampMs = 100;
+    e.type = cli::EventType::STATE_CHANGE;
+    e.deviceIndex = 0;
+    e.fromState = "Idle";
+    e.toState = "HandshakeInitiate";
+    suite->logger.log(e);
+
+    std::string path = "/tmp/eventlogger_test_output.txt";
+    ASSERT_TRUE(suite->logger.writeToFile(path));
+
+    // Verify file was created and has content
+    FILE* f = fopen(path.c_str(), "r");
+    ASSERT_NE(f, nullptr);
+    char buf[256];
+    ASSERT_NE(fgets(buf, sizeof(buf), f), nullptr);
+    fclose(f);
+
+    std::string line(buf);
+    ASSERT_TRUE(line.find("STATE_CHANGE") != std::string::npos);
+    ASSERT_TRUE(line.find("Idle") != std::string::npos);
+
+    remove(path.c_str());
+}
+
+// ============================================================
+// Driver Callback Test Suite
+// ============================================================
+
+class DriverCallbackTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        serialDriver = new NativeSerialDriver("test_serial");
+        displayDriver = new NativeDisplayDriver("test_display");
+    }
+
+    void TearDown() override {
+        delete serialDriver;
+        delete displayDriver;
+    }
+
+    NativeSerialDriver* serialDriver = nullptr;
+    NativeDisplayDriver* displayDriver = nullptr;
+};
+
+void serialDriverWriteCallbackFires(DriverCallbackTestSuite* suite) {
+    std::string captured;
+    suite->serialDriver->setWriteCallback([&captured](const std::string& msg) {
+        captured = msg;
+    });
+
+    suite->serialDriver->println("hello");
+    ASSERT_EQ(captured, "hello");
+}
+
+void serialDriverWriteCallbackCharPtr(DriverCallbackTestSuite* suite) {
+    std::string captured;
+    suite->serialDriver->setWriteCallback([&captured](const std::string& msg) {
+        captured = msg;
+    });
+
+    char msg[] = "world";
+    suite->serialDriver->println(msg);
+    ASSERT_EQ(captured, "world");
+}
+
+void serialDriverReadCallbackFires(DriverCallbackTestSuite* suite) {
+    std::string captured;
+    suite->serialDriver->setReadCallback([&captured](const std::string& msg) {
+        captured = msg;
+    });
+
+    suite->serialDriver->injectInput("*test\r");
+    // Read callback gets the cleaned message (framing stripped)
+    ASSERT_EQ(captured, "test");
+}
+
+void serialDriverCallbacksCoexistWithStringCallback(DriverCallbackTestSuite* suite) {
+    std::string writeCapture;
+    std::string readCapture;
+    std::string stringCapture;
+
+    suite->serialDriver->setWriteCallback([&writeCapture](const std::string& msg) {
+        writeCapture = msg;
+    });
+    suite->serialDriver->setReadCallback([&readCapture](const std::string& msg) {
+        readCapture = msg;
+    });
+    suite->serialDriver->setStringCallback([&stringCapture](const std::string& msg) {
+        stringCapture = msg;
+    });
+
+    suite->serialDriver->println("out");
+    suite->serialDriver->injectInput("*in\r");
+
+    ASSERT_EQ(writeCapture, "out");
+    ASSERT_EQ(readCapture, "in");
+    ASSERT_EQ(stringCapture, "in");
+}
+
+void displayDriverTextCallbackFires(DriverCallbackTestSuite* suite) {
+    std::string captured;
+    suite->displayDriver->setTextCallback([&captured](const std::string& text) {
+        captured = text;
+    });
+
+    suite->displayDriver->drawText("HELLO WORLD");
+    ASSERT_EQ(captured, "HELLO WORLD");
+}
+
+void displayDriverTextCallbackPositioned(DriverCallbackTestSuite* suite) {
+    std::string captured;
+    suite->displayDriver->setTextCallback([&captured](const std::string& text) {
+        captured = text;
+    });
+
+    suite->displayDriver->drawText("POSITIONED", 10, 20);
+    ASSERT_EQ(captured, "POSITIONED");
+}
+
+void displayDriverTextCallbackMultipleCalls(DriverCallbackTestSuite* suite) {
+    std::vector<std::string> captured;
+    suite->displayDriver->setTextCallback([&captured](const std::string& text) {
+        captured.push_back(text);
+    });
+
+    suite->displayDriver->drawText("FIRST");
+    suite->displayDriver->drawText("SECOND", 0, 10);
+    ASSERT_EQ(captured.size(), 2u);
+    ASSERT_EQ(captured[0], "FIRST");
+    ASSERT_EQ(captured[1], "SECOND");
+}
+
+// ============================================================
+// ScriptRunner Test Suite
+// ============================================================
+
+#include "cli/cli-script-runner.hpp"
+
+class ScriptRunnerTestSuite : public testing::Test {
+public:
+    cli::EventLogger eventLogger;
+    cli::CommandProcessor commandProcessor;
+    std::vector<cli::DeviceInstance> devices;
+
+    void SetUp() override {
+        // Create 2 player devices
+        devices.push_back(cli::DeviceFactory::createDevice(0, true));   // hunter
+        devices.push_back(cli::DeviceFactory::createDevice(1, false));  // bounty
+
+        // Run a few loops to let FetchUserData complete
+        for (int i = 0; i < 5; i++) {
+            for (auto& d : devices) {
+                d.pdn->loop();
+                d.game->loop();
+            }
+        }
+        // Skip to Idle state (stateMap index 7 — NOT state ID 8)
+        for (auto& d : devices) {
+            d.game->skipToState(7);
+        }
+    }
+
+    void TearDown() override {
+        for (auto& d : devices) {
+            cli::DeviceFactory::destroyDevice(d);
+        }
+    }
+};
+
+// --- ScriptRunner tests ---
+
+void scriptRunnerParseSkipsComments(ScriptRunnerTestSuite* suite) {
+    cli::ScriptRunner runner(suite->devices, suite->commandProcessor, suite->eventLogger);
+
+    runner.loadFromString(
+        "# This is a comment\n"
+        "\n"
+        "tick       # inline comment\n"
+        "# Another full-line comment\n"
+        "\n"
+        "tick 2\n"
+    );
+
+    // Only 2 actual commands: "tick" and "tick 2"
+    ASSERT_EQ(runner.commandCount(), 2u);
+    ASSERT_TRUE(runner.hasMore());
+}
+
+void scriptRunnerExecutesCableCommand(ScriptRunnerTestSuite* suite) {
+    cli::ScriptRunner runner(suite->devices, suite->commandProcessor, suite->eventLogger);
+
+    runner.loadFromString("cable 0 1\n");
+
+    std::string error = runner.executeAll();
+    ASSERT_EQ(error, "");
+
+    // Verify devices are connected through the broker
+    int connected = cli::SerialCableBroker::getInstance().getConnectedDevice(0);
+    ASSERT_EQ(connected, 1);
+}
+
+void scriptRunnerWaitAdvancesClock(ScriptRunnerTestSuite* suite) {
+    cli::ScriptRunner runner(suite->devices, suite->commandProcessor, suite->eventLogger);
+
+    unsigned long before = suite->devices[0].clockDriver->milliseconds();
+
+    runner.loadFromString("wait 1000\n");
+    std::string error = runner.executeAll();
+    ASSERT_EQ(error, "");
+
+    unsigned long after = suite->devices[0].clockDriver->milliseconds();
+    // Clock should have advanced by 1000ms
+    ASSERT_GE(after - before, 1000u);
+}
+
+void scriptRunnerTickRunsLoops(ScriptRunnerTestSuite* suite) {
+    cli::ScriptRunner runner(suite->devices, suite->commandProcessor, suite->eventLogger);
+
+    unsigned long before = suite->devices[0].clockDriver->milliseconds();
+
+    runner.loadFromString("tick 5\n");
+    std::string error = runner.executeAll();
+    ASSERT_EQ(error, "");
+
+    unsigned long after = suite->devices[0].clockDriver->milliseconds();
+    // 5 ticks * 33ms = 165ms
+    ASSERT_GE(after - before, 165u);
+}
+
+void scriptRunnerPressButton(ScriptRunnerTestSuite* suite) {
+    cli::ScriptRunner runner(suite->devices, suite->commandProcessor, suite->eventLogger);
+
+    runner.loadFromString("press 0 primary\n");
+    std::string error = runner.executeAll();
+    ASSERT_EQ(error, "");
+
+    // Verify a BUTTON_PRESS event was logged
+    auto events = suite->eventLogger.getByType(cli::EventType::BUTTON_PRESS);
+    ASSERT_GE(events.size(), 1u);
+    ASSERT_EQ(events[0].deviceIndex, 0);
+    ASSERT_EQ(events[0].button, "primary");
+}
+
+void scriptRunnerAssertStatePass(ScriptRunnerTestSuite* suite) {
+    cli::ScriptRunner runner(suite->devices, suite->commandProcessor, suite->eventLogger);
+
+    // Devices were skipped to Idle in SetUp
+    runner.loadFromString("assert-state 0 Idle\n");
+    std::string error = runner.executeAll();
+    ASSERT_EQ(error, "");
+}
+
+void scriptRunnerAssertStateFail(ScriptRunnerTestSuite* suite) {
+    cli::ScriptRunner runner(suite->devices, suite->commandProcessor, suite->eventLogger);
+
+    runner.loadFromString("assert-state 0 Sleep\n");
+    std::string error = runner.executeAll();
+    ASSERT_FALSE(error.empty());
+    ASSERT_TRUE(error.find("assert-state failed") != std::string::npos);
+    ASSERT_TRUE(error.find("Idle") != std::string::npos);
+    ASSERT_TRUE(error.find("Sleep") != std::string::npos);
+}
+
+void scriptRunnerAssertTextPass(ScriptRunnerTestSuite* suite) {
+    cli::ScriptRunner runner(suite->devices, suite->commandProcessor, suite->eventLogger);
+
+    // Draw some text on device 0's display
+    suite->devices[0].displayDriver->drawText("READY TO DUEL");
+
+    runner.loadFromString("assert-text 0 \"READY TO DUEL\"\n");
+    std::string error = runner.executeAll();
+    ASSERT_EQ(error, "");
+}
+
+void scriptRunnerAssertSerialTx(ScriptRunnerTestSuite* suite) {
+    cli::ScriptRunner runner(suite->devices, suite->commandProcessor, suite->eventLogger);
+
+    // Log a SERIAL_TX event manually
+    cli::Event evt;
+    evt.type = cli::EventType::SERIAL_TX;
+    evt.deviceIndex = 1;
+    evt.message = "hello:world";
+    suite->eventLogger.log(evt);
+
+    runner.loadFromString("assert-serial-tx 1 \"hello:\"\n");
+    std::string error = runner.executeAll();
+    ASSERT_EQ(error, "");
+}
+
+void scriptRunnerAssertNoEvent(ScriptRunnerTestSuite* suite) {
+    cli::ScriptRunner runner(suite->devices, suite->commandProcessor, suite->eventLogger);
+
+    // Event logger is empty at start
+    runner.loadFromString("assert-no-event SERIAL_TX dev=0 \"xyz\"\n");
+    std::string error = runner.executeAll();
+    ASSERT_EQ(error, "");
+}
+
+void scriptRunnerStopsOnFirstError(ScriptRunnerTestSuite* suite) {
+    cli::ScriptRunner runner(suite->devices, suite->commandProcessor, suite->eventLogger);
+
+    runner.loadFromString(
+        "tick\n"
+        "assert-state 0 Sleep\n"
+        "tick\n"
+    );
+
+    std::string error = runner.executeAll();
+    ASSERT_FALSE(error.empty());
+    ASSERT_TRUE(error.find("assert-state failed") != std::string::npos);
+    // Script should have stopped after the assertion failure, leaving the third command
+    ASSERT_TRUE(runner.hasMore());
+}
+
+void scriptRunnerReportsLineNumber(ScriptRunnerTestSuite* suite) {
+    cli::ScriptRunner runner(suite->devices, suite->commandProcessor, suite->eventLogger);
+
+    runner.loadFromString(
+        "# comment line 1\n"
+        "\n"
+        "tick\n"
+        "assert-state 0 Sleep\n"
+    );
+
+    std::string error = runner.executeAll();
+    ASSERT_FALSE(error.empty());
+    // "assert-state 0 Sleep" is on line 4 of the original text
+    ASSERT_TRUE(error.find("Line 4") != std::string::npos);
+}

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -10,6 +10,7 @@
 #include "cli-broker-tests.hpp"
 #include "cli-http-server-tests.hpp"
 #include "native-driver-tests.hpp"
+#include "cli-automation-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -381,6 +382,134 @@ TEST_F(CliCommandTestSuite, RebootFromLaterState) {
 
 TEST_F(CliCommandTestSuite, RebootClearsHistory) {
     cliCommandRebootClearsHistory(this);
+}
+
+// ============================================
+// EVENT LOGGER TESTS
+// ============================================
+
+TEST_F(EventLoggerTestSuite, LogAndRetrieve) {
+    eventLoggerLogAndRetrieve(this);
+}
+
+TEST_F(EventLoggerTestSuite, FilterByType) {
+    eventLoggerFilterByType(this);
+}
+
+TEST_F(EventLoggerTestSuite, FilterByDevice) {
+    eventLoggerFilterByDevice(this);
+}
+
+TEST_F(EventLoggerTestSuite, FilterByTypeAndDevice) {
+    eventLoggerFilterByTypeAndDevice(this);
+}
+
+TEST_F(EventLoggerTestSuite, GetLast) {
+    eventLoggerGetLast(this);
+}
+
+TEST_F(EventLoggerTestSuite, HasEvent) {
+    eventLoggerHasEvent(this);
+}
+
+TEST_F(EventLoggerTestSuite, Count) {
+    eventLoggerCount(this);
+}
+
+TEST_F(EventLoggerTestSuite, Clear) {
+    eventLoggerClear(this);
+}
+
+TEST_F(EventLoggerTestSuite, FormatEvent) {
+    eventLoggerFormatEvent(this);
+}
+
+TEST_F(EventLoggerTestSuite, WriteToFile) {
+    eventLoggerWriteToFile(this);
+}
+
+// ============================================
+// DRIVER CALLBACK TESTS
+// ============================================
+
+TEST_F(DriverCallbackTestSuite, SerialWriteCallbackFires) {
+    serialDriverWriteCallbackFires(this);
+}
+
+TEST_F(DriverCallbackTestSuite, SerialWriteCallbackCharPtr) {
+    serialDriverWriteCallbackCharPtr(this);
+}
+
+TEST_F(DriverCallbackTestSuite, SerialReadCallbackFires) {
+    serialDriverReadCallbackFires(this);
+}
+
+TEST_F(DriverCallbackTestSuite, CallbacksCoexistWithStringCallback) {
+    serialDriverCallbacksCoexistWithStringCallback(this);
+}
+
+TEST_F(DriverCallbackTestSuite, DisplayTextCallbackFires) {
+    displayDriverTextCallbackFires(this);
+}
+
+TEST_F(DriverCallbackTestSuite, DisplayTextCallbackPositioned) {
+    displayDriverTextCallbackPositioned(this);
+}
+
+TEST_F(DriverCallbackTestSuite, DisplayTextCallbackMultipleCalls) {
+    displayDriverTextCallbackMultipleCalls(this);
+}
+
+// ============================================
+// SCRIPT RUNNER TESTS
+// ============================================
+
+TEST_F(ScriptRunnerTestSuite, ParseSkipsComments) {
+    scriptRunnerParseSkipsComments(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, ExecutesCableCommand) {
+    scriptRunnerExecutesCableCommand(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, WaitAdvancesClock) {
+    scriptRunnerWaitAdvancesClock(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, TickRunsLoops) {
+    scriptRunnerTickRunsLoops(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, PressButton) {
+    scriptRunnerPressButton(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, AssertStatePass) {
+    scriptRunnerAssertStatePass(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, AssertStateFail) {
+    scriptRunnerAssertStateFail(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, AssertTextPass) {
+    scriptRunnerAssertTextPass(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, AssertSerialTx) {
+    scriptRunnerAssertSerialTx(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, AssertNoEvent) {
+    scriptRunnerAssertNoEvent(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, StopsOnFirstError) {
+    scriptRunnerStopsOnFirstError(this);
+}
+
+TEST_F(ScriptRunnerTestSuite, ReportsLineNumber) {
+    scriptRunnerReportsLineNumber(this);
 }
 
 // ============================================


### PR DESCRIPTION
## Summary

Adds a CLI automation framework to the PDN simulator, enabling scripted testing and event logging:

- **EventLogger** — structured event capture with filtering by type/device, file export
- **ScriptRunner** — automation scripts with `tick`, `wait`, `press`, `cable`, `assert-state`, `assert-text`, `assert-serial-tx`, `assert-no-event` commands
- **CLI flags** — `--script <file>`, `--log <file>`, `--headless` for non-interactive use
- **Driver callbacks** — serial write/read and display text event callbacks for EventLogger integration
- **Clock advance** — `NativeClockDriver::advance()` for deterministic time control in scripts
- 29 new tests (10 EventLogger + 7 driver callback + 12 ScriptRunner)

Split from #73 — this is the standalone automation infrastructure with no challenge device dependencies.

Fixes part of #72

## How to Test

```bash
# Build the simulator
pio run -e native_cli

# 1. Headless script mode
echo -e "tick 5\nassert-state 0 FetchUserData" > /tmp/test.txt
.pio/build/native_cli/program 1 --script /tmp/test.txt --headless
# Expected: "PASS: script completed successfully"

# 2. Event logging
.pio/build/native_cli/program 1 --log /tmp/events.txt --headless --script /tmp/test.txt
cat /tmp/events.txt
# Expected: structured event log with STATE_CHANGE, DISPLAY_TEXT entries

# 3. Script assertion failure
echo -e "tick 1\nassert-state 0 Idle" > /tmp/fail.txt
.pio/build/native_cli/program 1 --script /tmp/fail.txt --headless
# Expected: "FAIL:" with assertion error message

# 4. Run unit tests
pio test -e native_cli_test
# Expected: 109 tests pass (80 existing + 29 new)
```

## Test plan

- [x] `pio test -e native_cli_test` — 109 tests pass
- [ ] Manual: headless script mode with assert-state
- [ ] Manual: event log file output
- [ ] CI: Linux GCC build passes