### PR TITLE
StateMachineManager: pause/resume lifecycle for swappable games

### DIFF
--- a/include/game/test-swappable-game.hpp
+++ b/include/game/test-swappable-game.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#ifdef UNIT_TEST
+
+#include "state/state-machine-manager.hpp"
+#include "state/state.hpp"
+
+/*
+ * TestSwappableGame — a trivial 2-state game for testing the SM Manager.
+ *
+ * State 0: TestGameIntro — waits until triggerComplete() is called.
+ * State 1: TestGameComplete — sets outcome and signals readyForResume.
+ *
+ * This class is guarded by UNIT_TEST and should never appear in production builds.
+ */
+
+class TestSwappableGame;  // Forward declaration
+
+static const int TEST_GAME_INTRO_STATE_ID = 200;
+static const int TEST_GAME_COMPLETE_STATE_ID = 201;
+static const int TEST_GAME_ID = 99;
+
+class TestGameIntro : public State {
+public:
+    TestGameIntro() : State(TEST_GAME_INTRO_STATE_ID) {}
+    void onStateMounted(Device* PDN) override {}
+    void onStateLoop(Device* PDN) override {}
+    void onStateDismounted(Device* PDN) override {}
+};
+
+class TestGameComplete : public State {
+public:
+    TestGameComplete(TestSwappableGame* game, int resultToSet) :
+        State(TEST_GAME_COMPLETE_STATE_ID),
+        game_(game),
+        resultToSet_(resultToSet)
+    {
+    }
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override {}
+    void onStateDismounted(Device* PDN) override {}
+    bool isTerminalState() override { return true; }
+
+private:
+    TestSwappableGame* game_;
+    int resultToSet_;
+};
+
+class TestSwappableGame : public SwappableGame {
+public:
+    TestSwappableGame(Device* device, int resultToSet = SwappableOutcome::WON) :
+        SwappableGame(device),
+        resultToSet_(resultToSet)
+    {
+    }
+
+    void populateStateMap() override {
+        auto* intro = new TestGameIntro();
+        auto* complete = new TestGameComplete(this, resultToSet_);
+
+        intro->addTransition(new StateTransition(
+            [this]() { return triggerFlag_; },
+            complete
+        ));
+
+        stateMap.push_back(intro);
+        stateMap.push_back(complete);
+    }
+
+    bool isReadyForResume() const override { return readyForResume_; }
+    SwappableOutcome getOutcome() const override { return outcome_; }
+    int getGameId() const override { return TEST_GAME_ID; }
+
+    void setOutcome(const SwappableOutcome& o) { outcome_ = o; }
+    void setReadyForResume(bool ready) { readyForResume_ = ready; }
+
+    void triggerComplete() {
+        triggerFlag_ = true;
+    }
+
+private:
+    SwappableOutcome outcome_;
+    bool readyForResume_ = false;
+    int resultToSet_;
+    bool triggerFlag_ = false;
+};
+
+inline void TestGameComplete::onStateMounted(Device* PDN) {
+    SwappableOutcome out;
+    out.result = resultToSet_;
+    out.score = 42;
+    game_->setOutcome(out);
+    game_->setReadyForResume(true);
+}
+
+#endif // UNIT_TEST

--- a/include/state/state-machine-manager.hpp
+++ b/include/state/state-machine-manager.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "state/state-machine.hpp"
+
+/*
+ * SwappableOutcome — lightweight result from a completed swappable game.
+ * Uses plain ints so the SM Manager has no dependency on game-specific enums.
+ */
+struct SwappableOutcome {
+    static constexpr int IN_PROGRESS = 0;
+    static constexpr int WON = 1;
+    static constexpr int LOST = 2;
+
+    int result = IN_PROGRESS;
+    int score = 0;
+    bool isComplete() const { return result != IN_PROGRESS; }
+};
+
+/*
+ * SwappableGame — the contract a game must satisfy to be managed by
+ * the StateMachineManager. Extends StateMachine with completion signaling.
+ *
+ * Concrete games (e.g. MiniGame) implement this interface.
+ * The SM Manager never needs to know the concrete type.
+ */
+class SwappableGame : public StateMachine {
+public:
+    using StateMachine::StateMachine;
+    virtual ~SwappableGame() = default;
+
+    virtual bool isReadyForResume() const = 0;
+    virtual SwappableOutcome getOutcome() const = 0;
+    virtual int getGameId() const = 0;
+};
+
+/*
+ * StateMachineManager manages transitions between the default state machine
+ * (e.g. Quickdraw) and temporary swappable game state machines.
+ *
+ * When a swap is triggered, the SM Manager:
+ * 1. Pauses the current default state machine (dismounts current state)
+ * 2. Loads and initializes the swappable game
+ * 3. Runs the game until it signals readyForResume
+ * 4. Auto-resumes the default state machine at a specified state index
+ *
+ * The SM Manager does NOT own the default state machine. It DOES own
+ * the swapped game and deletes it on resume.
+ */
+class StateMachineManager {
+public:
+    explicit StateMachineManager(Device* device);
+    ~StateMachineManager();
+
+    void setDefaultStateMachine(StateMachine* sm);
+
+    /*
+     * Pause the default SM and load a swappable game.
+     * Takes ownership of 'game' (will delete on resume).
+     */
+    void pauseAndLoad(SwappableGame* game, int resumeStateIndex);
+
+    /*
+     * Resume the default SM after a game completes.
+     * Stores outcome, deletes the game, skips default SM to resumeStateIndex.
+     */
+    void resumePrevious();
+
+    /*
+     * Main loop — delegates to whichever SM is active.
+     * Auto-calls resumePrevious() when the swapped game signals readyForResume.
+     */
+    void loop();
+
+    StateMachine* getActive() const;
+    bool isSwapped() const;
+    SwappableOutcome getLastOutcome() const;
+    int getLastGameId() const;
+
+private:
+    Device* device;
+    StateMachine* defaultSM = nullptr;    // NOT owned
+    SwappableGame* swappedSM = nullptr;   // OWNED (deleted on resume)
+    bool swapped = false;
+    int resumeStateIndex_ = -1;
+    SwappableOutcome lastOutcome_;
+    int lastGameId_ = 0;
+};

--- a/src/state/state-machine-manager.cpp
+++ b/src/state/state-machine-manager.cpp
@@ -1,0 +1,85 @@
+#include "state/state-machine-manager.hpp"
+
+StateMachineManager::StateMachineManager(Device* device) :
+    device(device)
+{
+}
+
+StateMachineManager::~StateMachineManager() {
+    if (swappedSM) {
+        delete swappedSM;
+        swappedSM = nullptr;
+    }
+}
+
+void StateMachineManager::setDefaultStateMachine(StateMachine* sm) {
+    defaultSM = sm;
+}
+
+void StateMachineManager::pauseAndLoad(SwappableGame* game, int resumeStateIndex) {
+    if (!defaultSM || !game) return;
+
+    // Dismount the current state on the default SM
+    if (defaultSM->getCurrentState()) {
+        defaultSM->getCurrentState()->onStateDismounted(device);
+    }
+
+    // Store resume point
+    resumeStateIndex_ = resumeStateIndex;
+
+    // Take ownership of the swappable game
+    swappedSM = game;
+    swappedSM->initialize();
+    swapped = true;
+}
+
+void StateMachineManager::resumePrevious() {
+    if (!swapped || !swappedSM || !defaultSM) return;
+
+    // Store outcome from the completed game
+    lastOutcome_ = swappedSM->getOutcome();
+    lastGameId_ = swappedSM->getGameId();
+
+    // Dismount the swapped game's current state
+    if (swappedSM->getCurrentState()) {
+        swappedSM->getCurrentState()->onStateDismounted(device);
+    }
+
+    // Delete the game (we own it)
+    delete swappedSM;
+    swappedSM = nullptr;
+
+    // Resume the default SM at the stored index
+    defaultSM->skipToState(resumeStateIndex_);
+    swapped = false;
+}
+
+void StateMachineManager::loop() {
+    if (swapped && swappedSM) {
+        swappedSM->loop();
+        if (swappedSM->isReadyForResume()) {
+            resumePrevious();
+        }
+    } else if (defaultSM) {
+        defaultSM->loop();
+    }
+}
+
+StateMachine* StateMachineManager::getActive() const {
+    if (swapped && swappedSM) {
+        return swappedSM;
+    }
+    return defaultSM;
+}
+
+bool StateMachineManager::isSwapped() const {
+    return swapped;
+}
+
+SwappableOutcome StateMachineManager::getLastOutcome() const {
+    return lastOutcome_;
+}
+
+int StateMachineManager::getLastGameId() const {
+    return lastGameId_;
+}

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -10,6 +10,7 @@
 #include "cli-broker-tests.hpp"
 #include "cli-http-server-tests.hpp"
 #include "native-driver-tests.hpp"
+#include "sm-manager-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -381,6 +382,42 @@ TEST_F(CliCommandTestSuite, RebootFromLaterState) {
 
 TEST_F(CliCommandTestSuite, RebootClearsHistory) {
     cliCommandRebootClearsHistory(this);
+}
+
+// ============================================
+// STATE MACHINE MANAGER TESTS
+// ============================================
+
+TEST_F(SmManagerTestSuite, DefaultLoop) {
+    smManagerDefaultLoop(this);
+}
+
+TEST_F(SmManagerTestSuite, PauseAndLoad) {
+    smManagerPauseAndLoad(this);
+}
+
+TEST_F(SmManagerTestSuite, AutoResume) {
+    smManagerAutoResume(this);
+}
+
+TEST_F(SmManagerTestSuite, OutcomeStored) {
+    smManagerOutcomeStored(this);
+}
+
+TEST_F(SmManagerTestSuite, ResumeToCorrectState) {
+    smManagerResumeToCorrectState(this);
+}
+
+TEST_F(SmManagerTestSuite, DeletesSwappedGame) {
+    smManagerDeletesSwappedGame(this);
+}
+
+TEST_F(SmManagerTestSuite, PauseAndLoadWon) {
+    smManagerPauseAndLoadWon(this);
+}
+
+TEST_F(SmManagerTestSuite, PauseAndLoadLost) {
+    smManagerPauseAndLoadLost(this);
 }
 
 // ============================================

--- a/test/test_cli/sm-manager-tests.hpp
+++ b/test/test_cli/sm-manager-tests.hpp
@@ -1,0 +1,177 @@
+//
+// StateMachineManager Tests — verify pause/load/resume lifecycle
+// and outcome storage when swapping between default SM and games.
+//
+
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "state/state-machine-manager.hpp"
+#include "game/test-swappable-game.hpp"
+
+// ============================================
+// SM MANAGER TEST SUITE
+// ============================================
+
+class SmManagerTestSuite : public testing::Test {
+public:
+    cli::DeviceInstance device_;
+
+    void SetUp() override {
+        device_ = cli::DeviceFactory::createDevice(0, true);
+        // Run a few loops to get past initial states
+        for (int i = 0; i < 5; i++) {
+            device_.pdn->loop();
+            device_.game->loop();
+        }
+        // Skip to Idle (stateMap index 7)
+        device_.game->skipToState(7);
+    }
+
+    void TearDown() override {
+        cli::DeviceFactory::destroyDevice(device_);
+    }
+};
+
+// Test: SM Manager delegates to default SM when no game is active
+void smManagerDefaultLoop(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    ASSERT_EQ(manager.getActive(), suite->device_.game);
+    ASSERT_FALSE(manager.isSwapped());
+
+    manager.loop();
+
+    ASSERT_EQ(manager.getActive(), suite->device_.game);
+}
+
+// Test: pauseAndLoad swaps to game and sets isSwapped true
+void smManagerPauseAndLoad(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* game = new TestSwappableGame(suite->device_.pdn, SwappableOutcome::WON);
+    manager.pauseAndLoad(game, 7);
+
+    ASSERT_TRUE(manager.isSwapped());
+    ASSERT_EQ(manager.getActive(), game);
+}
+
+// Test: Auto-resume happens when game signals readyForResume
+void smManagerAutoResume(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* game = new TestSwappableGame(suite->device_.pdn, SwappableOutcome::WON);
+    manager.pauseAndLoad(game, 7);
+
+    game->triggerComplete();
+
+    manager.loop();
+    if (manager.isSwapped()) {
+        manager.loop();
+    }
+
+    ASSERT_FALSE(manager.isSwapped());
+    ASSERT_EQ(manager.getActive(), suite->device_.game);
+}
+
+// Test: After auto-resume, outcome and gameId are stored
+void smManagerOutcomeStored(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* game = new TestSwappableGame(suite->device_.pdn, SwappableOutcome::WON);
+    manager.pauseAndLoad(game, 7);
+
+    game->triggerComplete();
+    manager.loop();
+    if (manager.isSwapped()) {
+        manager.loop();
+    }
+
+    ASSERT_FALSE(manager.isSwapped());
+    ASSERT_EQ(manager.getLastOutcome().result, SwappableOutcome::WON);
+    ASSERT_EQ(manager.getLastOutcome().score, 42);
+    ASSERT_EQ(manager.getLastGameId(), TEST_GAME_ID);
+}
+
+// Test: After resume, default SM is at the resumeStateIndex
+void smManagerResumeToCorrectState(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* game = new TestSwappableGame(suite->device_.pdn, SwappableOutcome::WON);
+    manager.pauseAndLoad(game, 7);
+
+    game->triggerComplete();
+    manager.loop();
+    if (manager.isSwapped()) {
+        manager.loop();
+    }
+
+    ASSERT_FALSE(manager.isSwapped());
+    State* currentState = suite->device_.game->getCurrentState();
+    ASSERT_NE(currentState, nullptr);
+    ASSERT_EQ(currentState->getStateId(), 8);
+}
+
+// Test: After resume, swapped game was deleted
+void smManagerDeletesSwappedGame(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* game = new TestSwappableGame(suite->device_.pdn, SwappableOutcome::WON);
+    manager.pauseAndLoad(game, 7);
+
+    game->triggerComplete();
+    manager.loop();
+    if (manager.isSwapped()) {
+        manager.loop();
+    }
+
+    ASSERT_FALSE(manager.isSwapped());
+    ASSERT_EQ(manager.getActive(), suite->device_.game);
+}
+
+// Test: WON outcome stored correctly
+void smManagerPauseAndLoadWon(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* game = new TestSwappableGame(suite->device_.pdn, SwappableOutcome::WON);
+    manager.pauseAndLoad(game, 7);
+
+    game->triggerComplete();
+    manager.loop();
+    if (manager.isSwapped()) {
+        manager.loop();
+    }
+
+    ASSERT_EQ(manager.getLastOutcome().result, SwappableOutcome::WON);
+    ASSERT_EQ(manager.getLastOutcome().score, 42);
+}
+
+// Test: LOST outcome stored correctly
+void smManagerPauseAndLoadLost(SmManagerTestSuite* suite) {
+    StateMachineManager manager(suite->device_.pdn);
+    manager.setDefaultStateMachine(suite->device_.game);
+
+    auto* game = new TestSwappableGame(suite->device_.pdn, SwappableOutcome::LOST);
+    manager.pauseAndLoad(game, 7);
+
+    game->triggerComplete();
+    manager.loop();
+    if (manager.isSwapped()) {
+        manager.loop();
+    }
+
+    ASSERT_EQ(manager.getLastOutcome().result, SwappableOutcome::LOST);
+    ASSERT_EQ(manager.getLastOutcome().score, 42);
+}
+
+#endif // NATIVE_BUILD


### PR DESCRIPTION
## Summary

Adds the StateMachineManager — a generic coordinator for pausing the default state machine and loading temporary swappable games.

**Zero external dependencies.** The SM Manager defines its own contract:
- `SwappableOutcome` — lightweight result struct (int result, int score)
- `SwappableGame` — abstract interface extending StateMachine with `isReadyForResume()`, `getOutcome()`, `getGameId()`
- `StateMachineManager` — pause/load/resume lifecycle, auto-resume on completion, outcome storage

The test fixture (`TestSwappableGame`) implements `SwappableGame` directly — no game-specific types needed. The 8 tests verify the full lifecycle in isolation.

Concrete game classes (e.g. MiniGame for the challenge device system) will extend `SwappableGame` in a follow-up PR.

Fixes #74

## How to Test

```bash
pio test -e native_cli_test
# Verify: 8 new tests pass (DefaultLoop, PauseAndLoad, AutoResume,
# OutcomeStored, ResumeToCorrectState, DeletesSwappedGame,
# PauseAndLoadWon, PauseAndLoadLost)
```

## Test plan

- [x] `pio test -e native_cli_test` — 88 tests pass (80 existing + 8 new)
- [ ] CI: Linux GCC build passes