### PR TITLE
Add role CLI command

### DIFF
--- a/include/cli/cli-commands.hpp
+++ b/include/cli/cli-commands.hpp
@@ -613,7 +613,7 @@ private:
             }
             std::string out;
             for (size_t i = 0; i < devices.size(); i++) {
-                if (i > 0) out += "\n";
+                if (i > 0) out += " | ";
                 out += "Device " + devices[i].deviceId +
                        " [" + std::to_string(i) + "]: " +
                        (devices[i].isHunter ? "Hunter" : "Bounty");

--- a/include/cli/cli-commands.hpp
+++ b/include/cli/cli-commands.hpp
@@ -104,6 +104,9 @@ public:
         if (command == "reboot" || command == "restart") {
             return cmdReboot(tokens, devices, selectedDevice);
         }
+        if (command == "role" || command == "roles") {
+            return cmdRole(tokens, devices, selectedDevice);
+        }
 
         result.message = "Unknown command: " + command + " (try 'help')";
         return result;
@@ -114,7 +117,7 @@ private:
     
     static CommandResult cmdHelp(const std::vector<std::string>& /*tokens*/) {
         CommandResult result;
-        result.message = "Keys: LEFT/RIGHT=select, UP/DOWN=buttons | Cmds: help, quit, list, select, add, b/l, b2/l2, cable, peer, display, mirror, captions, reboot";
+        result.message = "Keys: LEFT/RIGHT=select, UP/DOWN=buttons | Cmds: help, quit, list, select, add, b/l, b2/l2, cable, peer, display, mirror, captions, reboot, role";
         return result;
     }
     
@@ -594,6 +597,46 @@ private:
         
         result.message = "Added " + devices.back().deviceId + 
                          " (" + (isHunter ? "Hunter" : "Bounty") + ") - now selected";
+        return result;
+    }
+
+    static CommandResult cmdRole(const std::vector<std::string>& tokens,
+                                 const std::vector<DeviceInstance>& devices,
+                                 int selectedDevice) {
+        CommandResult result;
+
+        // Handle "role all" - show all devices
+        if (tokens.size() >= 2 && tokens[1] == "all") {
+            if (devices.empty()) {
+                result.message = "No devices";
+                return result;
+            }
+            std::string out;
+            for (size_t i = 0; i < devices.size(); i++) {
+                if (i > 0) out += "\n";
+                out += "Device " + devices[i].deviceId +
+                       " [" + std::to_string(i) + "]: " +
+                       (devices[i].isHunter ? "Hunter" : "Bounty");
+            }
+            result.message = out;
+            return result;
+        }
+
+        // Determine target device
+        int targetDevice = selectedDevice;
+        if (tokens.size() >= 2) {
+            targetDevice = findDevice(tokens[1], devices, -1);
+        }
+
+        // Validate target device
+        if (targetDevice < 0 || targetDevice >= static_cast<int>(devices.size())) {
+            result.message = "Invalid device";
+            return result;
+        }
+
+        // Show single device role
+        result.message = "Device " + devices[targetDevice].deviceId + ": " +
+                         (devices[targetDevice].isHunter ? "Hunter" : "Bounty");
         return result;
     }
 

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -364,6 +364,34 @@ TEST_F(CliDisplayCommandTestSuite, DisplayAlias) {
 }
 
 // ============================================
+// CLI ROLE COMMAND TESTS
+// ============================================
+
+TEST_F(CliRoleCommandTestSuite, ShowsSelectedDevice) {
+    cliRoleCommandShowsSelectedDevice(this);
+}
+
+TEST_F(CliRoleCommandTestSuite, ShowsSpecificDevice) {
+    cliRoleCommandShowsSpecificDevice(this);
+}
+
+TEST_F(CliRoleCommandTestSuite, ShowsAllDevices) {
+    cliRoleCommandShowsAllDevices(this);
+}
+
+TEST_F(CliRoleCommandTestSuite, AliasWorks) {
+    cliRoleCommandAliasWorks(this);
+}
+
+TEST_F(CliRoleCommandTestSuite, InvalidDevice) {
+    cliRoleCommandInvalidDevice(this);
+}
+
+TEST_F(CliRoleCommandTestSuite, NoDevices) {
+    cliRoleCommandNoDevices(this);
+}
+
+// ============================================
 // CLI COMMAND / REBOOT TESTS
 // ============================================
 

--- a/test/test_cli/native-driver-tests.hpp
+++ b/test/test_cli/native-driver-tests.hpp
@@ -1068,7 +1068,7 @@ void cliRoleCommandShowsAllDevices(CliRoleCommandTestSuite* suite) {
                                              suite->selectedDevice_, *suite->renderer_);
 
     ASSERT_FALSE(result.shouldQuit);
-    ASSERT_EQ(result.message, "Device 0010 [0]: Hunter\nDevice 0011 [1]: Bounty");
+    ASSERT_EQ(result.message, "Device 0010 [0]: Hunter | Device 0011 [1]: Bounty");
 }
 
 // Test: roles alias works

--- a/test/test_cli/native-driver-tests.hpp
+++ b/test/test_cli/native-driver-tests.hpp
@@ -988,6 +988,123 @@ void cliCommandRebootFromLaterState(CliCommandTestSuite* suite) {
     ASSERT_EQ(suite->device_.game->getCurrentState()->getStateId(), WELCOME_MESSAGE);
 }
 
+// ============================================
+// CLI ROLE COMMAND TEST SUITE
+// ============================================
+
+class CliRoleCommandTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        globalClock_ = new NativeClockDriver("test_role_clock");
+        globalLogger_ = new NativeLoggerDriver("test_role_logger");
+        globalLogger_->setSuppressOutput(true);
+        g_logger = globalLogger_;
+        SimpleTimer::setPlatformClock(globalClock_);
+
+        // Create two devices - hunter and bounty
+        devices_.push_back(cli::DeviceFactory::createDevice(0, true));   // Hunter
+        devices_.push_back(cli::DeviceFactory::createDevice(1, false));  // Bounty
+
+        selectedDevice_ = 0;
+        processor_ = new cli::CommandProcessor();
+        renderer_ = new cli::Renderer();
+    }
+
+    void TearDown() override {
+        delete renderer_;
+        delete processor_;
+
+        for (auto& dev : devices_) {
+            cli::DeviceFactory::destroyDevice(dev);
+        }
+        devices_.clear();
+
+        SimpleTimer::setPlatformClock(nullptr);
+        g_logger = nullptr;
+        delete globalLogger_;
+        delete globalClock_;
+    }
+
+    std::vector<cli::DeviceInstance> devices_;
+    int selectedDevice_;
+    cli::CommandProcessor* processor_;
+    cli::Renderer* renderer_;
+    NativeClockDriver* globalClock_;
+    NativeLoggerDriver* globalLogger_;
+};
+
+// Test: role command shows selected device's role
+void cliRoleCommandShowsSelectedDevice(CliRoleCommandTestSuite* suite) {
+    // Selected device is 0 (hunter)
+    suite->selectedDevice_ = 0;
+    auto result = suite->processor_->execute("role", suite->devices_,
+                                             suite->selectedDevice_, *suite->renderer_);
+
+    ASSERT_FALSE(result.shouldQuit);
+    ASSERT_EQ(result.message, "Device 0010: Hunter");
+}
+
+// Test: role <device> shows specific device's role
+void cliRoleCommandShowsSpecificDevice(CliRoleCommandTestSuite* suite) {
+    // Request bounty device by index
+    suite->selectedDevice_ = 0;  // Hunter selected, but we ask for device 1
+    auto result = suite->processor_->execute("role 1", suite->devices_,
+                                             suite->selectedDevice_, *suite->renderer_);
+
+    ASSERT_FALSE(result.shouldQuit);
+    ASSERT_EQ(result.message, "Device 0011: Bounty");
+
+    // Request bounty device by ID
+    result = suite->processor_->execute("role 0011", suite->devices_,
+                                        suite->selectedDevice_, *suite->renderer_);
+
+    ASSERT_FALSE(result.shouldQuit);
+    ASSERT_EQ(result.message, "Device 0011: Bounty");
+}
+
+// Test: role all shows all devices
+void cliRoleCommandShowsAllDevices(CliRoleCommandTestSuite* suite) {
+    auto result = suite->processor_->execute("role all", suite->devices_,
+                                             suite->selectedDevice_, *suite->renderer_);
+
+    ASSERT_FALSE(result.shouldQuit);
+    ASSERT_EQ(result.message, "Device 0010 [0]: Hunter\nDevice 0011 [1]: Bounty");
+}
+
+// Test: roles alias works
+void cliRoleCommandAliasWorks(CliRoleCommandTestSuite* suite) {
+    suite->selectedDevice_ = 1;  // Bounty selected
+    auto result = suite->processor_->execute("roles", suite->devices_,
+                                             suite->selectedDevice_, *suite->renderer_);
+
+    ASSERT_FALSE(result.shouldQuit);
+    ASSERT_EQ(result.message, "Device 0011: Bounty");
+}
+
+// Test: role with invalid device shows error
+void cliRoleCommandInvalidDevice(CliRoleCommandTestSuite* suite) {
+    auto result = suite->processor_->execute("role 99", suite->devices_,
+                                             suite->selectedDevice_, *suite->renderer_);
+
+    ASSERT_FALSE(result.shouldQuit);
+    ASSERT_EQ(result.message, "Invalid device");
+}
+
+// Test: role all with no devices shows "No devices"
+void cliRoleCommandNoDevices(CliRoleCommandTestSuite* suite) {
+    // Clear devices
+    for (auto& dev : suite->devices_) {
+        cli::DeviceFactory::destroyDevice(dev);
+    }
+    suite->devices_.clear();
+
+    auto result = suite->processor_->execute("role all", suite->devices_,
+                                             suite->selectedDevice_, *suite->renderer_);
+
+    ASSERT_FALSE(result.shouldQuit);
+    ASSERT_EQ(result.message, "No devices");
+}
+
 // Test: Reboot clears state history and resets lastStateId
 void cliCommandRebootClearsHistory(CliCommandTestSuite* suite) {
     // Add some fake state history


### PR DESCRIPTION
## Summary

- Adds `role` command to the CLI simulator that displays device role (Hunter/Bounty)
- Supports three modes: `role` (selected device), `role <device>` (by index or ID), `role all` (list all)
- Accepts `roles` alias
- 6 new tests covering all modes, error handling, and edge cases

Fixes #79

## How to Test

```bash
# Build and run simulator
pio run -e native_cli
.pio/build/native_cli/program 2

# In simulator:
role          # Shows selected device's role
role 1        # Shows device 1's role
role 0011     # Shows device by ID
role all      # Lists all devices with roles
roles         # Alias works
help          # Should list 'role' in command list
```

```bash
# Run tests
pio test -e native_cli_test
# 6 new tests: ShowsSelectedDevice, ShowsSpecificDevice, ShowsAllDevices,
#              AliasWorks, InvalidDevice, NoDevices
```

## Test plan

- [x] All 86 CLI tests pass (`pio test -e native_cli_test`)
- [x] All 58 core tests pass (`pio test -e native`)
- [ ] Manual: `role`, `role 0`, `role 1`, `role all` in simulator
- [x] Manual: `help` shows `role` in command list
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)