### PR TITLE
FDN Detection + Progress Integration

### DIFF
--- a/include/cli/cli-device.hpp
+++ b/include/cli/cli-device.hpp
@@ -59,6 +59,8 @@ inline const char* getQuickdrawStateName(int stateId) {
         case 18: return "Win";
         case 19: return "Lose";
         case 20: return "UploadMatches";
+        case 21: return "FdnDetected";
+        case 22: return "FdnComplete";
         default: return "Unknown";
     }
 }
@@ -239,9 +241,13 @@ public:
         // Create game (no remote debug manager for now)
         instance.game = new Quickdraw(instance.player, instance.pdn, instance.quickdrawWirelessManager, nullptr);
 
+        // Create Signal Echo (pre-registered, configured lazily per encounter)
+        auto* signalEcho = new SignalEcho(SIGNAL_ECHO_EASY);
+
         // Register state machines with the device and launch Quickdraw
         AppConfig apps = {
-            {StateId(QUICKDRAW_APP_ID), instance.game}
+            {StateId(QUICKDRAW_APP_ID), instance.game},
+            {StateId(SIGNAL_ECHO_APP_ID), signalEcho}
         };
         instance.pdn->loadAppConfig(apps, StateId(QUICKDRAW_APP_ID));
         

--- a/include/game/player.hpp
+++ b/include/game/player.hpp
@@ -3,6 +3,8 @@
 #include <memory>
 #include <string>
 #include <iostream>
+#include <cstdint>
+#include <set>
 
 enum class Allegiance {
     ALLEYCAT = 0,
@@ -115,4 +117,44 @@ private:
     std::string opponentMacAddress;
     
     bool hunter = true;
+
+    // Challenge/FDN system
+    std::string pendingCdevMessage;
+    bool pendingChallenge = false;
+    uint8_t konamiProgress = 0;  // Bitmask of unlocked Konami buttons
+    int equippedColorProfile = -1;  // -1 = none, otherwise GameType value
+    std::set<int> colorProfileEligibility;  // GameTypes with hard mode beaten
+
+public:
+    // Pending FDN challenge (set by Idle, read by FdnDetected)
+    void setPendingChallenge(const std::string& cdevMessage) {
+        pendingCdevMessage = cdevMessage;
+        pendingChallenge = true;
+    }
+    bool hasPendingChallenge() const { return pendingChallenge; }
+    const std::string& getPendingCdevMessage() const { return pendingCdevMessage; }
+    void clearPendingChallenge() {
+        pendingCdevMessage.clear();
+        pendingChallenge = false;
+    }
+
+    // Konami progress
+    void unlockKonamiButton(uint8_t buttonIndex) {
+        konamiProgress |= (1 << buttonIndex);
+    }
+    bool hasUnlockedButton(uint8_t buttonIndex) const {
+        return (konamiProgress & (1 << buttonIndex)) != 0;
+    }
+    uint8_t getKonamiProgress() const { return konamiProgress; }
+    void setKonamiProgress(uint8_t progress) { konamiProgress = progress; }
+
+    // Color profile eligibility
+    void addColorProfileEligibility(int gameTypeValue) {
+        colorProfileEligibility.insert(gameTypeValue);
+    }
+    bool hasColorProfileEligibility(int gameTypeValue) const {
+        return colorProfileEligibility.count(gameTypeValue) > 0;
+    }
+    int getEquippedColorProfile() const { return equippedColorProfile; }
+    void setEquippedColorProfile(int gameTypeValue) { equippedColorProfile = gameTypeValue; }
 };

--- a/include/game/progress-manager.hpp
+++ b/include/game/progress-manager.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "game/player.hpp"
+#include "device/drivers/storage-interface.hpp"
+#include <cstdint>
+
+/*
+ * ProgressManager persists Konami progress to NVS storage.
+ *
+ * NVS keys:
+ *   "konami" — uint8_t bitmask of unlocked Konami buttons
+ *   "synced" — uint8_t (0 or 1), whether progress has been uploaded
+ */
+class ProgressManager {
+public:
+    ProgressManager() = default;
+    ~ProgressManager() = default;
+
+    void initialize(Player* player, StorageInterface* storage) {
+        this->player = player;
+        this->storage = storage;
+    }
+
+    void saveProgress() {
+        if (!storage || !player) return;
+        storage->writeUChar("konami", player->getKonamiProgress());
+        storage->writeUChar("synced", 0);
+        synced = false;
+    }
+
+    void loadProgress() {
+        if (!storage || !player) return;
+        uint8_t progress = storage->readUChar("konami", 0);
+        if (progress > 0) {
+            player->setKonamiProgress(progress);
+        }
+    }
+
+    bool hasUnsyncedProgress() const { return !synced; }
+
+    void clearProgress() {
+        if (!storage) return;
+        storage->writeUChar("konami", 0);
+        storage->writeUChar("synced", 1);
+        synced = true;
+    }
+
+private:
+    Player* player = nullptr;
+    StorageInterface* storage = nullptr;
+    bool synced = true;
+};

--- a/include/game/quickdraw.hpp
+++ b/include/game/quickdraw.hpp
@@ -6,6 +6,7 @@
 #include "state/state-machine.hpp"
 #include "game/quickdraw-states.hpp"
 #include "game/quickdraw-resources.hpp"
+#include "game/progress-manager.hpp"
 #include "device/drivers/http-client-interface.hpp"
 #include "device/drivers/storage-interface.hpp"
 #include "wireless/remote-debug-manager.hpp"
@@ -32,4 +33,5 @@ private:
     PeerCommsInterface* peerComms;
     QuickdrawWirelessManager* quickdrawWirelessManager;
     RemoteDebugManager* remoteDebugManager;
+    ProgressManager* progressManager = nullptr;
 };

--- a/src/game/quickdraw-states/fdn-complete-state.cpp
+++ b/src/game/quickdraw-states/fdn-complete-state.cpp
@@ -1,0 +1,97 @@
+#include "game/quickdraw-states.hpp"
+#include "game/quickdraw.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/progress-manager.hpp"
+#include "device/drivers/logger.hpp"
+#include "device/device-types.hpp"
+#include <cstdint>
+#include <cstdio>
+
+static const char* TAG = "FdnComplete";
+
+FdnComplete::FdnComplete(Player* player, ProgressManager* progressManager) :
+    State(FDN_COMPLETE),
+    player(player),
+    progressManager(progressManager)
+{
+}
+
+FdnComplete::~FdnComplete() {
+    player = nullptr;
+    progressManager = nullptr;
+}
+
+void FdnComplete::onStateMounted(Device* PDN) {
+    LOG_I(TAG, "FDN complete mounted");
+    transitionToIdleState = false;
+
+    // Read the outcome from Signal Echo
+    auto* echo = dynamic_cast<MiniGame*>(PDN->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+    if (!echo) {
+        LOG_W(TAG, "Signal Echo not found in AppConfig");
+        transitionToIdleState = true;
+        return;
+    }
+
+    const MiniGameOutcome& outcome = echo->getOutcome();
+
+    LOG_I(TAG, "Result: %s, Score: %d",
+           outcome.result == MiniGameResult::WON ? "WON" : "LOST",
+           outcome.score);
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+
+    if (outcome.result == MiniGameResult::WON) {
+        // Unlock the Konami button reward
+        GameType gameType = echo->getGameType();
+        KonamiButton reward = getRewardForGame(gameType);
+        player->unlockKonamiButton(static_cast<uint8_t>(reward));
+        LOG_I(TAG, "Unlocked Konami button: %s", getKonamiButtonName(reward));
+
+        // Check if hard mode was beaten — unlock color profile
+        if (outcome.hardMode) {
+            player->addColorProfileEligibility(static_cast<int>(gameType));
+            LOG_I(TAG, "Unlocked color profile for: %s", getGameDisplayName(gameType));
+        }
+
+        // Save progress
+        if (progressManager) {
+            progressManager->saveProgress();
+        }
+
+        // Display victory
+        PDN->getDisplay()->drawText("VICTORY!", 20, 15);
+        PDN->getDisplay()->drawText(getGameDisplayName(gameType), 10, 35);
+        char scoreStr[16];
+        snprintf(scoreStr, sizeof(scoreStr), "Score: %d", outcome.score);
+        PDN->getDisplay()->drawText(scoreStr, 20, 55);
+    } else {
+        // Display loss
+        PDN->getDisplay()->drawText("DEFEATED", 20, 15);
+        char scoreStr[16];
+        snprintf(scoreStr, sizeof(scoreStr), "Score: %d", outcome.score);
+        PDN->getDisplay()->drawText(scoreStr, 20, 35);
+    }
+
+    PDN->getDisplay()->render();
+
+    // Start display timer
+    displayTimer.setTimer(DISPLAY_DURATION_MS);
+}
+
+void FdnComplete::onStateLoop(Device* PDN) {
+    displayTimer.updateTime();
+    if (displayTimer.expired()) {
+        transitionToIdleState = true;
+    }
+}
+
+void FdnComplete::onStateDismounted(Device* PDN) {
+    displayTimer.invalidate();
+    player->clearPendingChallenge();
+}
+
+bool FdnComplete::transitionToIdle() {
+    return transitionToIdleState;
+}

--- a/src/game/quickdraw-states/fdn-detected-state.cpp
+++ b/src/game/quickdraw-states/fdn-detected-state.cpp
@@ -1,0 +1,141 @@
+#include "game/quickdraw-states.hpp"
+#include "game/quickdraw.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+#include "device/drivers/logger.hpp"
+#include "wireless/mac-functions.hpp"
+#include "device/device-constants.hpp"
+#include "device/device-types.hpp"
+#include <cstdint>
+
+static const char* TAG = "FdnDetected";
+
+FdnDetected::FdnDetected(Player* player) :
+    State(FDN_DETECTED),
+    player(player)
+{
+}
+
+FdnDetected::~FdnDetected() {
+    player = nullptr;
+}
+
+void FdnDetected::onStateMounted(Device* PDN) {
+    transitionToIdleState = false;
+    transitionToFdnCompleteState = false;
+    fackReceived = false;
+    macSent = false;
+    handshakeComplete = false;
+
+    // Read the pending FDN message from Player (set by Idle)
+    fdnMessage = player->getPendingCdevMessage();
+
+    LOG_I(TAG, "FDN detected, message: %s", fdnMessage.c_str());
+
+    // Parse the FDN message
+    if (!parseFdnMessage(fdnMessage, pendingGameType, pendingReward)) {
+        LOG_W(TAG, "Failed to parse FDN message: %s", fdnMessage.c_str());
+        transitionToIdleState = true;
+        return;
+    }
+
+    LOG_I(TAG, "Challenge: %s, reward: %s",
+           getGameDisplayName(pendingGameType),
+           getKonamiButtonName(pendingReward));
+
+    // Set up serial callback to listen for fack
+    PDN->setOnStringReceivedCallback([this](const std::string& message) {
+        LOG_I(TAG, "Serial received: %s", message.c_str());
+        if (message == FDN_ACK) {
+            LOG_I(TAG, "Received fack from NPC");
+            fackReceived = true;
+        }
+    });
+
+    // Send our MAC address to the NPC
+    uint8_t* macAddr = PDN->getWirelessManager()->getMacAddress();
+    const char* macStr = MacToString(macAddr);
+    std::string macMessage = SEND_MAC_ADDRESS + std::string(macStr);
+    PDN->writeString(macMessage.c_str());
+    macSent = true;
+
+    LOG_I(TAG, "Sent MAC: %s", macStr);
+
+    // Start timeout
+    timeoutTimer.setTimer(TIMEOUT_MS);
+
+    // Display challenge info
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+    PDN->getDisplay()->drawText("CHALLENGE", 20, 15);
+    PDN->getDisplay()->drawText(getGameDisplayName(pendingGameType), 20, 35);
+    PDN->getDisplay()->drawText("CONNECTING...", 10, 55);
+    PDN->getDisplay()->render();
+}
+
+void FdnDetected::onStateLoop(Device* PDN) {
+    if (fackReceived && !handshakeComplete) {
+        LOG_I(TAG, "fack received, launching Signal Echo");
+        handshakeComplete = true;
+
+        // Configure Signal Echo with hard mode and managed mode
+        auto* echo = dynamic_cast<SignalEcho*>(PDN->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+        if (echo) {
+            SignalEchoConfig config = SIGNAL_ECHO_HARD;
+            config.managedMode = true;
+            echo->getConfig() = config;
+            echo->resetGame();
+
+            // Switch to Signal Echo — Quickdraw pauses at this state
+            PDN->setActiveApp(StateId(SIGNAL_ECHO_APP_ID));
+        } else {
+            LOG_W(TAG, "Signal Echo not registered in AppConfig");
+            transitionToIdleState = true;
+        }
+        return;
+    }
+
+    if (timeoutTimer.expired()) {
+        LOG_W(TAG, "FDN handshake timed out");
+        transitionToIdleState = true;
+    }
+}
+
+void FdnDetected::onStateDismounted(Device* PDN) {
+    timeoutTimer.invalidate();
+    fdnMessage.clear();
+    fackReceived = false;
+    macSent = false;
+    player->clearPendingChallenge();
+    PDN->clearCallbacks();
+}
+
+std::unique_ptr<Snapshot> FdnDetected::onStatePaused(Device* PDN) {
+    auto snapshot = std::make_unique<FdnDetectedSnapshot>();
+    snapshot->gameType = pendingGameType;
+    snapshot->reward = pendingReward;
+    snapshot->handshakeComplete = handshakeComplete;
+    return snapshot;
+}
+
+void FdnDetected::onStateResumed(Device* PDN, Snapshot* snapshot) {
+    if (snapshot) {
+        auto* fdnSnapshot = static_cast<FdnDetectedSnapshot*>(snapshot);
+        pendingGameType = fdnSnapshot->gameType;
+        pendingReward = fdnSnapshot->reward;
+        handshakeComplete = fdnSnapshot->handshakeComplete;
+    }
+
+    // If handshake was complete when we paused, the minigame is done
+    if (handshakeComplete) {
+        transitionToFdnCompleteState = true;
+    }
+}
+
+bool FdnDetected::transitionToIdle() {
+    return transitionToIdleState;
+}
+
+bool FdnDetected::transitionToFdnComplete() {
+    return transitionToFdnCompleteState;
+}

--- a/src/game/quickdraw-states/idle-state.cpp
+++ b/src/game/quickdraw-states/idle-state.cpp
@@ -3,6 +3,7 @@
 #include "game/quickdraw-resources.hpp"
 #include "game/match-manager.hpp"
 #include "device/drivers/logger.hpp"
+#include "device/device-constants.hpp"
 #include "wireless/mac-functions.hpp"
 
 Idle::Idle(Player* player, MatchManager* matchManager, QuickdrawWirelessManager* quickdrawWirelessManager) : State(IDLE) {
@@ -18,6 +19,8 @@ Idle::~Idle() {
 }
 
 void Idle::onStateMounted(Device *PDN) {
+    fdnDetected = false;
+    lastFdnMessage.clear();
 
     // Switch to ESP-NOW mode for peer-to-peer communication
     PDN->getWirelessManager()->enablePeerCommsMode();
@@ -84,6 +87,7 @@ void Idle::onStateDismounted(Device *PDN) {
     transitionToHandshakeState = false;
     sendMacAddress = false;
     waitingForMacAddress = false;
+    fdnDetected = false;
     heartbeatTimer.invalidate();
     statsIndex = 0;
     PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
@@ -94,8 +98,14 @@ void Idle::onStateDismounted(Device *PDN) {
 
 void Idle::serialEventCallbacks(const std::string& message) {
     LOG_I("IDLE", "Serial event received: %s", message.c_str());
-    if(message.compare(SERIAL_HEARTBEAT) == 0) {
-        sendMacAddress = true;  
+    if (message.rfind(FDN_DEVICE_ID, 0) == 0) {
+        // Message starts with "fdn:" — FDN challenge device detected
+        LOG_I("IDLE", "FDN detected: %s", message.c_str());
+        lastFdnMessage = message;
+        player->setPendingChallenge(message);
+        fdnDetected = true;
+    } else if(message.compare(SERIAL_HEARTBEAT) == 0) {
+        sendMacAddress = true;
     } else if(message.rfind(SEND_MAC_ADDRESS, 0) == 0) {
         // Message starts with "smac" - extract MAC address after prefix
         std::string macAddress = message.substr(SEND_MAC_ADDRESS.length());

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -15,6 +15,7 @@
 #include "cli-fdn-tests.hpp"
 #include "device-extension-tests.hpp"
 #include "signal-echo-tests.hpp"
+#include "fdn-integration-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -594,6 +595,110 @@ TEST_F(SignalEchoDifficultyTestSuite, LifeIndicator) {
 
 TEST_F(SignalEchoDifficultyTestSuite, WrongInputAdvances) {
     echoDiffWrongInputAdvances(this);
+}
+
+// ============================================
+// FDN INTEGRATION TESTS
+// ============================================
+
+TEST_F(FdnIntegrationTestSuite, DetectsFdnBroadcast) {
+    fdnIntegrationDetectsFdnBroadcast(this);
+}
+
+TEST_F(FdnIntegrationTestSuite, HandshakeSendsMAC) {
+    fdnIntegrationHandshakeSendsMAC(this);
+}
+
+TEST_F(FdnIntegrationTestSuite, TransitionsToSignalEcho) {
+    fdnIntegrationTransitionsToSignalEcho(this);
+}
+
+TEST_F(FdnIntegrationTestSuite, HandshakeTimeout) {
+    fdnIntegrationHandshakeTimeout(this);
+}
+
+// ============================================
+// FDN COMPLETE TESTS
+// ============================================
+
+TEST_F(FdnCompleteTestSuite, ShowsVictoryOnWin) {
+    fdnCompleteShowsVictoryOnWin(this);
+}
+
+TEST_F(FdnCompleteTestSuite, UnlocksKonamiOnWin) {
+    fdnCompleteUnlocksKonamiOnWin(this);
+}
+
+TEST_F(FdnCompleteTestSuite, UnlocksColorProfileOnHardWin) {
+    fdnCompleteUnlocksColorProfileOnHardWin(this);
+}
+
+TEST_F(FdnCompleteTestSuite, ShowsDefeatedOnLoss) {
+    fdnCompleteShowsDefeatedOnLoss(this);
+}
+
+TEST_F(FdnCompleteTestSuite, TransitionsToIdleAfterTimer) {
+    fdnCompleteTransitionsToIdleAfterTimer(this);
+}
+
+TEST_F(FdnCompleteTestSuite, ClearsPendingChallenge) {
+    fdnCompleteClearsPendingChallenge(this);
+}
+
+// ============================================
+// PROGRESS MANAGER TESTS
+// ============================================
+
+TEST_F(ProgressManagerTestSuite, SavesOnWin) {
+    progressManagerSavesOnWin(this);
+}
+
+TEST_F(ProgressManagerTestSuite, LoadsProgress) {
+    progressManagerLoadsProgress(this);
+}
+
+TEST_F(ProgressManagerTestSuite, ClearsProgress) {
+    progressManagerClearsProgress(this);
+}
+
+// ============================================
+// PLAYER CHALLENGE TESTS
+// ============================================
+
+TEST_F(PlayerChallengeTestSuite, KonamiUnlockAndQuery) {
+    playerKonamiUnlockAndQuery(this);
+}
+
+TEST_F(PlayerChallengeTestSuite, PendingChallengeSetClear) {
+    playerPendingChallengeSetClear(this);
+}
+
+TEST_F(PlayerChallengeTestSuite, ColorProfileEligibility) {
+    playerColorProfileEligibility(this);
+}
+
+TEST_F(PlayerChallengeTestSuite, EquippedColorProfile) {
+    playerEquippedColorProfile(this);
+}
+
+TEST_F(PlayerChallengeTestSuite, KonamiProgressSetGet) {
+    playerKonamiProgressSetGet(this);
+}
+
+// ============================================
+// APP SWITCHING TESTS
+// ============================================
+
+TEST_F(AppSwitchingTestSuite, SignalEchoRegistered) {
+    appSwitchingSignalEchoRegistered(this);
+}
+
+TEST_F(AppSwitchingTestSuite, QuickdrawActiveAtStart) {
+    appSwitchingQuickdrawActiveAtStart(this);
+}
+
+TEST_F(AppSwitchingTestSuite, ReturnToPrevious) {
+    appSwitchingReturnToPrevious(this);
 }
 
 // ============================================

--- a/test/test_cli/fdn-integration-tests.hpp
+++ b/test/test_cli/fdn-integration-tests.hpp
@@ -1,0 +1,576 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+#include "game/minigame.hpp"
+#include "game/progress-manager.hpp"
+#include "device/device-constants.hpp"
+#include "device/device-types.hpp"
+#include "utils/simple-timer.hpp"
+
+using namespace cli;
+
+// ============================================
+// FDN INTEGRATION TEST SUITE
+// ============================================
+
+class FdnIntegrationTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        // Device 0 = player (hunter), Device 1 = FDN NPC
+        player_ = DeviceFactory::createDevice(0, true);
+        fdn_ = DeviceFactory::createFdnDevice(1, GameType::SIGNAL_ECHO);
+        SimpleTimer::setPlatformClock(player_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(fdn_);
+        DeviceFactory::destroyDevice(player_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            SerialCableBroker::getInstance().transferData();
+            player_.pdn->loop();
+            fdn_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            player_.clockDriver->advance(delayMs);
+            fdn_.clockDriver->advance(delayMs);
+            SerialCableBroker::getInstance().transferData();
+            player_.pdn->loop();
+            fdn_.pdn->loop();
+        }
+    }
+
+    void tickPlayerWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            player_.clockDriver->advance(delayMs);
+            player_.pdn->loop();
+        }
+    }
+
+    // Advance player to Idle state (skip to it directly)
+    void advanceToIdle() {
+        // stateMap index 7 = Idle (in populateStateMap order)
+        player_.game->skipToState(player_.pdn, 7);
+        player_.pdn->loop();
+    }
+
+    int getPlayerStateId() {
+        return player_.game->getCurrentState()->getStateId();
+    }
+
+    int getFdnStateId() {
+        return fdn_.game->getCurrentState()->getStateId();
+    }
+
+    void connectCable() {
+        SerialCableBroker::getInstance().connect(0, 1);
+    }
+
+    DeviceInstance player_;
+    DeviceInstance fdn_;
+};
+
+// ============================================
+// FDN DETECTION TESTS
+//
+// These tests simulate the serial handshake by directly injecting
+// messages into the player's PRIMARY jack (outputJack for hunters).
+// The SerialCableBroker can't route output↔output (both FDN and
+// hunter use OUTPUT_JACK as PRIMARY), so we inject directly.
+// ============================================
+
+// Test: Player in Idle detects FDN broadcast and transitions to FdnDetected
+void fdnIntegrationDetectsFdnBroadcast(FdnIntegrationTestSuite* suite) {
+    suite->advanceToIdle();
+    ASSERT_EQ(suite->getPlayerStateId(), IDLE);
+
+    // Simulate receiving an FDN broadcast on the player's PRIMARY jack
+    suite->player_.serialOutDriver->injectInput("*fdn:7:6\r");
+    suite->tick(3);
+
+    // Player should have detected the FDN and transitioned
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+}
+
+// Test: FdnDetected sends MAC address on mount
+void fdnIntegrationHandshakeSendsMAC(FdnIntegrationTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Trigger FDN detection
+    suite->player_.serialOutDriver->injectInput("*fdn:7:6\r");
+    suite->tick(3);
+
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Check that smac was sent by the player
+    auto& history = suite->player_.serialOutDriver->getSentHistory();
+    bool macSent = false;
+    for (const auto& msg : history) {
+        if (msg.rfind("smac", 0) == 0) {
+            macSent = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(macSent);
+}
+
+// Test: After fack received, player switches to Signal Echo app
+void fdnIntegrationTransitionsToSignalEcho(FdnIntegrationTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Trigger FDN detection
+    suite->player_.serialOutDriver->injectInput("*fdn:7:6\r");
+    suite->tick(3);
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Inject fack from NPC — this triggers the app switch
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickPlayerWithTime(5, 100);
+
+    // After handshake, player should have switched to Signal Echo
+    // The active app is now Signal Echo, so getPlayerStateId() returns
+    // the game pointer's state (Quickdraw), but the device is running Echo.
+    // Check Signal Echo via getApp:
+    auto* echo = suite->player_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID));
+    ASSERT_NE(echo, nullptr);
+    int echoStateId = echo->getCurrentState()->getStateId();
+    ASSERT_GE(echoStateId, ECHO_INTRO);
+}
+
+// Test: FdnDetected times out if no fack received
+void fdnIntegrationHandshakeTimeout(FdnIntegrationTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Inject an FDN message on the player's PRIMARY jack
+    suite->player_.serialOutDriver->injectInput("*fdn:7:6\r");
+    suite->tick(3);
+
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Wait for timeout (10 seconds)
+    suite->tickPlayerWithTime(60, 200);
+
+    // Should transition back to Idle after timeout
+    ASSERT_EQ(suite->getPlayerStateId(), IDLE);
+}
+
+// ============================================
+// FDN COMPLETE TESTS
+// ============================================
+
+class FdnCompleteTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            device_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            device_.clockDriver->advance(delayMs);
+            device_.pdn->loop();
+        }
+    }
+
+    DeviceInstance device_;
+};
+
+// Test: FdnComplete shows VICTORY on win
+void fdnCompleteShowsVictoryOnWin(FdnCompleteTestSuite* suite) {
+    // Set up Signal Echo with a won outcome
+    auto* echo = dynamic_cast<MiniGame*>(
+        suite->device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+    ASSERT_NE(echo, nullptr);
+
+    MiniGameOutcome outcome;
+    outcome.result = MiniGameResult::WON;
+    outcome.score = 42;
+    outcome.hardMode = true;
+    echo->setOutcome(outcome);
+
+    // Set pending challenge on player
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    // Skip Quickdraw to the FdnComplete state
+    // stateMap order: playerReg(0), fetchUser(1), confirmOffline(2), chooseRole(3),
+    // allegiancePicker(4), welcome(5), awaken(6), idle(7), handshakeInit(8),
+    // bountySendCC(9), hunterSendId(10), connSuccessful(11), duelCountdown(12),
+    // duel(13), duelPushed(14), duelReceivedResult(15), duelResult(16),
+    // win(17), lose(18), uploadMatches(19), sleep(20), fdnDetected(21), fdnComplete(22)
+    suite->device_.game->skipToState(suite->device_.pdn, 22);
+    suite->tick(1);
+
+    // Check display shows VICTORY
+    auto& textHistory = suite->device_.displayDriver->getTextHistory();
+    bool foundVictory = false;
+    for (const auto& entry : textHistory) {
+        if (entry.find("VICTORY!") != std::string::npos) {
+            foundVictory = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(foundVictory);
+}
+
+// Test: FdnComplete unlocks Konami button on win
+void fdnCompleteUnlocksKonamiOnWin(FdnCompleteTestSuite* suite) {
+    auto* echo = dynamic_cast<MiniGame*>(
+        suite->device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+    ASSERT_NE(echo, nullptr);
+
+    MiniGameOutcome outcome;
+    outcome.result = MiniGameResult::WON;
+    outcome.score = 10;
+    outcome.hardMode = false;
+    echo->setOutcome(outcome);
+
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    // Verify button not unlocked before
+    ASSERT_FALSE(suite->device_.player->hasUnlockedButton(
+        static_cast<uint8_t>(KonamiButton::START)));
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);
+    suite->tick(1);
+
+    // Signal Echo = GameType 7, reward = START(6)
+    ASSERT_TRUE(suite->device_.player->hasUnlockedButton(
+        static_cast<uint8_t>(KonamiButton::START)));
+}
+
+// Test: FdnComplete unlocks color profile on hard mode win
+void fdnCompleteUnlocksColorProfileOnHardWin(FdnCompleteTestSuite* suite) {
+    auto* echo = dynamic_cast<MiniGame*>(
+        suite->device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+    ASSERT_NE(echo, nullptr);
+
+    MiniGameOutcome outcome;
+    outcome.result = MiniGameResult::WON;
+    outcome.score = 20;
+    outcome.hardMode = true;
+    echo->setOutcome(outcome);
+
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    ASSERT_FALSE(suite->device_.player->hasColorProfileEligibility(
+        static_cast<int>(GameType::SIGNAL_ECHO)));
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);
+    suite->tick(1);
+
+    ASSERT_TRUE(suite->device_.player->hasColorProfileEligibility(
+        static_cast<int>(GameType::SIGNAL_ECHO)));
+}
+
+// Test: FdnComplete shows DEFEATED on loss
+void fdnCompleteShowsDefeatedOnLoss(FdnCompleteTestSuite* suite) {
+    auto* echo = dynamic_cast<MiniGame*>(
+        suite->device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+    ASSERT_NE(echo, nullptr);
+
+    MiniGameOutcome outcome;
+    outcome.result = MiniGameResult::LOST;
+    outcome.score = 5;
+    echo->setOutcome(outcome);
+
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);
+    suite->tick(1);
+
+    auto& textHistory = suite->device_.displayDriver->getTextHistory();
+    bool foundDefeated = false;
+    for (const auto& entry : textHistory) {
+        if (entry.find("DEFEATED") != std::string::npos) {
+            foundDefeated = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(foundDefeated);
+
+    // Should NOT unlock Konami button on loss
+    ASSERT_FALSE(suite->device_.player->hasUnlockedButton(
+        static_cast<uint8_t>(KonamiButton::START)));
+}
+
+// Test: FdnComplete transitions to Idle after timer
+void fdnCompleteTransitionsToIdleAfterTimer(FdnCompleteTestSuite* suite) {
+    auto* echo = dynamic_cast<MiniGame*>(
+        suite->device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+    ASSERT_NE(echo, nullptr);
+
+    MiniGameOutcome outcome;
+    outcome.result = MiniGameResult::WON;
+    outcome.score = 10;
+    echo->setOutcome(outcome);
+
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);
+    suite->tick(1);
+
+    // Should be at FdnComplete
+    int stateId = suite->device_.game->getCurrentState()->getStateId();
+    ASSERT_EQ(stateId, FDN_COMPLETE);
+
+    // Wait for display timer (3 seconds)
+    suite->tickWithTime(20, 200);
+
+    // Should have transitioned back to Idle
+    stateId = suite->device_.game->getCurrentState()->getStateId();
+    ASSERT_EQ(stateId, IDLE);
+}
+
+// Test: FdnComplete clears pending challenge on dismount
+void fdnCompleteClearsPendingChallenge(FdnCompleteTestSuite* suite) {
+    auto* echo = dynamic_cast<MiniGame*>(
+        suite->device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+    ASSERT_NE(echo, nullptr);
+
+    MiniGameOutcome outcome;
+    outcome.result = MiniGameResult::LOST;
+    outcome.score = 0;
+    echo->setOutcome(outcome);
+
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+    ASSERT_TRUE(suite->device_.player->hasPendingChallenge());
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);
+    suite->tick(1);
+
+    // Wait for transition to Idle (clears pending challenge on dismount)
+    suite->tickWithTime(20, 200);
+
+    ASSERT_FALSE(suite->device_.player->hasPendingChallenge());
+}
+
+// ============================================
+// PROGRESS MANAGER TESTS
+// ============================================
+
+class ProgressManagerTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    DeviceInstance device_;
+};
+
+// Test: Progress is saved to NVS on win
+void progressManagerSavesOnWin(ProgressManagerTestSuite* suite) {
+    ProgressManager pm;
+    pm.initialize(suite->device_.player, suite->device_.storageDriver);
+
+    suite->device_.player->unlockKonamiButton(0);  // UP
+    suite->device_.player->unlockKonamiButton(6);  // START
+    pm.saveProgress();
+
+    uint8_t stored = suite->device_.storageDriver->readUChar("konami", 0);
+    ASSERT_EQ(stored, suite->device_.player->getKonamiProgress());
+    ASSERT_TRUE(pm.hasUnsyncedProgress());
+}
+
+// Test: Progress is loaded from NVS
+void progressManagerLoadsProgress(ProgressManagerTestSuite* suite) {
+    // Write directly to storage
+    suite->device_.storageDriver->writeUChar("konami", 0b01000011);  // UP + DOWN + START
+
+    ProgressManager pm;
+    pm.initialize(suite->device_.player, suite->device_.storageDriver);
+    pm.loadProgress();
+
+    ASSERT_EQ(suite->device_.player->getKonamiProgress(), 0b01000011);
+    ASSERT_TRUE(suite->device_.player->hasUnlockedButton(0));   // UP
+    ASSERT_TRUE(suite->device_.player->hasUnlockedButton(1));   // DOWN
+    ASSERT_TRUE(suite->device_.player->hasUnlockedButton(6));   // START
+    ASSERT_FALSE(suite->device_.player->hasUnlockedButton(2));  // LEFT
+}
+
+// Test: Clear progress resets storage
+void progressManagerClearsProgress(ProgressManagerTestSuite* suite) {
+    ProgressManager pm;
+    pm.initialize(suite->device_.player, suite->device_.storageDriver);
+
+    suite->device_.player->unlockKonamiButton(0);
+    pm.saveProgress();
+    ASSERT_TRUE(pm.hasUnsyncedProgress());
+
+    pm.clearProgress();
+    ASSERT_FALSE(pm.hasUnsyncedProgress());
+
+    uint8_t stored = suite->device_.storageDriver->readUChar("konami", 99);
+    ASSERT_EQ(stored, 0);
+}
+
+// ============================================
+// PLAYER CHALLENGE FIELDS TESTS
+// ============================================
+
+class PlayerChallengeTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        player_ = new Player();
+    }
+
+    void TearDown() override {
+        delete player_;
+    }
+
+    Player* player_;
+};
+
+// Test: Konami button unlock and query
+void playerKonamiUnlockAndQuery(PlayerChallengeTestSuite* suite) {
+    ASSERT_EQ(suite->player_->getKonamiProgress(), 0);
+    ASSERT_FALSE(suite->player_->hasUnlockedButton(0));
+
+    suite->player_->unlockKonamiButton(0);
+    ASSERT_TRUE(suite->player_->hasUnlockedButton(0));
+    ASSERT_FALSE(suite->player_->hasUnlockedButton(1));
+
+    suite->player_->unlockKonamiButton(6);
+    ASSERT_TRUE(suite->player_->hasUnlockedButton(6));
+    ASSERT_EQ(suite->player_->getKonamiProgress(), 0b01000001);
+}
+
+// Test: Pending challenge set/clear
+void playerPendingChallengeSetClear(PlayerChallengeTestSuite* suite) {
+    ASSERT_FALSE(suite->player_->hasPendingChallenge());
+
+    suite->player_->setPendingChallenge("fdn:7:6");
+    ASSERT_TRUE(suite->player_->hasPendingChallenge());
+    ASSERT_EQ(suite->player_->getPendingCdevMessage(), "fdn:7:6");
+
+    suite->player_->clearPendingChallenge();
+    ASSERT_FALSE(suite->player_->hasPendingChallenge());
+}
+
+// Test: Color profile eligibility
+void playerColorProfileEligibility(PlayerChallengeTestSuite* suite) {
+    ASSERT_FALSE(suite->player_->hasColorProfileEligibility(7));
+
+    suite->player_->addColorProfileEligibility(7);
+    ASSERT_TRUE(suite->player_->hasColorProfileEligibility(7));
+    ASSERT_FALSE(suite->player_->hasColorProfileEligibility(1));
+}
+
+// Test: Equipped color profile
+void playerEquippedColorProfile(PlayerChallengeTestSuite* suite) {
+    ASSERT_EQ(suite->player_->getEquippedColorProfile(), -1);
+
+    suite->player_->setEquippedColorProfile(7);
+    ASSERT_EQ(suite->player_->getEquippedColorProfile(), 7);
+}
+
+// Test: Konami progress set/get
+void playerKonamiProgressSetGet(PlayerChallengeTestSuite* suite) {
+    suite->player_->setKonamiProgress(0xFF);
+    ASSERT_EQ(suite->player_->getKonamiProgress(), 0xFF);
+    for (int i = 0; i < 7; i++) {
+        ASSERT_TRUE(suite->player_->hasUnlockedButton(i));
+    }
+}
+
+// ============================================
+// APP SWITCHING TESTS (FDN → Signal Echo → Quickdraw)
+// ============================================
+
+class AppSwitchingTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            device_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            device_.clockDriver->advance(delayMs);
+            device_.pdn->loop();
+        }
+    }
+
+    DeviceInstance device_;
+};
+
+// Test: Signal Echo is registered and accessible via getApp
+void appSwitchingSignalEchoRegistered(AppSwitchingTestSuite* suite) {
+    auto* app = suite->device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID));
+    ASSERT_NE(app, nullptr);
+
+    auto* echo = dynamic_cast<MiniGame*>(app);
+    ASSERT_NE(echo, nullptr);
+    ASSERT_EQ(echo->getGameType(), GameType::SIGNAL_ECHO);
+}
+
+// Test: Quickdraw is the active app at start
+void appSwitchingQuickdrawActiveAtStart(AppSwitchingTestSuite* suite) {
+    // The game pointer points to the Quickdraw instance
+    ASSERT_NE(suite->device_.game, nullptr);
+
+    // Its current state should be in the Quickdraw range (0-22)
+    int stateId = suite->device_.game->getCurrentState()->getStateId();
+    ASSERT_LE(stateId, 22);
+}
+
+// Test: returnToPreviousApp goes back to Quickdraw
+void appSwitchingReturnToPrevious(AppSwitchingTestSuite* suite) {
+    // Switch to Signal Echo
+    suite->device_.pdn->setActiveApp(StateId(SIGNAL_ECHO_APP_ID));
+    suite->tick(1);
+
+    // Get the Signal Echo app and check it's in the Echo state range
+    auto* echo = suite->device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID));
+    int stateId = echo->getCurrentState()->getStateId();
+    ASSERT_GE(stateId, ECHO_INTRO);
+
+    // Return to previous (Quickdraw)
+    suite->device_.pdn->returnToPreviousApp();
+    suite->tick(1);
+
+    stateId = suite->device_.game->getCurrentState()->getStateId();
+    ASSERT_LT(stateId, ECHO_INTRO);
+}
+
+#endif // NATIVE_BUILD


### PR DESCRIPTION
## Summary
- Create FdnDetected state: serial handshake (smac/fack), configures Signal Echo, calls `setActiveApp()`, Snapshot for pause/resume
- Create FdnComplete state: reads outcome from Signal Echo, unlocks Konami button on win, color profile on hard mode, saves progress via ProgressManager
- Idle state detects `fdn:` serial broadcasts and transitions to FdnDetected
- ProgressManager persists Konami progress to NVS storage
- Player extensions: pendingChallenge, konamiProgress, colorProfileEligibility
- Player devices register Signal Echo in AppConfig at boot
- 22 tests: handshake flow, timeout, app switching, outcome display, progress persistence, player fields

Part 3 of 3 for #72. Stacked: FDN Infrastructure ← Signal Echo ← **this PR**

## Test plan
- [x] `pio test -e native_cli_test` — 147 tests pass
- [x] `pio test -e native` — 55/56 pass (1 pre-existing SIGABRT)
- [ ] Manual: connect player to FDN via cable, complete handshake, play Signal Echo, verify Konami unlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)