### PR TITLE
Progression core: difficulty gating, auto-boon, NVS persistence

### DIFF
--- a/include/cli/cli-http-server.hpp
+++ b/include/cli/cli-http-server.hpp
@@ -86,6 +86,8 @@ public:
             statusCode = handleGetPlayer(path, responseBody);
         } else if (method == "PUT" && path == "/api/matches") {
             statusCode = handlePutMatches(body, responseBody);
+        } else if (method == "PUT" && path == "/api/progress") {
+            statusCode = handlePutProgress(body, responseBody);
         } else {
             statusCode = 404;
             responseBody = R"({"errors":["Not found"]})";
@@ -229,6 +231,27 @@ private:
         responseBody = R"({"success":true,"message":"Matches uploaded"})";
         return 200;
     }
+
+    /**
+     * Handle PUT /api/progress
+     */
+    int handlePutProgress(const std::string& body, std::string& responseBody) {
+        // Acknowledge the progress upload
+        lastProgressBody_ = body;
+        responseBody = R"({"success":true,"message":"Progress synced"})";
+        return 200;
+    }
+
+public:
+    /**
+     * Get the last progress body received (for test verification).
+     */
+    const std::string& getLastProgressBody() const {
+        return lastProgressBody_;
+    }
+
+private:
+    std::string lastProgressBody_;
 };
 
 } // namespace cli

--- a/include/device/device-types.hpp
+++ b/include/device/device-types.hpp
@@ -80,6 +80,19 @@ inline const char* getKonamiButtonName(KonamiButton button) {
 }
 
 /*
+ * Lookup: GameType -> AppConfig StateId for that game.
+ * Returns the StateId used in AppConfig registration.
+ * Returns -1 if no app is registered for this game type.
+ */
+inline int getAppIdForGame(GameType type) {
+    switch (type) {
+        case GameType::SIGNAL_ECHO:       return 2;  // SIGNAL_ECHO_APP_ID
+        case GameType::FIREWALL_DECRYPT:  return 3;  // FIREWALL_DECRYPT_APP_ID (future)
+        default:                          return -1;
+    }
+}
+
+/*
  * Check if a pairing code is a reserved FDN device code (7001-7007).
  */
 inline bool isFdnDeviceCode(const std::string& code) {

--- a/include/game/player.hpp
+++ b/include/game/player.hpp
@@ -122,8 +122,11 @@ private:
     std::string pendingCdevMessage;
     bool pendingChallenge = false;
     uint8_t konamiProgress = 0;  // Bitmask of unlocked Konami buttons
+    bool konamiBoon = false;  // True when Konami puzzle "complete" (auto-set when all 7 collected)
     int equippedColorProfile = -1;  // -1 = none, otherwise GameType value
     std::set<int> colorProfileEligibility;  // GameTypes with hard mode beaten
+    int lastFdnGameType = -1;  // GameType of last FDN encounter (set by FdnDetected)
+    int pendingProfileGame = -1;  // Set by FdnComplete for ColorProfilePrompt
 
 public:
     // Pending FDN challenge (set by Idle, read by FdnDetected)
@@ -147,6 +150,19 @@ public:
     }
     uint8_t getKonamiProgress() const { return konamiProgress; }
     void setKonamiProgress(uint8_t progress) { konamiProgress = progress; }
+    bool isKonamiComplete() const { return (konamiProgress & 0x7F) == 0x7F; }
+
+    // Konami boon (auto-set when all 7 buttons collected)
+    bool hasKonamiBoon() const { return konamiBoon; }
+    void setKonamiBoon(bool boon) { konamiBoon = boon; }
+
+    // Last FDN game type (set by FdnDetected, read by FdnComplete)
+    int getLastFdnGameType() const { return lastFdnGameType; }
+    void setLastFdnGameType(int gameType) { lastFdnGameType = gameType; }
+
+    // Pending profile game (set by FdnComplete for ColorProfilePrompt)
+    int getPendingProfileGame() const { return pendingProfileGame; }
+    void setPendingProfileGame(int gameType) { pendingProfileGame = gameType; }
 
     // Color profile eligibility
     void addColorProfileEligibility(int gameTypeValue) {
@@ -155,6 +171,7 @@ public:
     bool hasColorProfileEligibility(int gameTypeValue) const {
         return colorProfileEligibility.count(gameTypeValue) > 0;
     }
+    const std::set<int>& getColorProfileEligibility() const { return colorProfileEligibility; }
     int getEquippedColorProfile() const { return equippedColorProfile; }
     void setEquippedColorProfile(int gameTypeValue) { equippedColorProfile = gameTypeValue; }
 };

--- a/include/game/progress-manager.hpp
+++ b/include/game/progress-manager.hpp
@@ -2,14 +2,19 @@
 
 #include "game/player.hpp"
 #include "device/drivers/storage-interface.hpp"
+#include "device/drivers/http-client-interface.hpp"
 #include <cstdint>
+#include <cstdio>
 
 /*
  * ProgressManager persists Konami progress to NVS storage.
  *
  * NVS keys:
- *   "konami" — uint8_t bitmask of unlocked Konami buttons
- *   "synced" — uint8_t (0 or 1), whether progress has been uploaded
+ *   "konami"        — uint8_t bitmask of unlocked Konami buttons
+ *   "konami_boon"   — uint8_t (0/1), Konami puzzle complete
+ *   "color_profile" — uint8_t (equipped + 1, 0 = none)
+ *   "color_elig"    — uint8_t bitmask of eligible color profiles (7 games = 7 bits)
+ *   "synced"        — uint8_t (0 or 1), whether progress has been uploaded
  */
 class ProgressManager {
 public:
@@ -24,6 +29,21 @@ public:
     void saveProgress() {
         if (!storage || !player) return;
         storage->writeUChar("konami", player->getKonamiProgress());
+        storage->writeUChar("konami_boon", player->hasKonamiBoon() ? 1 : 0);
+
+        // Equipped color profile: store as gameType + 1 (0 = none)
+        int equipped = player->getEquippedColorProfile();
+        storage->writeUChar("color_profile", static_cast<uint8_t>(equipped + 1));
+
+        // Color profile eligibility: pack set into bitmask (8 game types, 8 bits)
+        uint8_t eligMask = 0;
+        for (int gameType : player->getColorProfileEligibility()) {
+            if (gameType >= 0 && gameType < 8) {
+                eligMask |= (1 << gameType);
+            }
+        }
+        storage->writeUChar("color_elig", eligMask);
+
         storage->writeUChar("synced", 0);
         synced = false;
     }
@@ -34,6 +54,24 @@ public:
         if (progress > 0) {
             player->setKonamiProgress(progress);
         }
+
+        uint8_t boon = storage->readUChar("konami_boon", 0);
+        player->setKonamiBoon(boon != 0);
+
+        uint8_t profileStored = storage->readUChar("color_profile", 0);
+        if (profileStored > 0) {
+            player->setEquippedColorProfile(static_cast<int>(profileStored) - 1);
+        }
+
+        uint8_t eligMask = storage->readUChar("color_elig", 0);
+        for (int i = 0; i < 8; i++) {
+            if (eligMask & (1 << i)) {
+                player->addColorProfileEligibility(i);
+            }
+        }
+
+        uint8_t syncedVal = storage->readUChar("synced", 1);
+        synced = (syncedVal != 0);
     }
 
     bool hasUnsyncedProgress() const { return !synced; }
@@ -41,8 +79,45 @@ public:
     void clearProgress() {
         if (!storage) return;
         storage->writeUChar("konami", 0);
+        storage->writeUChar("konami_boon", 0);
+        storage->writeUChar("color_profile", 0);
+        storage->writeUChar("color_elig", 0);
         storage->writeUChar("synced", 1);
         synced = true;
+    }
+
+    /*
+     * Sync progress to server via HTTP PUT /api/progress.
+     * Marks progress as synced on success. No-op if already synced.
+     */
+    void syncProgress(HttpClientInterface* httpClient) {
+        if (!httpClient || synced) return;
+        if (!httpClient->isConnected()) return;
+
+        // Build progress JSON
+        char body[128];
+        snprintf(body, sizeof(body),
+            R"({"konami":%d,"boon":%s,"profile":%d})",
+            player ? player->getKonamiProgress() : 0,
+            (player && player->hasKonamiBoon()) ? "true" : "false",
+            player ? player->getEquippedColorProfile() : -1);
+
+        HttpRequest request(
+            "/api/progress",
+            "PUT",
+            std::string(body),
+            [this](const std::string& response) {
+                synced = true;
+                if (storage) {
+                    storage->writeUChar("synced", 1);
+                }
+            },
+            [](const WirelessErrorInfo& error) {
+                // Sync failed — will retry on next save
+            }
+        );
+
+        httpClient->queueRequest(request);
     }
 
 private:

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -16,6 +16,7 @@
 #include "device-extension-tests.hpp"
 #include "signal-echo-tests.hpp"
 #include "fdn-integration-tests.hpp"
+#include "progression-core-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -699,6 +700,118 @@ TEST_F(AppSwitchingTestSuite, QuickdrawActiveAtStart) {
 
 TEST_F(AppSwitchingTestSuite, ReturnToPrevious) {
     appSwitchingReturnToPrevious(this);
+}
+
+// ============================================
+// DIFFICULTY GATING TESTS
+// ============================================
+
+TEST_F(DifficultyGatingTestSuite, EasyWithoutBoon) {
+    difficultyGatingEasyWithoutBoon(this);
+}
+
+TEST_F(DifficultyGatingTestSuite, HardWithBoon) {
+    difficultyGatingHardWithBoon(this);
+}
+
+TEST_F(DifficultyGatingTestSuite, SetsLastGameType) {
+    difficultyGatingSetsLastGameType(this);
+}
+
+TEST_F(DifficultyGatingTestSuite, UnknownGameIdle) {
+    difficultyGatingUnknownGameIdle(this);
+}
+
+// ============================================
+// AUTO-BOON TESTS
+// ============================================
+
+TEST_F(AutoBoonTestSuite, TriggersOnSeventhButton) {
+    autoBoonTriggersOnSeventhButton(this);
+}
+
+TEST_F(AutoBoonTestSuite, DoesNotRetrigger) {
+    autoBoonDoesNotRetrigger(this);
+}
+
+TEST_F(AutoBoonTestSuite, ShowsDisplay) {
+    autoBoonShowsDisplay(this);
+}
+
+TEST_F(AutoBoonTestSuite, HardWinSetsPending) {
+    autoBoonHardWinSetsPending(this);
+}
+
+TEST_F(AutoBoonTestSuite, EasyWinNoPending) {
+    autoBoonEasyWinNoPending(this);
+}
+
+// ============================================
+// PLAYER FIELD ACCESSOR TESTS (extended)
+// ============================================
+
+TEST_F(PlayerChallengeTestSuite, IsKonamiComplete) {
+    playerIsKonamiComplete(this);
+}
+
+TEST_F(PlayerChallengeTestSuite, KonamiBoonSetGet) {
+    playerKonamiBoonSetGet(this);
+}
+
+TEST_F(PlayerChallengeTestSuite, LastFdnGameTypeSetGet) {
+    playerLastFdnGameTypeSetGet(this);
+}
+
+TEST_F(PlayerChallengeTestSuite, PendingProfileGameSetGet) {
+    playerPendingProfileGameSetGet(this);
+}
+
+TEST_F(PlayerChallengeTestSuite, ColorProfileEligibilitySet) {
+    playerColorProfileEligibilitySet(this);
+}
+
+// ============================================
+// PROGRESS MANAGER EXTENDED TESTS
+// ============================================
+
+TEST_F(ProgressManagerTestSuite, SaveLoadBoon) {
+    progressManagerSaveLoadBoon(this);
+}
+
+TEST_F(ProgressManagerTestSuite, SaveLoadProfile) {
+    progressManagerSaveLoadProfile(this);
+}
+
+TEST_F(ProgressManagerTestSuite, SaveLoadEligibility) {
+    progressManagerSaveLoadEligibility(this);
+}
+
+TEST_F(ProgressManagerTestSuite, ClearAll) {
+    progressManagerClearAll(this);
+}
+
+TEST_F(ProgressManagerTestSuite, SyncCallsServer) {
+    progressManagerSyncCallsServer(this);
+}
+
+// ============================================
+// GAME ROUTING TESTS
+// ============================================
+
+TEST_F(GameRoutingTestSuite, AppIdForGame) {
+    gameRoutingSignalEcho(this);
+}
+
+// ============================================
+// KONAMI COMMAND TESTS
+// ============================================
+
+TEST_F(KonamiCommandTestSuite, ShowsProgress) {
+    konamiCommandShowsProgress(this);
+}
+
+TEST_F(KonamiCommandTestSuite, SetsProgress) {
+    konamiCommandSetsProgress(this);
 }
 
 // ============================================

--- a/test/test_cli/fdn-integration-tests.hpp
+++ b/test/test_cli/fdn-integration-tests.hpp
@@ -212,8 +212,9 @@ void fdnCompleteShowsVictoryOnWin(FdnCompleteTestSuite* suite) {
     outcome.hardMode = true;
     echo->setOutcome(outcome);
 
-    // Set pending challenge on player
+    // Set pending challenge and last game type on player
     suite->device_.player->setPendingChallenge("fdn:7:6");
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
 
     // Skip Quickdraw to the FdnComplete state
     // stateMap order: playerReg(0), fetchUser(1), confirmOffline(2), chooseRole(3),
@@ -249,6 +250,7 @@ void fdnCompleteUnlocksKonamiOnWin(FdnCompleteTestSuite* suite) {
     echo->setOutcome(outcome);
 
     suite->device_.player->setPendingChallenge("fdn:7:6");
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
 
     // Verify button not unlocked before
     ASSERT_FALSE(suite->device_.player->hasUnlockedButton(
@@ -275,6 +277,7 @@ void fdnCompleteUnlocksColorProfileOnHardWin(FdnCompleteTestSuite* suite) {
     echo->setOutcome(outcome);
 
     suite->device_.player->setPendingChallenge("fdn:7:6");
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
 
     ASSERT_FALSE(suite->device_.player->hasColorProfileEligibility(
         static_cast<int>(GameType::SIGNAL_ECHO)));
@@ -298,6 +301,7 @@ void fdnCompleteShowsDefeatedOnLoss(FdnCompleteTestSuite* suite) {
     echo->setOutcome(outcome);
 
     suite->device_.player->setPendingChallenge("fdn:7:6");
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
 
     suite->device_.game->skipToState(suite->device_.pdn, 22);
     suite->tick(1);
@@ -329,6 +333,7 @@ void fdnCompleteTransitionsToIdleAfterTimer(FdnCompleteTestSuite* suite) {
     echo->setOutcome(outcome);
 
     suite->device_.player->setPendingChallenge("fdn:7:6");
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
 
     suite->device_.game->skipToState(suite->device_.pdn, 22);
     suite->tick(1);
@@ -357,6 +362,7 @@ void fdnCompleteClearsPendingChallenge(FdnCompleteTestSuite* suite) {
     echo->setOutcome(outcome);
 
     suite->device_.player->setPendingChallenge("fdn:7:6");
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
     ASSERT_TRUE(suite->device_.player->hasPendingChallenge());
 
     suite->device_.game->skipToState(suite->device_.pdn, 22);

--- a/test/test_cli/progression-core-tests.hpp
+++ b/test/test_cli/progression-core-tests.hpp
@@ -1,0 +1,494 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
+#include "cli/cli-commands.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+#include "game/minigame.hpp"
+#include "game/progress-manager.hpp"
+#include "device/device-constants.hpp"
+#include "device/device-types.hpp"
+#include "utils/simple-timer.hpp"
+
+using namespace cli;
+
+// ============================================
+// DIFFICULTY GATING TEST SUITE
+// ============================================
+
+class DifficultyGatingTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        player_ = DeviceFactory::createDevice(0, true);
+        fdn_ = DeviceFactory::createFdnDevice(1, GameType::SIGNAL_ECHO);
+        SimpleTimer::setPlatformClock(player_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(fdn_);
+        DeviceFactory::destroyDevice(player_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            SerialCableBroker::getInstance().transferData();
+            player_.pdn->loop();
+            fdn_.pdn->loop();
+        }
+    }
+
+    void tickPlayerWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            player_.clockDriver->advance(delayMs);
+            player_.pdn->loop();
+        }
+    }
+
+    void advanceToIdle() {
+        player_.game->skipToState(player_.pdn, 7);
+        player_.pdn->loop();
+    }
+
+    int getPlayerStateId() {
+        return player_.game->getCurrentState()->getStateId();
+    }
+
+    SignalEcho* getSignalEcho() {
+        return dynamic_cast<SignalEcho*>(
+            player_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+    }
+
+    DeviceInstance player_;
+    DeviceInstance fdn_;
+};
+
+// Test: First encounter (no boon) → EASY mode
+void difficultyGatingEasyWithoutBoon(DifficultyGatingTestSuite* suite) {
+    suite->advanceToIdle();
+    ASSERT_FALSE(suite->player_.player->hasKonamiBoon());
+
+    // Trigger FDN detection + handshake
+    suite->player_.serialOutDriver->injectInput("*fdn:7:6\r");
+    suite->tick(3);
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickPlayerWithTime(5, 100);
+
+    // Signal Echo should be in EASY mode
+    auto* echo = suite->getSignalEcho();
+    ASSERT_NE(echo, nullptr);
+    ASSERT_EQ(echo->getConfig().sequenceLength, SIGNAL_ECHO_EASY.sequenceLength);
+    ASSERT_EQ(echo->getConfig().allowedMistakes, SIGNAL_ECHO_EASY.allowedMistakes);
+    ASSERT_TRUE(echo->getConfig().managedMode);
+}
+
+// Test: After boon → HARD mode
+void difficultyGatingHardWithBoon(DifficultyGatingTestSuite* suite) {
+    suite->advanceToIdle();
+    suite->player_.player->setKonamiBoon(true);
+
+    suite->player_.serialOutDriver->injectInput("*fdn:7:6\r");
+    suite->tick(3);
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickPlayerWithTime(5, 100);
+
+    auto* echo = suite->getSignalEcho();
+    ASSERT_NE(echo, nullptr);
+    ASSERT_EQ(echo->getConfig().sequenceLength, SIGNAL_ECHO_HARD.sequenceLength);
+    ASSERT_EQ(echo->getConfig().allowedMistakes, SIGNAL_ECHO_HARD.allowedMistakes);
+    ASSERT_TRUE(echo->getConfig().managedMode);
+}
+
+// Test: FdnDetected sets lastFdnGameType on player
+void difficultyGatingSetsLastGameType(DifficultyGatingTestSuite* suite) {
+    suite->advanceToIdle();
+    ASSERT_EQ(suite->player_.player->getLastFdnGameType(), -1);
+
+    suite->player_.serialOutDriver->injectInput("*fdn:7:6\r");
+    suite->tick(3);
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickPlayerWithTime(5, 100);
+
+    ASSERT_EQ(suite->player_.player->getLastFdnGameType(),
+              static_cast<int>(GameType::SIGNAL_ECHO));
+}
+
+// Test: Unknown game type → transitions back to idle
+void difficultyGatingUnknownGameIdle(DifficultyGatingTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // GameType::QUICKDRAW has no registered app (getAppIdForGame returns -1)
+    suite->player_.serialOutDriver->injectInput("*fdn:0:0\r");
+    suite->tick(3);
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickPlayerWithTime(5, 100);
+
+    // Should fall back to Idle since no app for QUICKDRAW game type
+    ASSERT_EQ(suite->getPlayerStateId(), IDLE);
+}
+
+// ============================================
+// AUTO-BOON TEST SUITE
+// ============================================
+
+class AutoBoonTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            device_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            device_.clockDriver->advance(delayMs);
+            device_.pdn->loop();
+        }
+    }
+
+    void setupWinOutcome(bool hardMode = false) {
+        auto* echo = dynamic_cast<MiniGame*>(
+            device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+        MiniGameOutcome outcome;
+        outcome.result = MiniGameResult::WON;
+        outcome.score = 100;
+        outcome.hardMode = hardMode;
+        echo->setOutcome(outcome);
+    }
+
+    DeviceInstance device_;
+};
+
+// Test: Auto-boon triggers when 7th button is unlocked
+void autoBoonTriggersOnSeventhButton(AutoBoonTestSuite* suite) {
+    // Set 6 of 7 buttons (all except START)
+    suite->device_.player->setKonamiProgress(0x3F);  // bits 0-5
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
+    ASSERT_FALSE(suite->device_.player->isKonamiComplete());
+    ASSERT_FALSE(suite->device_.player->hasKonamiBoon());
+
+    suite->setupWinOutcome();
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    // Skip to FdnComplete (stateMap index 22)
+    suite->device_.game->skipToState(suite->device_.pdn, 22);
+    suite->tick(1);
+
+    // The win unlocks START (bit 6), completing all 7
+    ASSERT_TRUE(suite->device_.player->isKonamiComplete());
+    ASSERT_TRUE(suite->device_.player->hasKonamiBoon());
+}
+
+// Test: Auto-boon does NOT trigger if already has boon
+void autoBoonDoesNotRetrigger(AutoBoonTestSuite* suite) {
+    suite->device_.player->setKonamiProgress(0x7F);
+    suite->device_.player->setKonamiBoon(true);
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
+
+    suite->setupWinOutcome();
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);
+    suite->tick(1);
+
+    // Still has boon, but no KONAMI COMPLETE message on display
+    ASSERT_TRUE(suite->device_.player->hasKonamiBoon());
+    auto& textHistory = suite->device_.displayDriver->getTextHistory();
+    bool foundKonamiComplete = false;
+    for (const auto& entry : textHistory) {
+        if (entry.find("KONAMI COMPLETE!") != std::string::npos) {
+            foundKonamiComplete = true;
+        }
+    }
+    ASSERT_FALSE(foundKonamiComplete);
+}
+
+// Test: Display shows KONAMI COMPLETE! when boon first triggers
+void autoBoonShowsDisplay(AutoBoonTestSuite* suite) {
+    suite->device_.player->setKonamiProgress(0x3F);  // 6 of 7
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
+
+    suite->setupWinOutcome();
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);
+    suite->tick(1);
+
+    auto& textHistory = suite->device_.displayDriver->getTextHistory();
+    bool foundKonamiComplete = false;
+    for (const auto& entry : textHistory) {
+        if (entry.find("KONAMI COMPLETE!") != std::string::npos) {
+            foundKonamiComplete = true;
+        }
+    }
+    ASSERT_TRUE(foundKonamiComplete);
+}
+
+// Test: Hard mode win sets pendingProfileGame
+void autoBoonHardWinSetsPending(AutoBoonTestSuite* suite) {
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
+
+    suite->setupWinOutcome(true);  // hardMode = true
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);
+    suite->tick(1);
+
+    ASSERT_EQ(suite->device_.player->getPendingProfileGame(),
+              static_cast<int>(GameType::SIGNAL_ECHO));
+}
+
+// Test: Easy mode win does NOT set pendingProfileGame
+void autoBoonEasyWinNoPending(AutoBoonTestSuite* suite) {
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
+
+    suite->setupWinOutcome(false);  // hardMode = false
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);
+    suite->tick(1);
+
+    ASSERT_EQ(suite->device_.player->getPendingProfileGame(), -1);
+}
+
+// ============================================
+// PLAYER FIELD ACCESSORS TEST SUITE
+// ============================================
+
+// Test: isKonamiComplete when all 7 bits set
+void playerIsKonamiComplete(PlayerChallengeTestSuite* suite) {
+    ASSERT_FALSE(suite->player_->isKonamiComplete());
+    suite->player_->setKonamiProgress(0x7F);
+    ASSERT_TRUE(suite->player_->isKonamiComplete());
+    // Extra bits beyond 7 don't affect it
+    suite->player_->setKonamiProgress(0xFF);
+    ASSERT_TRUE(suite->player_->isKonamiComplete());
+}
+
+// Test: konamiBoon set/get
+void playerKonamiBoonSetGet(PlayerChallengeTestSuite* suite) {
+    ASSERT_FALSE(suite->player_->hasKonamiBoon());
+    suite->player_->setKonamiBoon(true);
+    ASSERT_TRUE(suite->player_->hasKonamiBoon());
+    suite->player_->setKonamiBoon(false);
+    ASSERT_FALSE(suite->player_->hasKonamiBoon());
+}
+
+// Test: lastFdnGameType set/get
+void playerLastFdnGameTypeSetGet(PlayerChallengeTestSuite* suite) {
+    ASSERT_EQ(suite->player_->getLastFdnGameType(), -1);
+    suite->player_->setLastFdnGameType(7);
+    ASSERT_EQ(suite->player_->getLastFdnGameType(), 7);
+}
+
+// Test: pendingProfileGame set/get
+void playerPendingProfileGameSetGet(PlayerChallengeTestSuite* suite) {
+    ASSERT_EQ(suite->player_->getPendingProfileGame(), -1);
+    suite->player_->setPendingProfileGame(7);
+    ASSERT_EQ(suite->player_->getPendingProfileGame(), 7);
+}
+
+// Test: getColorProfileEligibility returns the set
+void playerColorProfileEligibilitySet(PlayerChallengeTestSuite* suite) {
+    ASSERT_TRUE(suite->player_->getColorProfileEligibility().empty());
+    suite->player_->addColorProfileEligibility(7);
+    suite->player_->addColorProfileEligibility(3);
+    const auto& elig = suite->player_->getColorProfileEligibility();
+    ASSERT_EQ(elig.size(), 2u);
+    ASSERT_TRUE(elig.count(7) > 0);
+    ASSERT_TRUE(elig.count(3) > 0);
+}
+
+// ============================================
+// PROGRESS MANAGER EXTENDED TESTS
+// ============================================
+
+// Test: ProgressManager saves and loads konamiBoon
+void progressManagerSaveLoadBoon(ProgressManagerTestSuite* suite) {
+    ProgressManager pm;
+    pm.initialize(suite->device_.player, suite->device_.storageDriver);
+
+    suite->device_.player->setKonamiBoon(true);
+    pm.saveProgress();
+
+    // Reset player and reload
+    suite->device_.player->setKonamiBoon(false);
+    ASSERT_FALSE(suite->device_.player->hasKonamiBoon());
+
+    pm.loadProgress();
+    ASSERT_TRUE(suite->device_.player->hasKonamiBoon());
+}
+
+// Test: ProgressManager saves and loads equippedColorProfile
+void progressManagerSaveLoadProfile(ProgressManagerTestSuite* suite) {
+    ProgressManager pm;
+    pm.initialize(suite->device_.player, suite->device_.storageDriver);
+
+    suite->device_.player->setEquippedColorProfile(7);
+    pm.saveProgress();
+
+    suite->device_.player->setEquippedColorProfile(-1);
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(), -1);
+
+    pm.loadProgress();
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(), 7);
+}
+
+// Test: ProgressManager saves and loads colorProfileEligibility
+void progressManagerSaveLoadEligibility(ProgressManagerTestSuite* suite) {
+    ProgressManager pm;
+    pm.initialize(suite->device_.player, suite->device_.storageDriver);
+
+    suite->device_.player->addColorProfileEligibility(3);
+    suite->device_.player->addColorProfileEligibility(7);
+    pm.saveProgress();
+
+    // Create a fresh player to load into
+    Player freshPlayer;
+    ProgressManager pm2;
+    pm2.initialize(&freshPlayer, suite->device_.storageDriver);
+    pm2.loadProgress();
+
+    ASSERT_TRUE(freshPlayer.hasColorProfileEligibility(3));
+    ASSERT_TRUE(freshPlayer.hasColorProfileEligibility(7));
+    ASSERT_FALSE(freshPlayer.hasColorProfileEligibility(1));
+}
+
+// Test: ProgressManager clear resets all new fields
+void progressManagerClearAll(ProgressManagerTestSuite* suite) {
+    ProgressManager pm;
+    pm.initialize(suite->device_.player, suite->device_.storageDriver);
+
+    suite->device_.player->setKonamiProgress(0x7F);
+    suite->device_.player->setKonamiBoon(true);
+    suite->device_.player->setEquippedColorProfile(7);
+    suite->device_.player->addColorProfileEligibility(7);
+    pm.saveProgress();
+    pm.clearProgress();
+
+    // Load into fresh player
+    Player freshPlayer;
+    ProgressManager pm2;
+    pm2.initialize(&freshPlayer, suite->device_.storageDriver);
+    pm2.loadProgress();
+
+    ASSERT_EQ(freshPlayer.getKonamiProgress(), 0);
+    ASSERT_FALSE(freshPlayer.hasKonamiBoon());
+    ASSERT_EQ(freshPlayer.getEquippedColorProfile(), -1);
+    ASSERT_TRUE(freshPlayer.getColorProfileEligibility().empty());
+}
+
+// ============================================
+// SERVER SYNC TESTS
+// ============================================
+
+// Test: syncProgress sends PUT /api/progress
+void progressManagerSyncCallsServer(ProgressManagerTestSuite* suite) {
+    ProgressManager pm;
+    pm.initialize(suite->device_.player, suite->device_.storageDriver);
+
+    suite->device_.player->setKonamiProgress(0x7F);
+    suite->device_.player->setKonamiBoon(true);
+    pm.saveProgress();
+    ASSERT_TRUE(pm.hasUnsyncedProgress());
+
+    // Sync to server
+    pm.syncProgress(suite->device_.httpClientDriver);
+
+    // Process the queued request
+    suite->device_.httpClientDriver->exec();
+
+    // Verify request was made
+    auto& history = suite->device_.httpClientDriver->getRequestHistory();
+    ASSERT_FALSE(history.empty());
+
+    bool foundProgress = false;
+    for (const auto& entry : history) {
+        if (entry.path == "/api/progress" && entry.method == "PUT") {
+            foundProgress = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(foundProgress);
+}
+
+// ============================================
+// GETAPPIDFOREGAME TESTS
+// ============================================
+
+class GameRoutingTestSuite : public testing::Test {};
+
+// Test: getAppIdForGame returns correct IDs
+void gameRoutingSignalEcho(GameRoutingTestSuite* /*suite*/) {
+    ASSERT_EQ(getAppIdForGame(GameType::SIGNAL_ECHO), 2);
+    ASSERT_EQ(getAppIdForGame(GameType::FIREWALL_DECRYPT), 3);
+    ASSERT_EQ(getAppIdForGame(GameType::QUICKDRAW), -1);
+    ASSERT_EQ(getAppIdForGame(GameType::GHOST_RUNNER), -1);
+}
+
+// ============================================
+// KONAMI COMMAND TESTS
+// ============================================
+
+class KonamiCommandTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        devices_.push_back(DeviceFactory::createDevice(0, true));
+        SimpleTimer::setPlatformClock(devices_[0].clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        for (auto& dev : devices_) {
+            DeviceFactory::destroyDevice(dev);
+        }
+        devices_.clear();
+    }
+
+    std::vector<DeviceInstance> devices_;
+    Renderer renderer_;
+    CommandProcessor processor_;
+};
+
+// Test: konami command shows current progress
+void konamiCommandShowsProgress(KonamiCommandTestSuite* suite) {
+    suite->devices_[0].player->setKonamiProgress(0x03);  // UP + DOWN
+    int selected = 0;
+    auto result = suite->processor_.execute("konami", suite->devices_, selected, suite->renderer_);
+    ASSERT_TRUE(result.message.find("0x03") != std::string::npos);
+    ASSERT_TRUE(result.message.find("2/7") != std::string::npos);
+}
+
+// Test: konami command sets progress
+void konamiCommandSetsProgress(KonamiCommandTestSuite* suite) {
+    int selected = 0;
+    auto result = suite->processor_.execute("konami 127", suite->devices_, selected, suite->renderer_);
+    ASSERT_EQ(suite->devices_[0].player->getKonamiProgress(), 127);
+    ASSERT_TRUE(suite->devices_[0].player->hasKonamiBoon());
+    ASSERT_TRUE(result.message.find("7/7") != std::string::npos);
+    ASSERT_TRUE(result.message.find("boon=yes") != std::string::npos);
+}
+
+#endif // NATIVE_BUILD


### PR DESCRIPTION
## Summary
- **Difficulty gating**: FdnDetected routes EASY (no boon) or HARD (has boon) config to minigames
- **Auto-boon**: When all 7 Konami buttons collected, boon auto-grants in FdnComplete
- **NVS persistence**: ProgressManager saves/loads konamiBoon, equippedColorProfile, colorProfileEligibility
- **Server sync**: `PUT /api/progress` mock endpoint + syncProgress call after wins
- **Dynamic game routing**: `getAppIdForGame(GameType)` maps game types to AppConfig StateIds
- **Konami debug command**: `konami <device> [progress]` for testing

Part of #72 — FDN Progression Pipeline

## Test plan
- [x] 18 new CLI tests (DifficultyGating, AutoBoon, PlayerFields, ProgressManager, ServerSync, GameRouting, KonamiCommand)
- [x] All 169→187 CLI tests pass
- [x] 55/56 core tests (1 pre-existing SIGABRT)
- [x] Simulator builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)