### PR TITLE
E2E progression tests: full FDN loop + branching paths

### DIFF
--- a/include/cli/cli-device.hpp
+++ b/include/cli/cli-device.hpp
@@ -61,6 +61,8 @@ inline const char* getQuickdrawStateName(int stateId) {
         case 20: return "UploadMatches";
         case 21: return "FdnDetected";
         case 22: return "FdnComplete";
+        case 23: return "ColorProfilePrompt";
+        case 24: return "ColorProfilePicker";
         default: return "Unknown";
     }
 }

--- a/include/game/color-profiles.hpp
+++ b/include/game/color-profiles.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "device/drivers/light-interface.hpp"
+#include "device/device-types.hpp"
+
+/*
+ * Color profile lookup.
+ *
+ * Each minigame has a unique 9-LED palette that serves as a walking
+ * advertisement on the FDN NPC and as an equippable idle animation
+ * for players who beat hard mode.
+ *
+ * getColorProfileState(gameType) returns a const ref to the LEDState.
+ * Returns a default neutral palette if the game type has no profile.
+ */
+
+// Signal Echo palette — magenta/pink/purple
+const LEDState SIGNAL_ECHO_PROFILE_STATE = [](){
+    LEDState state;
+    LEDColor colors[9] = {
+        {255,0,255}, {200,0,200}, {255,50,200}, {180,0,255},
+        {255,0,255}, {200,0,200}, {255,50,200}, {180,0,255}, {180,0,255}
+    };
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(colors[i], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(colors[i], 65);
+    }
+    return state;
+}();
+
+// Firewall Decrypt palette — green/cyan hacker theme
+const LEDState FIREWALL_DECRYPT_PROFILE_STATE = [](){
+    LEDState state;
+    LEDColor colors[9] = {
+        {0,255,100}, {0,200,150}, {0,255,200}, {0,150,255},
+        {0,255,100}, {0,200,150}, {0,255,200}, {0,150,255}, {0,150,255}
+    };
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(colors[i], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(colors[i], 65);
+    }
+    return state;
+}();
+
+// Default/neutral palette — warm yellow/white
+const LEDState DEFAULT_PROFILE_STATE = [](){
+    LEDState state;
+    LEDColor colors[9] = {
+        {255,255,100}, {255,255,200}, {255,255,255}, {200,200,150},
+        {255,255,100}, {255,255,200}, {255,255,255}, {200,200,150}, {200,200,150}
+    };
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(colors[i], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(colors[i], 65);
+    }
+    return state;
+}();
+
+/*
+ * Look up the LED profile state for a given game type.
+ * Returns DEFAULT_PROFILE_STATE if no specific profile exists.
+ */
+inline const LEDState& getColorProfileState(int gameType) {
+    switch (static_cast<GameType>(gameType)) {
+        case GameType::SIGNAL_ECHO:       return SIGNAL_ECHO_PROFILE_STATE;
+        case GameType::FIREWALL_DECRYPT:  return FIREWALL_DECRYPT_PROFILE_STATE;
+        default:                          return DEFAULT_PROFILE_STATE;
+    }
+}
+
+/*
+ * Get display name for a color profile.
+ */
+inline const char* getColorProfileName(int gameType) {
+    if (gameType < 0) return "DEFAULT";
+    return getGameDisplayName(static_cast<GameType>(gameType));
+}

--- a/src/game/quickdraw-states/color-profile-picker.cpp
+++ b/src/game/quickdraw-states/color-profile-picker.cpp
@@ -1,0 +1,121 @@
+#include "game/quickdraw-states.hpp"
+#include "game/quickdraw.hpp"
+#include "game/color-profiles.hpp"
+#include "game/progress-manager.hpp"
+#include "device/drivers/logger.hpp"
+#include "device/device-types.hpp"
+
+static const char* TAG = "ColorProfilePicker";
+
+ColorProfilePicker::ColorProfilePicker(Player* player, ProgressManager* progressManager) :
+    State(COLOR_PROFILE_PICKER),
+    player(player),
+    progressManager(progressManager)
+{
+}
+
+ColorProfilePicker::~ColorProfilePicker() {
+    player = nullptr;
+    progressManager = nullptr;
+}
+
+void ColorProfilePicker::buildProfileList() {
+    profileList.clear();
+    // Add eligible game profiles
+    for (int gameType : player->getColorProfileEligibility()) {
+        profileList.push_back(gameType);
+    }
+    // Always add DEFAULT as last option
+    profileList.push_back(-1);
+}
+
+void ColorProfilePicker::onStateMounted(Device* PDN) {
+    transitionToIdleState = false;
+    displayIsDirty = false;
+    cursorIndex = 0;
+
+    buildProfileList();
+
+    // Pre-select currently equipped profile
+    int equipped = player->getEquippedColorProfile();
+    for (size_t i = 0; i < profileList.size(); i++) {
+        if (profileList[i] == equipped) {
+            cursorIndex = static_cast<int>(i);
+            break;
+        }
+    }
+
+    LOG_I(TAG, "Color picker opened, %zu profiles available", profileList.size());
+
+    // Primary = scroll, Secondary = confirm
+    parameterizedCallbackFunction scrollCb = [](void* ctx) {
+        auto* self = static_cast<ColorProfilePicker*>(ctx);
+        self->cursorIndex = (self->cursorIndex + 1) % static_cast<int>(self->profileList.size());
+        self->displayIsDirty = true;
+    };
+
+    parameterizedCallbackFunction confirmCb = [](void* ctx) {
+        auto* self = static_cast<ColorProfilePicker*>(ctx);
+        int selected = self->profileList[self->cursorIndex];
+        self->player->setEquippedColorProfile(selected);
+        LOG_I(TAG, "Equipped profile: %s", getColorProfileName(selected));
+        if (self->progressManager) {
+            self->progressManager->saveProgress();
+        }
+        self->transitionToIdleState = true;
+    };
+
+    PDN->getPrimaryButton()->setButtonPress(scrollCb, this, ButtonInteraction::CLICK);
+    PDN->getSecondaryButton()->setButtonPress(confirmCb, this, ButtonInteraction::CLICK);
+
+    renderUi(PDN);
+}
+
+void ColorProfilePicker::onStateLoop(Device* PDN) {
+    if (displayIsDirty) {
+        renderUi(PDN);
+        displayIsDirty = false;
+    }
+}
+
+void ColorProfilePicker::onStateDismounted(Device* PDN) {
+    profileList.clear();
+    PDN->getPrimaryButton()->removeButtonCallbacks();
+    PDN->getSecondaryButton()->removeButtonCallbacks();
+}
+
+bool ColorProfilePicker::transitionToIdle() {
+    return transitionToIdleState;
+}
+
+void ColorProfilePicker::renderUi(Device* PDN) {
+    if (!PDN) return;
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+    PDN->getDisplay()->drawText("COLOR PALETTE", 10, 12);
+
+    // Show up to 3 items centered around cursor
+    int listSize = static_cast<int>(profileList.size());
+    int startIdx = cursorIndex;  // Start from cursor, show up to 3
+    int visibleCount = (listSize < 3) ? listSize : 3;
+
+    for (int i = 0; i < visibleCount; i++) {
+        int idx = (startIdx + i) % listSize;
+        int y = 28 + (i * 12);
+        const char* name = getColorProfileName(profileList[idx]);
+
+        if (idx == cursorIndex) {
+            char line[32];
+            snprintf(line, sizeof(line), "> %s", name);
+            PDN->getDisplay()->drawText(line, 5, y);
+        } else {
+            char line[32];
+            snprintf(line, sizeof(line), "  %s", name);
+            PDN->getDisplay()->drawText(line, 5, y);
+        }
+    }
+
+    PDN->getDisplay()->drawText("UP:scroll DOWN:ok", 5, 60);
+    PDN->getDisplay()->render();
+}

--- a/src/game/quickdraw-states/color-profile-prompt.cpp
+++ b/src/game/quickdraw-states/color-profile-prompt.cpp
@@ -1,0 +1,101 @@
+#include "game/quickdraw-states.hpp"
+#include "game/quickdraw.hpp"
+#include "game/color-profiles.hpp"
+#include "game/progress-manager.hpp"
+#include "device/drivers/logger.hpp"
+#include "device/device-types.hpp"
+
+static const char* TAG = "ColorProfilePrompt";
+
+ColorProfilePrompt::ColorProfilePrompt(Player* player, ProgressManager* progressManager) :
+    State(COLOR_PROFILE_PROMPT),
+    player(player),
+    progressManager(progressManager)
+{
+}
+
+ColorProfilePrompt::~ColorProfilePrompt() {
+    player = nullptr;
+    progressManager = nullptr;
+}
+
+void ColorProfilePrompt::onStateMounted(Device* PDN) {
+    transitionToIdleState = false;
+    selectYes = true;
+
+    int gameType = player->getPendingProfileGame();
+    LOG_I(TAG, "Color profile prompt for game type %d", gameType);
+
+    // Set up button callbacks
+    parameterizedCallbackFunction toggleCb = [](void* ctx) {
+        auto* self = static_cast<ColorProfilePrompt*>(ctx);
+        self->selectYes = !self->selectYes;
+        self->renderUi(nullptr);  // Will be rendered on next loop
+    };
+
+    parameterizedCallbackFunction confirmCb = [](void* ctx) {
+        auto* self = static_cast<ColorProfilePrompt*>(ctx);
+        int gameType = self->player->getPendingProfileGame();
+
+        if (self->selectYes && gameType >= 0) {
+            self->player->setEquippedColorProfile(gameType);
+            LOG_I(TAG, "Equipped color profile: %s",
+                   getColorProfileName(gameType));
+            if (self->progressManager) {
+                self->progressManager->saveProgress();
+            }
+        } else {
+            LOG_I(TAG, "Declined color profile");
+        }
+        self->transitionToIdleState = true;
+    };
+
+    PDN->getPrimaryButton()->setButtonPress(toggleCb, this, ButtonInteraction::CLICK);
+    PDN->getSecondaryButton()->setButtonPress(confirmCb, this, ButtonInteraction::CLICK);
+
+    // Auto-dismiss timer
+    dismissTimer.setTimer(AUTO_DISMISS_MS);
+
+    renderUi(PDN);
+}
+
+void ColorProfilePrompt::onStateLoop(Device* PDN) {
+    dismissTimer.updateTime();
+    if (dismissTimer.expired()) {
+        LOG_I(TAG, "Auto-dismissed (NO)");
+        transitionToIdleState = true;
+    }
+}
+
+void ColorProfilePrompt::onStateDismounted(Device* PDN) {
+    dismissTimer.invalidate();
+    player->setPendingProfileGame(-1);
+    PDN->getPrimaryButton()->removeButtonCallbacks();
+    PDN->getSecondaryButton()->removeButtonCallbacks();
+}
+
+bool ColorProfilePrompt::transitionToIdle() {
+    return transitionToIdleState;
+}
+
+void ColorProfilePrompt::renderUi(Device* PDN) {
+    if (!PDN) return;
+
+    int gameType = player->getPendingProfileGame();
+    const char* gameName = (gameType >= 0) ? getGameDisplayName(static_cast<GameType>(gameType)) : "UNKNOWN";
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+    PDN->getDisplay()->drawText("NEW PALETTE!", 15, 12);
+    PDN->getDisplay()->drawText(gameName, 15, 28);
+    PDN->getDisplay()->drawText("EQUIP?", 10, 44);
+
+    if (selectYes) {
+        PDN->getDisplay()->drawText("[YES] NO", 60, 44);
+    } else {
+        PDN->getDisplay()->drawText("YES [NO]", 60, 44);
+    }
+
+    PDN->getDisplay()->drawText("UP:toggle DOWN:ok", 5, 60);
+    PDN->getDisplay()->render();
+}

--- a/src/game/quickdraw-states/fdn-complete-state.cpp
+++ b/src/game/quickdraw-states/fdn-complete-state.cpp
@@ -24,6 +24,7 @@ FdnComplete::~FdnComplete() {
 void FdnComplete::onStateMounted(Device* PDN) {
     LOG_I(TAG, "FDN complete mounted");
     transitionToIdleState = false;
+    transitionToColorPromptState = false;
 
     // Look up the minigame using the game type tracked by FdnDetected
     int lastGameType = player->getLastFdnGameType();
@@ -99,13 +100,22 @@ void FdnComplete::onStateMounted(Device* PDN) {
 void FdnComplete::onStateLoop(Device* PDN) {
     displayTimer.updateTime();
     if (displayTimer.expired()) {
-        transitionToIdleState = true;
+        // Route to color prompt if hard mode was won and profile is pending
+        if (player->getPendingProfileGame() >= 0) {
+            transitionToColorPromptState = true;
+        } else {
+            transitionToIdleState = true;
+        }
     }
 }
 
 void FdnComplete::onStateDismounted(Device* PDN) {
     displayTimer.invalidate();
     player->clearPendingChallenge();
+}
+
+bool FdnComplete::transitionToColorPrompt() {
+    return transitionToColorPromptState;
 }
 
 bool FdnComplete::transitionToIdle() {

--- a/src/game/quickdraw.cpp
+++ b/src/game/quickdraw.cpp
@@ -55,6 +55,8 @@ void Quickdraw::populateStateMap() {
 
     FdnDetected* fdnDetected = new FdnDetected(player);
     FdnComplete* fdnComplete = new FdnComplete(player, progressManager);
+    ColorProfilePrompt* colorProfilePrompt = new ColorProfilePrompt(player, progressManager);
+    ColorProfilePicker* colorProfilePicker = new ColorProfilePicker(player, progressManager);
 
     playerRegistration->addTransition(
         new StateTransition(
@@ -113,6 +115,11 @@ void Quickdraw::populateStateMap() {
 
     idle->addTransition(
         new StateTransition(
+            std::bind(&Idle::transitionToColorPicker, idle),
+            colorProfilePicker));
+
+    idle->addTransition(
+        new StateTransition(
             std::bind(&Idle::isFdnDetected, idle),
             fdnDetected));
 
@@ -133,7 +140,22 @@ void Quickdraw::populateStateMap() {
 
     fdnComplete->addTransition(
         new StateTransition(
+            std::bind(&FdnComplete::transitionToColorPrompt, fdnComplete),
+            colorProfilePrompt));
+
+    fdnComplete->addTransition(
+        new StateTransition(
             std::bind(&FdnComplete::transitionToIdle, fdnComplete),
+            idle));
+
+    colorProfilePrompt->addTransition(
+        new StateTransition(
+            std::bind(&ColorProfilePrompt::transitionToIdle, colorProfilePrompt),
+            idle));
+
+    colorProfilePicker->addTransition(
+        new StateTransition(
+            std::bind(&ColorProfilePicker::transitionToIdle, colorProfilePicker),
             idle));
 
     handshakeInitiate->addTransition(
@@ -264,6 +286,8 @@ void Quickdraw::populateStateMap() {
     stateMap.push_back(sleep);
     stateMap.push_back(fdnDetected);
     stateMap.push_back(fdnComplete);
+    stateMap.push_back(colorProfilePrompt);
+    stateMap.push_back(colorProfilePicker);
 }
 
 Image Quickdraw::getImageForAllegiance(Allegiance allegiance, ImageType whichImage) {

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -17,6 +17,7 @@
 #include "signal-echo-tests.hpp"
 #include "fdn-integration-tests.hpp"
 #include "progression-core-tests.hpp"
+#include "color-profile-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -812,6 +813,114 @@ TEST_F(KonamiCommandTestSuite, ShowsProgress) {
 
 TEST_F(KonamiCommandTestSuite, SetsProgress) {
     konamiCommandSetsProgress(this);
+}
+
+// ============================================
+// COLOR PROFILE LOOKUP TESTS
+// ============================================
+
+TEST_F(ColorProfileLookupTestSuite, SignalEcho) {
+    colorProfileLookupSignalEcho(this);
+}
+
+TEST_F(ColorProfileLookupTestSuite, FirewallDecrypt) {
+    colorProfileLookupFirewallDecrypt(this);
+}
+
+TEST_F(ColorProfileLookupTestSuite, Default) {
+    colorProfileLookupDefault(this);
+}
+
+TEST_F(ColorProfileLookupTestSuite, Names) {
+    colorProfileLookupNames(this);
+}
+
+// ============================================
+// COLOR PROFILE PROMPT TESTS
+// ============================================
+
+TEST_F(ColorProfilePromptTestSuite, YesEquips) {
+    colorProfilePromptYesEquips(this);
+}
+
+TEST_F(ColorProfilePromptTestSuite, NoDoesNotEquip) {
+    colorProfilePromptNoDoesNotEquip(this);
+}
+
+TEST_F(ColorProfilePromptTestSuite, AutoDismiss) {
+    colorProfilePromptAutoDismiss(this);
+}
+
+TEST_F(ColorProfilePromptTestSuite, ShowsDisplay) {
+    colorProfilePromptShowsDisplay(this);
+}
+
+TEST_F(ColorProfilePromptTestSuite, ClearsPending) {
+    colorProfilePromptClearsPending(this);
+}
+
+// ============================================
+// COLOR PROFILE PICKER TESTS
+// ============================================
+
+TEST_F(ColorProfilePickerTestSuite, ShowsHeader) {
+    colorProfilePickerShowsHeader(this);
+}
+
+TEST_F(ColorProfilePickerTestSuite, ScrollWraps) {
+    colorProfilePickerScrollWraps(this);
+}
+
+TEST_F(ColorProfilePickerTestSuite, SelectDefault) {
+    colorProfilePickerSelectDefault(this);
+}
+
+TEST_F(ColorProfilePickerTestSuite, TransitionsToIdle) {
+    colorProfilePickerTransitionsToIdle(this);
+}
+
+TEST_F(ColorProfilePickerTestSuite, PreselectsEquipped) {
+    colorProfilePickerPreselectsEquipped(this);
+}
+
+// ============================================
+// FDN COMPLETE ROUTING TESTS
+// ============================================
+
+TEST_F(FdnCompleteRoutingTestSuite, RoutesToPromptOnHardWin) {
+    fdnCompleteRoutesToPromptOnHardWin(this);
+}
+
+TEST_F(FdnCompleteRoutingTestSuite, RoutesToIdleOnEasyWin) {
+    fdnCompleteRoutesToIdleOnEasyWin(this);
+}
+
+TEST_F(FdnCompleteRoutingTestSuite, RoutesToIdleOnLoss) {
+    fdnCompleteRoutesToIdleOnLoss(this);
+}
+
+// ============================================
+// IDLE COLOR PICKER ENTRY TESTS
+// ============================================
+
+TEST_F(IdleColorPickerTestSuite, LongPressEntersPicker) {
+    idleLongPressEntersPicker(this);
+}
+
+TEST_F(IdleColorPickerTestSuite, LongPressNoPickerWithoutEligibility) {
+    idleLongPressNoPickerWithoutEligibility(this);
+}
+
+// ============================================
+// STATE NAME TESTS
+// ============================================
+
+TEST_F(StateNameTestSuite, ColorProfilePrompt) {
+    stateNameColorProfilePrompt(this);
+}
+
+TEST_F(StateNameTestSuite, ColorProfilePicker) {
+    stateNameColorProfilePicker(this);
 }
 
 // ============================================

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -19,6 +19,7 @@
 #include "progression-core-tests.hpp"
 #include "firewall-decrypt-tests.hpp"
 #include "color-profile-tests.hpp"
+#include "progression-e2e-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -1042,6 +1043,66 @@ TEST_F(StateNameTestSuite, ColorProfilePrompt) {
 
 TEST_F(StateNameTestSuite, ColorProfilePicker) {
     stateNameColorProfilePicker(this);
+}
+
+// ============================================
+// E2E PROGRESSION TESTS
+// ============================================
+
+TEST_F(ProgressionE2ETestSuite, SignalEchoEasyWin) {
+    e2eSignalEchoEasyWin(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, AutoBoonOnSeventhButton) {
+    e2eAutoBoonOnSeventhButton(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, ServerSyncOnWin) {
+    e2eServerSyncOnWin(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, HardModeColorEquip) {
+    e2eHardModeColorEquip(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, ColorPromptDecline) {
+    e2eColorPromptDecline(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, ColorPickerFromIdle) {
+    e2eColorPickerFromIdle(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, EasyModeLoss) {
+    e2eEasyModeLoss(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, HardModeLoss) {
+    e2eHardModeLoss(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, FirewallDecryptProgression) {
+    e2eFirewallDecryptProgression(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, FirewallDecryptHard) {
+    e2eFirewallDecryptHard(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, NvsRoundTrip) {
+    e2eNvsRoundTrip(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, PromptAutoDismiss) {
+    e2ePromptAutoDismiss(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, DifficultyGatingDynamic) {
+    e2eDifficultyGatingDynamic(this);
+}
+
+TEST_F(ProgressionE2ETestSuite, EquipLaterViaPicker) {
+    e2eEquipLaterViaPicker(this);
 }
 
 // ============================================

--- a/test/test_cli/color-profile-tests.hpp
+++ b/test/test_cli/color-profile-tests.hpp
@@ -1,0 +1,456 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "game/color-profiles.hpp"
+#include "game/progress-manager.hpp"
+#include "game/minigame.hpp"
+#include "device/device-types.hpp"
+#include "utils/simple-timer.hpp"
+
+using namespace cli;
+
+// ============================================
+// COLOR PROFILE LOOKUP TEST SUITE
+// ============================================
+
+class ColorProfileLookupTestSuite : public testing::Test {};
+
+// Test: getColorProfileState returns Signal Echo palette
+void colorProfileLookupSignalEcho(ColorProfileLookupTestSuite* /*suite*/) {
+    const LEDState& state = getColorProfileState(static_cast<int>(GameType::SIGNAL_ECHO));
+    // Signal Echo palette: first LED should be magenta (255,0,255)
+    ASSERT_EQ(state.leftLights[0].color.red, 255);
+    ASSERT_EQ(state.leftLights[0].color.green, 0);
+    ASSERT_EQ(state.leftLights[0].color.blue, 255);
+}
+
+// Test: getColorProfileState returns Firewall Decrypt palette
+void colorProfileLookupFirewallDecrypt(ColorProfileLookupTestSuite* /*suite*/) {
+    const LEDState& state = getColorProfileState(static_cast<int>(GameType::FIREWALL_DECRYPT));
+    // Firewall Decrypt palette: first LED should be green (0,255,100)
+    ASSERT_EQ(state.leftLights[0].color.red, 0);
+    ASSERT_EQ(state.leftLights[0].color.green, 255);
+    ASSERT_EQ(state.leftLights[0].color.blue, 100);
+}
+
+// Test: getColorProfileState returns default for unknown game type
+void colorProfileLookupDefault(ColorProfileLookupTestSuite* /*suite*/) {
+    const LEDState& state = getColorProfileState(-1);
+    // Default palette: warm yellow (255,255,100)
+    ASSERT_EQ(state.leftLights[0].color.red, 255);
+    ASSERT_EQ(state.leftLights[0].color.green, 255);
+    ASSERT_EQ(state.leftLights[0].color.blue, 100);
+}
+
+// Test: getColorProfileName returns correct names
+void colorProfileLookupNames(ColorProfileLookupTestSuite* /*suite*/) {
+    ASSERT_STREQ(getColorProfileName(-1), "DEFAULT");
+    const char* echoName = getColorProfileName(static_cast<int>(GameType::SIGNAL_ECHO));
+    ASSERT_NE(echoName, nullptr);
+    ASSERT_STRNE(echoName, "DEFAULT");
+}
+
+// ============================================
+// COLOR PROFILE PROMPT TEST SUITE
+// ============================================
+
+class ColorProfilePromptTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            device_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            device_.clockDriver->advance(delayMs);
+            device_.pdn->loop();
+        }
+    }
+
+    void skipToPrompt() {
+        // Set up player state: pending profile game set
+        device_.player->setPendingProfileGame(static_cast<int>(GameType::SIGNAL_ECHO));
+        device_.game->skipToState(device_.pdn, 23);  // ColorProfilePrompt
+        tick(1);
+    }
+
+    int getStateId() {
+        return device_.game->getCurrentState()->getStateId();
+    }
+
+    DeviceInstance device_;
+};
+
+// Test: YES equips the color profile
+void colorProfilePromptYesEquips(ColorProfilePromptTestSuite* suite) {
+    suite->skipToPrompt();
+    ASSERT_EQ(suite->getStateId(), COLOR_PROFILE_PROMPT);
+
+    // Default selection is YES. Press secondary to confirm.
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(),
+              static_cast<int>(GameType::SIGNAL_ECHO));
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// Test: Toggling to NO then confirming does NOT equip
+void colorProfilePromptNoDoesNotEquip(ColorProfilePromptTestSuite* suite) {
+    suite->skipToPrompt();
+    ASSERT_EQ(suite->getStateId(), COLOR_PROFILE_PROMPT);
+
+    // Toggle to NO (primary), then confirm (secondary)
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(), -1);
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// Test: Auto-dismiss after timeout defaults to NO
+void colorProfilePromptAutoDismiss(ColorProfilePromptTestSuite* suite) {
+    suite->skipToPrompt();
+    ASSERT_EQ(suite->getStateId(), COLOR_PROFILE_PROMPT);
+
+    // Advance past 10s auto-dismiss
+    suite->tickWithTime(20, 600);
+
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(), -1);
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// Test: Display shows EQUIP text and YES/NO
+void colorProfilePromptShowsDisplay(ColorProfilePromptTestSuite* suite) {
+    suite->skipToPrompt();
+
+    auto& textHistory = suite->device_.displayDriver->getTextHistory();
+    bool foundEquip = false;
+    bool foundYesNo = false;
+    for (const auto& entry : textHistory) {
+        if (entry.find("EQUIP?") != std::string::npos) foundEquip = true;
+        if (entry.find("YES") != std::string::npos) foundYesNo = true;
+    }
+    ASSERT_TRUE(foundEquip);
+    ASSERT_TRUE(foundYesNo);
+}
+
+// Test: Clears pendingProfileGame on dismount
+void colorProfilePromptClearsPending(ColorProfilePromptTestSuite* suite) {
+    suite->skipToPrompt();
+
+    suite->device_.player->setPendingProfileGame(7);
+    // Confirm YES to transition away
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->device_.player->getPendingProfileGame(), -1);
+}
+
+// ============================================
+// COLOR PROFILE PICKER TEST SUITE
+// ============================================
+
+class ColorProfilePickerTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            device_.pdn->loop();
+        }
+    }
+
+    void skipToPicker() {
+        // Add some eligible profiles
+        device_.player->addColorProfileEligibility(static_cast<int>(GameType::SIGNAL_ECHO));
+        device_.game->skipToState(device_.pdn, 24);  // ColorProfilePicker
+        tick(1);
+    }
+
+    int getStateId() {
+        return device_.game->getCurrentState()->getStateId();
+    }
+
+    DeviceInstance device_;
+};
+
+// Test: Picker shows COLOR PALETTE header
+void colorProfilePickerShowsHeader(ColorProfilePickerTestSuite* suite) {
+    suite->skipToPicker();
+    ASSERT_EQ(suite->getStateId(), COLOR_PROFILE_PICKER);
+
+    auto& textHistory = suite->device_.displayDriver->getTextHistory();
+    bool foundHeader = false;
+    for (const auto& entry : textHistory) {
+        if (entry.find("COLOR PALETTE") != std::string::npos) foundHeader = true;
+    }
+    ASSERT_TRUE(foundHeader);
+}
+
+// Test: Scrolling wraps around profile list
+void colorProfilePickerScrollWraps(ColorProfilePickerTestSuite* suite) {
+    suite->skipToPicker();
+
+    // profileList = [SIGNAL_ECHO(7), DEFAULT(-1)]
+    // Pre-select: equipped=-1 → cursorIndex=1 (DEFAULT)
+    // Scroll once → wraps to index 0 (SIGNAL_ECHO)
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+
+    // Scroll again → back to index 1 (DEFAULT)
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+
+    // Scroll third time → wraps to index 0 (SIGNAL_ECHO)
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+
+    // Confirm — should equip SIGNAL_ECHO
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(),
+              static_cast<int>(GameType::SIGNAL_ECHO));
+}
+
+// Test: Selecting DEFAULT equips -1
+void colorProfilePickerSelectDefault(ColorProfilePickerTestSuite* suite) {
+    suite->skipToPicker();
+
+    // profileList = [SIGNAL_ECHO(7), DEFAULT(-1)]
+    // Pre-select: equipped=-1 → cursorIndex=1 (DEFAULT)
+    // Already on DEFAULT, just confirm
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(), -1);
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// Test: Picker transitions back to Idle on confirm
+void colorProfilePickerTransitionsToIdle(ColorProfilePickerTestSuite* suite) {
+    suite->skipToPicker();
+
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// Test: Pre-selects currently equipped profile
+void colorProfilePickerPreselectsEquipped(ColorProfilePickerTestSuite* suite) {
+    // Equip Signal Echo before entering picker
+    suite->device_.player->setEquippedColorProfile(static_cast<int>(GameType::SIGNAL_ECHO));
+    suite->skipToPicker();
+
+    // Confirm immediately (should keep SIGNAL_ECHO since it was pre-selected)
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(),
+              static_cast<int>(GameType::SIGNAL_ECHO));
+}
+
+// ============================================
+// FDN COMPLETE → COLOR PROMPT ROUTING
+// ============================================
+
+class FdnCompleteRoutingTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            device_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            device_.clockDriver->advance(delayMs);
+            device_.pdn->loop();
+        }
+    }
+
+    void setupWinOutcome(bool hardMode = false) {
+        auto* echo = dynamic_cast<MiniGame*>(
+            device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+        MiniGameOutcome outcome;
+        outcome.result = MiniGameResult::WON;
+        outcome.score = 100;
+        outcome.hardMode = hardMode;
+        echo->setOutcome(outcome);
+    }
+
+    int getStateId() {
+        return device_.game->getCurrentState()->getStateId();
+    }
+
+    DeviceInstance device_;
+};
+
+// Test: Hard win routes to ColorProfilePrompt
+void fdnCompleteRoutesToPromptOnHardWin(FdnCompleteRoutingTestSuite* suite) {
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
+    suite->setupWinOutcome(true);  // hard mode
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);  // FdnComplete
+    suite->tick(1);
+
+    // pendingProfileGame should be set
+    ASSERT_GE(suite->device_.player->getPendingProfileGame(), 0);
+
+    // Wait for display timer
+    suite->tickWithTime(10, 400);
+
+    ASSERT_EQ(suite->getStateId(), COLOR_PROFILE_PROMPT);
+}
+
+// Test: Easy win routes to Idle (no color prompt)
+void fdnCompleteRoutesToIdleOnEasyWin(FdnCompleteRoutingTestSuite* suite) {
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
+    suite->setupWinOutcome(false);  // easy mode
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);  // FdnComplete
+    suite->tick(1);
+
+    // pendingProfileGame should NOT be set
+    ASSERT_EQ(suite->device_.player->getPendingProfileGame(), -1);
+
+    // Wait for display timer
+    suite->tickWithTime(10, 400);
+
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// Test: Loss routes to Idle (no color prompt)
+void fdnCompleteRoutesToIdleOnLoss(FdnCompleteRoutingTestSuite* suite) {
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
+
+    auto* echo = dynamic_cast<MiniGame*>(
+        suite->device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+    MiniGameOutcome outcome;
+    outcome.result = MiniGameResult::LOST;
+    outcome.score = 50;
+    outcome.hardMode = true;
+    echo->setOutcome(outcome);
+
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);  // FdnComplete
+    suite->tick(1);
+
+    suite->tickWithTime(10, 400);
+
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// ============================================
+// IDLE COLOR PICKER ENTRY TEST SUITE
+// ============================================
+
+class IdleColorPickerTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            device_.pdn->loop();
+        }
+    }
+
+    void skipToIdle() {
+        device_.game->skipToState(device_.pdn, 7);  // Idle
+        tick(1);
+    }
+
+    int getStateId() {
+        return device_.game->getCurrentState()->getStateId();
+    }
+
+    DeviceInstance device_;
+};
+
+// Test: Long press secondary enters ColorProfilePicker when eligible profiles exist
+void idleLongPressEntersPicker(IdleColorPickerTestSuite* suite) {
+    suite->device_.player->addColorProfileEligibility(static_cast<int>(GameType::SIGNAL_ECHO));
+    suite->skipToIdle();
+    ASSERT_EQ(suite->getStateId(), IDLE);
+
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::LONG_PRESS);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->getStateId(), COLOR_PROFILE_PICKER);
+}
+
+// Test: Long press does NOT enter picker when no eligible profiles
+void idleLongPressNoPickerWithoutEligibility(IdleColorPickerTestSuite* suite) {
+    suite->skipToIdle();
+    ASSERT_EQ(suite->getStateId(), IDLE);
+
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::LONG_PRESS);
+    suite->tick(2);
+
+    // Should stay in Idle since no eligible profiles
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// ============================================
+// STATE NAME MAPPING TESTS
+// ============================================
+
+class StateNameTestSuite : public testing::Test {};
+
+void stateNameColorProfilePrompt(StateNameTestSuite* /*suite*/) {
+    ASSERT_STREQ(getQuickdrawStateName(23), "ColorProfilePrompt");
+}
+
+void stateNameColorProfilePicker(StateNameTestSuite* /*suite*/) {
+    ASSERT_STREQ(getQuickdrawStateName(24), "ColorProfilePicker");
+}
+
+#endif // NATIVE_BUILD

--- a/test/test_cli/progression-e2e-tests.hpp
+++ b/test/test_cli/progression-e2e-tests.hpp
@@ -1,0 +1,566 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+#include "game/firewall-decrypt/firewall-decrypt.hpp"
+#include "game/firewall-decrypt/firewall-decrypt-states.hpp"
+#include "game/firewall-decrypt/firewall-decrypt-resources.hpp"
+#include "game/color-profiles.hpp"
+#include "game/minigame.hpp"
+#include "game/progress-manager.hpp"
+#include "device/device-constants.hpp"
+#include "device/device-types.hpp"
+#include "utils/simple-timer.hpp"
+
+using namespace cli;
+
+// ============================================
+// E2E PROGRESSION TEST SUITE
+//
+// Full end-to-end tests covering the entire FDN
+// progression loop: Idle → FDN → minigame → FdnComplete
+// → Konami button → auto-boon → color profile → equip.
+// ============================================
+
+class ProgressionE2ETestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        player_ = DeviceFactory::createDevice(0, true);
+        fdn_ = DeviceFactory::createFdnDevice(1, GameType::SIGNAL_ECHO);
+        SimpleTimer::setPlatformClock(player_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(fdn_);
+        DeviceFactory::destroyDevice(player_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            SerialCableBroker::getInstance().transferData();
+            player_.pdn->loop();
+            fdn_.pdn->loop();
+        }
+    }
+
+    void tickPlayerWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            player_.clockDriver->advance(delayMs);
+            player_.pdn->loop();
+        }
+    }
+
+    void advanceToIdle() {
+        player_.game->skipToState(player_.pdn, 7);
+        player_.pdn->loop();
+    }
+
+    int getPlayerStateId() {
+        return player_.game->getCurrentState()->getStateId();
+    }
+
+    SignalEcho* getSignalEcho() {
+        return dynamic_cast<SignalEcho*>(
+            player_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+    }
+
+    FirewallDecrypt* getFirewallDecrypt() {
+        return dynamic_cast<FirewallDecrypt*>(
+            player_.pdn->getApp(StateId(FIREWALL_DECRYPT_APP_ID)));
+    }
+
+    // Helper: trigger FDN handshake from Idle
+    // gameType: "7" for SIGNAL_ECHO, "3" for FIREWALL_DECRYPT
+    // reward: "6" for START, "2" for LEFT
+    void triggerFdnHandshake(const std::string& gameType, const std::string& reward) {
+        std::string msg = "*fdn:" + gameType + ":" + reward + "\r";
+        player_.serialOutDriver->injectInput(msg.c_str());
+        tick(3);
+        ASSERT_EQ(getPlayerStateId(), FDN_DETECTED);
+
+        player_.serialOutDriver->injectInput("*fack\r");
+        tickPlayerWithTime(5, 100);
+    }
+
+    // Helper: play Signal Echo to completion (win).
+    // Advances through intro, show sequence, player input for all rounds.
+    void playSignalEchoToWin() {
+        auto* echo = getSignalEcho();
+        ASSERT_NE(echo, nullptr);
+
+        // Advance past intro timer (2s)
+        tickPlayerWithTime(5, 500);
+
+        int numRounds = echo->getConfig().numSequences;
+        for (int round = 0; round < numRounds; round++) {
+            // In ShowSequence state — advance past all signal displays
+            int seqLen = echo->getConfig().sequenceLength;
+            int displayMs = echo->getConfig().displaySpeedMs;
+            tickPlayerWithTime(seqLen * 3, displayMs);
+
+            // Now in PlayerInput — press the correct sequence
+            auto& session = echo->getSession();
+            std::vector<bool> seq = session.currentSequence;
+            for (bool isUp : seq) {
+                if (isUp) {
+                    player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+                } else {
+                    player_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+                }
+                tickPlayerWithTime(1, 10);
+            }
+
+            // Tick to process evaluate + next round transition
+            tickPlayerWithTime(3, 10);
+        }
+    }
+
+    // Helper: play Firewall Decrypt to completion (win).
+    void playFirewallDecryptToWin() {
+        auto* fw = getFirewallDecrypt();
+        ASSERT_NE(fw, nullptr);
+
+        // Advance past intro timer (2s)
+        tickPlayerWithTime(5, 500);
+
+        int numRounds = fw->getConfig().numRounds;
+        for (int round = 0; round < numRounds; round++) {
+            auto& session = fw->getSession();
+
+            // Scroll to target index
+            for (int i = 0; i < session.targetIndex; i++) {
+                player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+                tickPlayerWithTime(1, 10);
+            }
+
+            // Confirm correct selection
+            player_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+            tickPlayerWithTime(3, 10);
+        }
+    }
+
+    // Helper: play Signal Echo and intentionally lose (press wrong every time)
+    void playSignalEchoToLose() {
+        auto* echo = getSignalEcho();
+        ASSERT_NE(echo, nullptr);
+
+        // Advance past intro
+        tickPlayerWithTime(5, 500);
+
+        // In ShowSequence — advance past signal displays
+        int seqLen = echo->getConfig().sequenceLength;
+        int displayMs = echo->getConfig().displaySpeedMs;
+        tickPlayerWithTime(seqLen * 3, displayMs);
+
+        // In PlayerInput — press wrong buttons until mistakes exceed allowed
+        auto& session = echo->getSession();
+        int allowed = echo->getConfig().allowedMistakes;
+        for (int i = 0; i <= allowed + 1; i++) {
+            bool expected = session.currentSequence[i % seqLen];
+            // Press the opposite of what's expected
+            if (expected) {
+                player_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+            } else {
+                player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+            }
+            tickPlayerWithTime(1, 10);
+        }
+        tickPlayerWithTime(3, 10);
+    }
+
+    DeviceInstance player_;
+    DeviceInstance fdn_;
+};
+
+// ============================================
+// TEST: Full Signal Echo easy win → Konami button
+// Steps 1-3: Connect to FDN, beat EASY, win START button
+// ============================================
+void e2eSignalEchoEasyWin(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+    ASSERT_FALSE(suite->player_.player->hasKonamiBoon());
+
+    // Step 1: Trigger FDN (Signal Echo, reward START)
+    suite->triggerFdnHandshake("7", "6");
+
+    // Verify EASY config (no boon → easy)
+    auto* echo = suite->getSignalEcho();
+    ASSERT_NE(echo, nullptr);
+    ASSERT_EQ(echo->getConfig().sequenceLength, SIGNAL_ECHO_EASY.sequenceLength);
+    ASSERT_TRUE(echo->getConfig().managedMode);
+
+    // Step 2: Play to win
+    suite->playSignalEchoToWin();
+
+    // Should be in EchoWin
+    auto* echoSM = suite->getSignalEcho();
+    ASSERT_EQ(echoSM->getOutcome().result, MiniGameResult::WON);
+
+    // Wait for win timer, returnToPreviousApp → FdnComplete
+    suite->tickPlayerWithTime(10, 400);
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+
+    // Step 3: Konami button START (bit 6) should be unlocked
+    uint8_t progress = suite->player_.player->getKonamiProgress();
+    ASSERT_TRUE(progress & (1 << 6));  // START = bit 6
+}
+
+// ============================================
+// TEST: Auto-boon triggers on 7th button
+// Step 4: Set 6 other buttons + win again → auto-boon
+// ============================================
+void e2eAutoBoonOnSeventhButton(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Pre-set 6 of 7 buttons (all except START = bit 6)
+    suite->player_.player->setKonamiProgress(0x3F);
+    ASSERT_FALSE(suite->player_.player->isKonamiComplete());
+
+    // Trigger Signal Echo, win → unlocks START (7th button)
+    suite->triggerFdnHandshake("7", "6");
+    suite->playSignalEchoToWin();
+    suite->tickPlayerWithTime(10, 400);  // Win timer → FdnComplete
+
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+    ASSERT_TRUE(suite->player_.player->isKonamiComplete());
+    ASSERT_TRUE(suite->player_.player->hasKonamiBoon());
+}
+
+// ============================================
+// TEST: Server sync on progress save
+// Step 5: Verify PUT /api/progress called
+// ============================================
+void e2eServerSyncOnWin(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+
+    suite->triggerFdnHandshake("7", "6");
+    suite->playSignalEchoToWin();
+    suite->tickPlayerWithTime(10, 400);  // → FdnComplete
+
+    // Check HTTP history for PUT /api/progress
+    const auto& history = MockHttpServer::getInstance().getHistory();
+    bool foundSync = false;
+    for (const auto& entry : history) {
+        if (entry.method == "PUT" && entry.path == "/api/progress") {
+            foundSync = true;
+        }
+    }
+    ASSERT_TRUE(foundSync);
+}
+
+// ============================================
+// TEST: Hard mode after boon, color prompt on win
+// Steps 6-8: Reconnect with boon → HARD → win → prompt → YES → equip
+// ============================================
+void e2eHardModeColorEquip(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+    suite->player_.player->setKonamiBoon(true);
+
+    // Step 6: Reconnect to FDN
+    suite->triggerFdnHandshake("7", "6");
+
+    // Step 7: Verify HARD config
+    auto* echo = suite->getSignalEcho();
+    ASSERT_NE(echo, nullptr);
+    ASSERT_EQ(echo->getConfig().sequenceLength, SIGNAL_ECHO_HARD.sequenceLength);
+    ASSERT_TRUE(echo->getConfig().managedMode);
+
+    // Play to win
+    suite->playSignalEchoToWin();
+    suite->tickPlayerWithTime(10, 400);  // → FdnComplete
+
+    // FdnComplete should set pendingProfileGame
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+
+    // Wait for FdnComplete display timer → ColorProfilePrompt
+    suite->tickPlayerWithTime(10, 400);
+    ASSERT_EQ(suite->getPlayerStateId(), COLOR_PROFILE_PROMPT);
+
+    // Step 8: Select YES (default) + confirm
+    suite->player_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tickPlayerWithTime(3, 10);
+
+    // Should be back at Idle with profile equipped
+    ASSERT_EQ(suite->getPlayerStateId(), IDLE);
+    ASSERT_EQ(suite->player_.player->getEquippedColorProfile(),
+              static_cast<int>(GameType::SIGNAL_ECHO));
+}
+
+// ============================================
+// TEST: Color prompt NO → palette NOT equipped
+// Step 8 alt: select NO → Idle without equip
+// ============================================
+void e2eColorPromptDecline(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+    suite->player_.player->setKonamiBoon(true);
+
+    suite->triggerFdnHandshake("7", "6");
+    suite->playSignalEchoToWin();
+    suite->tickPlayerWithTime(10, 400);  // → FdnComplete
+    suite->tickPlayerWithTime(10, 400);  // → ColorProfilePrompt
+    ASSERT_EQ(suite->getPlayerStateId(), COLOR_PROFILE_PROMPT);
+
+    // Toggle to NO, then confirm
+    suite->player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tickPlayerWithTime(1, 10);
+    suite->player_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tickPlayerWithTime(3, 10);
+
+    ASSERT_EQ(suite->getPlayerStateId(), IDLE);
+    // Profile NOT equipped
+    ASSERT_EQ(suite->player_.player->getEquippedColorProfile(), -1);
+    // But eligibility is still there for later
+    ASSERT_TRUE(suite->player_.player->hasColorProfileEligibility(
+        static_cast<int>(GameType::SIGNAL_ECHO)));
+}
+
+// ============================================
+// TEST: Color picker from Idle (long press)
+// Steps 10-11: Long press → picker → scroll → equip/unequip
+// ============================================
+void e2eColorPickerFromIdle(ProgressionE2ETestSuite* suite) {
+    // Set eligibility BEFORE advancing to Idle (long press is registered during mount)
+    suite->player_.player->addColorProfileEligibility(
+        static_cast<int>(GameType::SIGNAL_ECHO));
+    suite->player_.player->setEquippedColorProfile(
+        static_cast<int>(GameType::SIGNAL_ECHO));
+
+    suite->advanceToIdle();
+
+    // Long press secondary → picker
+    suite->player_.secondaryButtonDriver->execCallback(ButtonInteraction::LONG_PRESS);
+    suite->tickPlayerWithTime(3, 10);
+    ASSERT_EQ(suite->getPlayerStateId(), COLOR_PROFILE_PICKER);
+
+    // Profile list: [SIGNAL_ECHO, DEFAULT]
+    // Pre-selected: SIGNAL_ECHO (index 0, since it's equipped)
+    // Scroll to DEFAULT (index 1)
+    suite->player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tickPlayerWithTime(1, 10);
+
+    // Confirm → equip DEFAULT (-1)
+    suite->player_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tickPlayerWithTime(3, 10);
+
+    ASSERT_EQ(suite->getPlayerStateId(), IDLE);
+    ASSERT_EQ(suite->player_.player->getEquippedColorProfile(), -1);
+}
+
+// ============================================
+// TEST: Easy mode loss → no Konami button, no progression
+// ============================================
+void e2eEasyModeLoss(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+
+    uint8_t progressBefore = suite->player_.player->getKonamiProgress();
+
+    suite->triggerFdnHandshake("7", "6");
+    suite->playSignalEchoToLose();
+
+    // Wait for lose timer → FdnComplete
+    suite->tickPlayerWithTime(10, 400);
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+
+    // No Konami button unlocked
+    ASSERT_EQ(suite->player_.player->getKonamiProgress(), progressBefore);
+    ASSERT_FALSE(suite->player_.player->hasKonamiBoon());
+
+    // FdnComplete timer → back to Idle (no prompt)
+    suite->tickPlayerWithTime(10, 400);
+    ASSERT_EQ(suite->getPlayerStateId(), IDLE);
+}
+
+// ============================================
+// TEST: Hard mode loss → no color eligibility
+// ============================================
+void e2eHardModeLoss(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+    suite->player_.player->setKonamiBoon(true);
+
+    suite->triggerFdnHandshake("7", "6");
+    suite->playSignalEchoToLose();
+    suite->tickPlayerWithTime(10, 400);  // → FdnComplete
+
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+
+    // No color eligibility on loss
+    ASSERT_FALSE(suite->player_.player->hasColorProfileEligibility(
+        static_cast<int>(GameType::SIGNAL_ECHO)));
+
+    // No pending profile → goes straight to Idle
+    suite->tickPlayerWithTime(10, 400);
+    ASSERT_EQ(suite->getPlayerStateId(), IDLE);
+}
+
+// ============================================
+// TEST: Firewall Decrypt E2E — same progression flow
+// ============================================
+void e2eFirewallDecryptProgression(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Trigger FDN with FIREWALL_DECRYPT (GameType 3, reward LEFT=2)
+    suite->triggerFdnHandshake("3", "2");
+
+    auto* fw = suite->getFirewallDecrypt();
+    ASSERT_NE(fw, nullptr);
+    ASSERT_EQ(fw->getConfig().numCandidates, FIREWALL_DECRYPT_EASY.numCandidates);
+    ASSERT_TRUE(fw->getConfig().managedMode);
+
+    // Play to win
+    suite->playFirewallDecryptToWin();
+    suite->tickPlayerWithTime(10, 400);  // → FdnComplete
+
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+
+    // LEFT button (bit 2) should be unlocked
+    uint8_t progress = suite->player_.player->getKonamiProgress();
+    ASSERT_TRUE(progress & (1 << 2));
+}
+
+// ============================================
+// TEST: Firewall Decrypt hard mode with boon
+// ============================================
+void e2eFirewallDecryptHard(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+    suite->player_.player->setKonamiBoon(true);
+
+    suite->triggerFdnHandshake("3", "2");
+
+    auto* fw = suite->getFirewallDecrypt();
+    ASSERT_NE(fw, nullptr);
+    ASSERT_EQ(fw->getConfig().numCandidates, FIREWALL_DECRYPT_HARD.numCandidates);
+    ASSERT_EQ(fw->getConfig().numRounds, FIREWALL_DECRYPT_HARD.numRounds);
+    ASSERT_TRUE(fw->getConfig().managedMode);
+}
+
+// ============================================
+// TEST: NVS round-trip (save → load into fresh player)
+// ============================================
+void e2eNvsRoundTrip(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Set some progression state
+    suite->player_.player->setKonamiProgress(0x3F);
+    suite->player_.player->setKonamiBoon(true);
+    suite->player_.player->setEquippedColorProfile(
+        static_cast<int>(GameType::SIGNAL_ECHO));
+    suite->player_.player->addColorProfileEligibility(
+        static_cast<int>(GameType::SIGNAL_ECHO));
+
+    // Save via a ProgressManager
+    ProgressManager pm;
+    pm.initialize(suite->player_.player, suite->player_.storageDriver);
+    pm.saveProgress();
+
+    // Load into a fresh player to verify persistence
+    Player freshPlayer;
+    ProgressManager pm2;
+    pm2.initialize(&freshPlayer, suite->player_.storageDriver);
+    pm2.loadProgress();
+
+    ASSERT_EQ(freshPlayer.getKonamiProgress(), 0x3F);
+    ASSERT_TRUE(freshPlayer.hasKonamiBoon());
+    ASSERT_EQ(freshPlayer.getEquippedColorProfile(),
+              static_cast<int>(GameType::SIGNAL_ECHO));
+    ASSERT_TRUE(freshPlayer.hasColorProfileEligibility(
+        static_cast<int>(GameType::SIGNAL_ECHO)));
+}
+
+// ============================================
+// TEST: Prompt auto-dismiss defaults to NO
+// ============================================
+void e2ePromptAutoDismiss(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+    suite->player_.player->setKonamiBoon(true);
+
+    suite->triggerFdnHandshake("7", "6");
+    suite->playSignalEchoToWin();
+    suite->tickPlayerWithTime(10, 400);  // → FdnComplete
+    suite->tickPlayerWithTime(10, 400);  // → ColorProfilePrompt
+    ASSERT_EQ(suite->getPlayerStateId(), COLOR_PROFILE_PROMPT);
+
+    // Wait for auto-dismiss (10s)
+    suite->tickPlayerWithTime(25, 500);
+
+    // Should be at Idle, profile NOT equipped
+    ASSERT_EQ(suite->getPlayerStateId(), IDLE);
+    ASSERT_EQ(suite->player_.player->getEquippedColorProfile(), -1);
+}
+
+// ============================================
+// TEST: Difficulty gating is dynamic (switches on boon)
+// ============================================
+void e2eDifficultyGatingDynamic(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+
+    // First encounter — EASY
+    ASSERT_FALSE(suite->player_.player->hasKonamiBoon());
+    suite->triggerFdnHandshake("7", "6");
+    auto* echo1 = suite->getSignalEcho();
+    ASSERT_EQ(echo1->getConfig().sequenceLength, SIGNAL_ECHO_EASY.sequenceLength);
+
+    // Play to win, get through FdnComplete
+    suite->playSignalEchoToWin();
+    suite->tickPlayerWithTime(10, 400);  // Win timer
+    suite->tickPlayerWithTime(10, 400);  // FdnComplete → Idle
+    ASSERT_EQ(suite->getPlayerStateId(), IDLE);
+
+    // Grant boon
+    suite->player_.player->setKonamiBoon(true);
+
+    // Second encounter — should be HARD now
+    suite->triggerFdnHandshake("7", "6");
+    auto* echo2 = suite->getSignalEcho();
+    ASSERT_EQ(echo2->getConfig().sequenceLength, SIGNAL_ECHO_HARD.sequenceLength);
+}
+
+// ============================================
+// TEST: Equip later via picker after declining prompt
+// ============================================
+void e2eEquipLaterViaPicker(ProgressionE2ETestSuite* suite) {
+    suite->advanceToIdle();
+    suite->player_.player->setKonamiBoon(true);
+
+    // Win hard mode, decline at prompt
+    suite->triggerFdnHandshake("7", "6");
+    suite->playSignalEchoToWin();
+    suite->tickPlayerWithTime(10, 400);  // → FdnComplete
+    suite->tickPlayerWithTime(10, 400);  // → ColorProfilePrompt
+
+    // Toggle to NO, confirm
+    suite->player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tickPlayerWithTime(1, 10);
+    suite->player_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tickPlayerWithTime(3, 10);
+    ASSERT_EQ(suite->getPlayerStateId(), IDLE);
+    ASSERT_EQ(suite->player_.player->getEquippedColorProfile(), -1);
+
+    // Long press → picker
+    suite->player_.secondaryButtonDriver->execCallback(ButtonInteraction::LONG_PRESS);
+    suite->tickPlayerWithTime(3, 10);
+    ASSERT_EQ(suite->getPlayerStateId(), COLOR_PROFILE_PICKER);
+
+    // Picker list: [SIGNAL_ECHO, DEFAULT]
+    // Pre-selected: DEFAULT (index 1, since equippedColorProfile=-1)
+    // Scroll to SIGNAL_ECHO (index 0)
+    suite->player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tickPlayerWithTime(1, 10);
+
+    // Confirm → equip Signal Echo
+    suite->player_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tickPlayerWithTime(3, 10);
+
+    ASSERT_EQ(suite->getPlayerStateId(), IDLE);
+    ASSERT_EQ(suite->player_.player->getEquippedColorProfile(),
+              static_cast<int>(GameType::SIGNAL_ECHO));
+}
+
+#endif // NATIVE_BUILD


### PR DESCRIPTION
## Summary
- 14 end-to-end tests covering the complete FDN progression pipeline
- **Happy path**: Signal Echo easy win → Konami button → auto-boon → hard win → color prompt → equip
- **Branching paths**: Decline prompt, auto-dismiss, equip later via picker, easy/hard loss
- **Cross-game**: Firewall Decrypt progression + hard mode verification
- **Infrastructure**: NVS round-trip persistence, server sync verification, dynamic difficulty gating

Part of #72 — FDN Progression Pipeline. Depends on PR #87 (Color Profile UI) + PR #88 (Firewall Decrypt).

## Merge order
`#81 → #83 → #84 → #85 → #86 → #87 + #88 → #89`

## Test plan
- [x] 14 new E2E CLI tests (ProgressionE2ETestSuite)
- [x] All 228 CLI tests pass (combined: 169 base + 18 PR1 + 21 PR2 + 24 PR3 + 14 PR4 - 18 shared)
- [x] 55/56 core tests (1 pre-existing SIGABRT)
- [x] Simulator builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)