### PR TITLE
Fixes From Performance & Memory Profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ wifi_credentials.ini
 .cache/
 
 .vscode/extensions.json
+
+callgrind*

--- a/include/device/countdown-animation.hpp
+++ b/include/device/countdown-animation.hpp
@@ -30,9 +30,9 @@ protected:
         for(int i = 3; i <= 9; i++) {
             if(i == 9 && currentState_.leftLights[i-1].brightness == 255) {
                 currentLed_ = i;
-            } else if(currentState_.leftLights[i].brightness == 255) {
+            } else if(i < 9 && currentState_.leftLights[i].brightness == 255) {
                 currentLed_ = i;
-            } else if(currentState_.leftLights[i].brightness == 0
+            } else if(i < 9 && currentState_.leftLights[i].brightness == 0
                         && currentState_.leftLights[i-1].brightness == 255) {
                 currentLed_ = i;
             }

--- a/include/device/drivers/logger.hpp
+++ b/include/device/drivers/logger.hpp
@@ -54,23 +54,49 @@ inline void log_helper(LogLevel level, const char* tag, const char* file, int li
 }
 
 /**
- * Convenience macros for logging (similar to ESP_LOG style).
- * Usage: LOG_E("TAG", "Error: %d", errorCode);
- * 
- * These macros capture __FILE__ and __LINE__ at the call site
- * so log output shows the actual source location.
+ * Compile-time log level filter.
+ *
+ * CORE_DEBUG_LEVEL is set per-environment in platformio.ini:
+ *   0 = silent   1 = error   2 = warn   3 = info   4 = debug   5 = verbose
+ *
+ * Macros below the active level expand to nothing, so their arguments
+ * (e.g. MacToString(), string formatting) are never evaluated.
  */
+#ifndef CORE_DEBUG_LEVEL
+#define CORE_DEBUG_LEVEL 3  // Default: info and above
+#endif
+
+#if CORE_DEBUG_LEVEL >= 1
 #define LOG_E(tag, format, ...) \
     log_helper(LogLevel::ERROR, tag, __FILE__, __LINE__, format, ##__VA_ARGS__)
+#else
+#define LOG_E(tag, format, ...) do {} while(0)
+#endif
 
+#if CORE_DEBUG_LEVEL >= 2
 #define LOG_W(tag, format, ...) \
     log_helper(LogLevel::WARN, tag, __FILE__, __LINE__, format, ##__VA_ARGS__)
+#else
+#define LOG_W(tag, format, ...) do {} while(0)
+#endif
 
+#if CORE_DEBUG_LEVEL >= 3
 #define LOG_I(tag, format, ...) \
     log_helper(LogLevel::INFO, tag, __FILE__, __LINE__, format, ##__VA_ARGS__)
+#else
+#define LOG_I(tag, format, ...) do {} while(0)
+#endif
 
+#if CORE_DEBUG_LEVEL >= 4
 #define LOG_D(tag, format, ...) \
     log_helper(LogLevel::DEBUG, tag, __FILE__, __LINE__, format, ##__VA_ARGS__)
+#else
+#define LOG_D(tag, format, ...) do {} while(0)
+#endif
 
+#if CORE_DEBUG_LEVEL >= 5
 #define LOG_V(tag, format, ...) \
     log_helper(LogLevel::VERBOSE, tag, __FILE__, __LINE__, format, ##__VA_ARGS__)
+#else
+#define LOG_V(tag, format, ...) do {} while(0)
+#endif

--- a/include/game/match-manager.hpp
+++ b/include/game/match-manager.hpp
@@ -8,6 +8,7 @@
 */
 #pragma once
 
+#include <optional>
 #include <vector>
 #include <string>
 #include "device/drivers/button.hpp"
@@ -25,7 +26,7 @@ struct ActiveDuelState {
     unsigned long duelLocalStartTime = 0;
     unsigned long BUTTON_MASHER_PENALTY_MS = 75;
     int buttonMasherCount = 0;
-    Match* match = nullptr;
+    std::optional<Match> match;
 };
 
 class MatchManager {
@@ -78,7 +79,7 @@ public:
      * Gets the current active match if any
      * @return Pointer to the active match, nullptr if none
      */
-    Match* getCurrentMatch() const { return activeDuelState.match; }
+    Match* getCurrentMatch() { return activeDuelState.match ? &*activeDuelState.match : nullptr; }
 
     /**
      * Converts all stored matches to a JSON array string
@@ -99,7 +100,7 @@ public:
 
     void clearCurrentMatch();
 
-    void listenForMatchResults(QuickdrawCommand command);
+    void listenForMatchResults(const QuickdrawCommand& command);
 
     void initialize(Player* player, StorageInterface* storage, PeerCommsInterface* peerComms, QuickdrawWirelessManager* quickdrawWirelessManager);
 

--- a/include/game/player.hpp
+++ b/include/game/player.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <iostream>
+#include <cstdint>
 
 enum class Allegiance {
     ALLEYCAT = 0,
@@ -62,9 +63,13 @@ public:
     const std::string& getCurrentOpponentId() const;
 
     void setOpponentMacAddress(const std::string& macAddress);
+    void setOpponentMacAddress(const uint8_t* macBytes);
 
     std::string& getOpponentMacAddress();
     const std::string& getOpponentMacAddress() const;
+
+    const uint8_t* getOpponentMacBytes() const;
+    bool hasOpponentMac() const;
 
     unsigned long getLastReactionTime();
 
@@ -113,6 +118,8 @@ private:
     std::string currentMatchId;
     std::string currentOpponentId;
     std::string opponentMacAddress;
+    uint8_t opponentMacBytes[6] = {};
+    bool opponentMacValid = false;
     
     bool hunter = true;
 };

--- a/include/state/state.hpp
+++ b/include/state/state.hpp
@@ -67,6 +67,9 @@ public:
 class State {
 public:
     virtual ~State() {
+        for (auto* t : transitions) {
+            delete t;
+        }
         transitions.clear();
     }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,7 @@ build_src_filter =
     +<*>
     -<native-main.cpp>
     -<cli-main.cpp>
+    -<perf-main.cpp>
     -<cli/*>
     -<device/drivers/native/*>
 
@@ -114,23 +115,55 @@ build_flags =
 build_unflags = -Werror
 
 ; ========================================
-; NATIVE PROFILE ENVIRONMENT (CPU profiling via gprof)
+; NATIVE PROFILE ENVIRONMENT (CPU profiling via perf)
 ; ========================================
-; Run in WSL:
-;   1. pio test -e native_profile
-;   2. gprof .pio/build/native_profile/program gmon.out > profile.txt
-;   3. Open profile.txt to see flat profile + call graph
-; For a flame graph instead, pipe through gprof2dot + dot:
-;   gprof .pio/build/native_profile/program gmon.out | gprof2dot | dot -Tsvg -o profile.svg
 
 [env:native_profile]
 extends = env:native
 build_flags =
     -std=c++17
     -DNATIVE_BUILD
-    -pg
     -g
     -O2
+    -fno-omit-frame-pointer
+build_unflags = -Werror
+
+; ========================================
+; NATIVE PERF ENVIRONMENT (Business-logic duel benchmark)
+; ========================================
+; Builds a standalone executable with no test framework overhead.
+; Uses null-logger and stub drivers so only game logic is hot.
+;
+; Build:   pio run -e native_perf
+; Run:     .pio/build/native_perf/program [NUM_DUELS]
+; Profile:
+;   valgrind --tool=callgrind --callgrind-out-file=callgrind.out \
+;     .pio/build/native_perf/program 50000
+;   callgrind_annotate --auto=yes callgrind.out > callgrind_report.txt
+
+[env:native_perf]
+platform = native
+build_type = release
+
+build_flags =
+    -std=c++17
+    -DNATIVE_BUILD
+    -DPERF_BUILD
+    -DCORE_DEBUG_LEVEL=0
+    -g
+    -O2
+    -fno-omit-frame-pointer
+
+build_src_filter =
+    +<*>
+    -<main.cpp>
+    -<native-main.cpp>
+    -<cli-main.cpp>
+    -<device/drivers/esp32-s3/*>
+
+lib_deps =
+    bblanchon/ArduinoJson@^7.4.2
+
 build_unflags = -Werror
 
 ; ========================================

--- a/platformio.ini
+++ b/platformio.ini
@@ -95,6 +95,45 @@ lib_deps =
 build_unflags = -Werror
 
 ; ========================================
+; NATIVE ASAN ENVIRONMENT (Memory / leak detection)
+; ========================================
+; Run in WSL: pio test -e native_asan
+; Enables AddressSanitizer + LeakSanitizer.
+; Any heap overflows, use-after-free, or leaks are reported
+; inline with a full stack trace after the test run.
+
+[env:native_asan]
+extends = env:native
+build_flags =
+    -std=c++17
+    -DNATIVE_BUILD
+    -fsanitize=address,leak
+    -fno-omit-frame-pointer
+    -g
+    -O1
+build_unflags = -Werror
+
+; ========================================
+; NATIVE PROFILE ENVIRONMENT (CPU profiling via gprof)
+; ========================================
+; Run in WSL:
+;   1. pio test -e native_profile
+;   2. gprof .pio/build/native_profile/program gmon.out > profile.txt
+;   3. Open profile.txt to see flat profile + call graph
+; For a flame graph instead, pipe through gprof2dot + dot:
+;   gprof .pio/build/native_profile/program gmon.out | gprof2dot | dot -Tsvg -o profile.svg
+
+[env:native_profile]
+extends = env:native
+build_flags =
+    -std=c++17
+    -DNATIVE_BUILD
+    -pg
+    -g
+    -O2
+build_unflags = -Werror
+
+; ========================================
 ; NATIVE CLI ENVIRONMENT (PDN Simulator)
 ; ========================================
 ; PLATFORM REQUIREMENT: Unix/POSIX only (Linux, macOS)

--- a/src/apps/handshake/bounty-send-cc.cpp
+++ b/src/apps/handshake/bounty-send-cc.cpp
@@ -24,7 +24,7 @@ void BountySendConnectionConfirmedState::onStateMounted(Device *PDN) {
         return;
     }
 
-    if (player->getOpponentMacAddress().empty()) {
+    if (!player->hasOpponentMac()) {
         LOG_E("BOUNTY_SEND_CC", "Opponent MAC address is empty");
         return;
     }
@@ -53,7 +53,7 @@ void BountySendConnectionConfirmedState::onStateMounted(Device *PDN) {
     try {
         Match initialMatch(matchId, "", bountyId);  // Empty hunter ID initially
         quickdrawWirelessManager->broadcastPacket(
-            player->getOpponentMacAddress(),
+            player->getOpponentMacBytes(),
             CONNECTION_CONFIRMED,
             initialMatch
         );
@@ -69,7 +69,7 @@ void BountySendConnectionConfirmedState::onQuickdrawCommandReceived(QuickdrawCom
         return;
     }
 
-    if (player->getOpponentMacAddress().empty()) {
+    if (!player->hasOpponentMac()) {
         LOG_E("BOUNTY_SEND_CC", "Opponent MAC address is empty");
         return;
     }
@@ -80,23 +80,23 @@ void BountySendConnectionConfirmedState::onQuickdrawCommandReceived(QuickdrawCom
         LOG_I("BOUNTY_SEND_CC", "Received HUNTER_RECEIVE_MATCH command");
         
         // Validate received match data
-        if (command.match.getMatchId().empty()) {
+        if (!*command.match.getMatchId()) {
             LOG_E("BOUNTY_SEND_CC", "Received empty match ID");
             return;
         }
-        if (command.match.getHunterId().empty()) {
+        if (!*command.match.getHunterId()) {
             LOG_E("BOUNTY_SEND_CC", "Received empty hunter ID");
             return;
         }
-        if (command.match.getBountyId().empty()) {
+        if (!*command.match.getBountyId()) {
             LOG_E("BOUNTY_SEND_CC", "Received empty bounty ID");
             return;
         }
 
         LOG_I("BOUNTY_SEND_CC", "Received match - ID: %s, Hunter: %s, Bounty: %s",
-                 command.match.getMatchId().c_str(),
-                 command.match.getHunterId().c_str(),
-                 command.match.getBountyId().c_str());
+                 command.match.getMatchId(),
+                 command.match.getHunterId(),
+                 command.match.getBountyId());
 
         Match* match = matchManager->receiveMatch(command.match);
         if (!match) {
@@ -106,7 +106,7 @@ void BountySendConnectionConfirmedState::onQuickdrawCommandReceived(QuickdrawCom
 
         try {
             quickdrawWirelessManager->broadcastPacket(
-                player->getOpponentMacAddress(),
+                player->getOpponentMacBytes(),
                 BOUNTY_FINAL_ACK,
                 *match
             );

--- a/src/apps/handshake/hunter-send-id.cpp
+++ b/src/apps/handshake/hunter-send-id.cpp
@@ -35,25 +35,25 @@ void HunterSendIdState::onQuickdrawCommandReceived(QuickdrawCommand command) {
         LOG_I("HUNTER_SEND_ID", "Received CONNECTION_CONFIRMED from opponent");
         
         // Validate received match data
-        if (command.match.getMatchId().empty()) {
+        if (!*command.match.getMatchId()) {
             LOG_E("HUNTER_SEND_ID", "Received empty match ID");
             return;
         }
-        if (command.match.getBountyId().empty()) {
+        if (!*command.match.getBountyId()) {
             LOG_E("HUNTER_SEND_ID", "Received empty bounty ID");
             return;
         }
         
         LOG_I("HUNTER_SEND_ID", "Received match ID: %s, bounty ID: %s", 
-                 command.match.getMatchId().c_str(), 
-                 command.match.getBountyId().c_str());
+                 command.match.getMatchId(), 
+                 command.match.getBountyId());
 
         // Set opponent MAC address
-        if (command.wifiMacAddr.empty()) {
+        if (!command.wifiMacAddrValid) {
             LOG_E("HUNTER_SEND_ID", "Received empty MAC address");
             return;
         }
-        player->setOpponentMacAddress(command.wifiMacAddr);
+        player->setOpponentMacAddress(command.wifiMacAddr);  // uint8_t[6] overload
         
         // Create new match with validated data
         Match* newMatch = matchManager->createMatch(
@@ -67,11 +67,11 @@ void HunterSendIdState::onQuickdrawCommandReceived(QuickdrawCommand command) {
             return;
         }
 
-        LOG_I("HUNTER_SEND_ID", "Created match with ID: %s", newMatch->getMatchId().c_str());
+        LOG_I("HUNTER_SEND_ID", "Created match with ID: %s", newMatch->getMatchId());
         
         try {
             quickdrawWirelessManager->broadcastPacket(
-                player->getOpponentMacAddress(),
+                player->getOpponentMacBytes(),
                 HUNTER_RECEIVE_MATCH,
                 *newMatch
             );

--- a/src/game/match-manager.cpp
+++ b/src/game/match-manager.cpp
@@ -283,12 +283,17 @@ void MatchManager::initialize(Player* player, StorageInterface* storage, PeerCom
     this->quickdrawWirelessManager = quickdrawWirelessManager;
 
     duelButtonPush = [](void *ctx) {
-        unsigned long now = SimpleTimer::getPlatformClock()->milliseconds();
-        
         if (!ctx) {
             LOG_E(MATCH_MANAGER_TAG, "Button press handler received null context");
             return;
         }
+
+        auto* clock = SimpleTimer::getPlatformClock();
+        if (!clock) {
+            LOG_E(MATCH_MANAGER_TAG, "Button press handler called with no platform clock");
+            return;
+        }
+        unsigned long now = clock->milliseconds();
 
         MatchManager* matchManager = static_cast<MatchManager*>(ctx);
         ActiveDuelState* activeDuelState = &matchManager->activeDuelState;

--- a/src/game/match-manager.cpp
+++ b/src/game/match-manager.cpp
@@ -14,8 +14,6 @@ MatchManager::MatchManager()
 }
 
 MatchManager::~MatchManager() { 
-    delete activeDuelState.match;
-    activeDuelState.match = nullptr;
     quickdrawWirelessManager = nullptr;
     if (storage) {
         storage->end();
@@ -24,17 +22,13 @@ MatchManager::~MatchManager() {
 
 void MatchManager::clearCurrentMatch() {
     if (activeDuelState.match) {
-        if (peerComms && player && !player->getOpponentMacAddress().empty()) {
-            uint8_t mac[6];
-            if (StringToMac(player->getOpponentMacAddress().c_str(), mac)) {
-                peerComms->removePeer(mac);
-                LOG_I(MATCH_MANAGER_TAG, "Removed opponent peer from ESP-NOW");
-            }
+        if (peerComms && player && player->hasOpponentMac()) {
+            peerComms->removePeer(const_cast<uint8_t*>(player->getOpponentMacBytes()));
+            LOG_I(MATCH_MANAGER_TAG, "Removed opponent peer from ESP-NOW");
         }
 
         LOG_I(MATCH_MANAGER_TAG, "Clearing current match");
-        delete activeDuelState.match;
-        activeDuelState.match = nullptr;
+        activeDuelState.match.reset();
         activeDuelState.hasReceivedDrawResult = false;
         activeDuelState.hasPressedButton = false;
         activeDuelState.duelLocalStartTime = 0;
@@ -44,28 +38,22 @@ void MatchManager::clearCurrentMatch() {
 
 Match* MatchManager::createMatch(const std::string& match_id, const std::string& hunter_id, const std::string& bounty_id) {
     // Only allow one active match at a time
-    if (activeDuelState.match != nullptr) {
+    if (activeDuelState.match.has_value()) {
         return nullptr;
     }
 
-    activeDuelState.match = new Match(match_id, hunter_id, bounty_id);
-    return activeDuelState.match;
+    activeDuelState.match.emplace(match_id.c_str(), hunter_id.c_str(), bounty_id.c_str(), 0UL, 0UL);
+    return &*activeDuelState.match;
 }
 
 Match* MatchManager::receiveMatch(const Match& match) {
     // Only allow one active match at a time
-    if (activeDuelState.match != nullptr) {
+    if (activeDuelState.match.has_value()) {
         return nullptr;
     }
 
-    // Create a new Match object on the heap instead of storing a pointer to the parameter
-    activeDuelState.match = new Match(match.getMatchId(), match.getHunterId(), match.getBountyId());
-    
-    // Copy draw times
-    activeDuelState.match->setHunterDrawTime(match.getHunterDrawTime());
-    activeDuelState.match->setBountyDrawTime(match.getBountyDrawTime());
-    
-    return activeDuelState.match;
+    activeDuelState.match = match;
+    return &*activeDuelState.match;
 }
 
 void MatchManager::setDuelLocalStartTime(unsigned long local_start_time_ms) {
@@ -118,7 +106,7 @@ bool MatchManager::finalizeMatch() {
     std::string match_id = activeDuelState.match->getMatchId();
 
     // Save to storage
-    if (appendMatchToStorage(activeDuelState.match)) {
+    if (appendMatchToStorage(&*activeDuelState.match)) {
         // Update stored count
         updateStoredMatchCount(getStoredMatchCount() + 1);
         clearCurrentMatch();
@@ -326,16 +314,16 @@ void MatchManager::initialize(Player* player, StorageInterface* storage, PeerCom
         LOG_I(MATCH_MANAGER_TAG, "Stored reaction time in MatchManager");
 
         // Send a packet with the reaction time
-        if (player->getOpponentMacAddress().empty()) {
+        if (!player->hasOpponentMac()) {
             LOG_E(MATCH_MANAGER_TAG, "Cannot send packet - opponent MAC address is empty");
             return;
         }
 
-        LOG_I(MATCH_MANAGER_TAG, "Broadcasting DRAW_RESULT to opponent MAC: %s", 
+        LOG_I(MATCH_MANAGER_TAG, "Broadcasting DRAW_RESULT to opponent MAC: %s",
                 player->getOpponentMacAddress().c_str());
-                
+
         quickdrawWirelessManager->broadcastPacket(
-            player->getOpponentMacAddress(),
+            player->getOpponentMacBytes(),
             QDCommand::DRAW_RESULT,
             *matchManager->getCurrentMatch()
         );
@@ -352,7 +340,7 @@ void MatchManager::initialize(Player* player, StorageInterface* storage, PeerCom
     };
 }
 
-void MatchManager::listenForMatchResults(QuickdrawCommand command) {
+void MatchManager::listenForMatchResults(const QuickdrawCommand& command) {
     LOG_I(MATCH_MANAGER_TAG, "Received command: %d", command.command);
     
     if(command.command == QDCommand::DRAW_RESULT || command.command == QDCommand::NEVER_PRESSED) {

--- a/src/game/quickdraw-states/duel-result-received-state.cpp
+++ b/src/game/quickdraw-states/duel-result-received-state.cpp
@@ -46,7 +46,7 @@ void DuelReceivedResult::onStateLoop(Device *PDN) {
         : matchManager->setBountyDrawTime(pityTime);
         
         quickdrawWirelessManager->broadcastPacket(
-            player->getOpponentMacAddress(),
+            player->getOpponentMacBytes(),
             QDCommand::NEVER_PRESSED,
             *matchManager->getCurrentMatch()
         );

--- a/src/perf-main.cpp
+++ b/src/perf-main.cpp
@@ -244,13 +244,11 @@ int main(int argc, char** argv) {
         hunter.matchMgr->setDuelLocalStartTime(duelStart);
         bounty.matchMgr->setDuelLocalStartTime(duelStart);
 
-        // Vary press times so the profiler sees all result branches.
-        // Pattern covers: hunter faster, bounty faster, and close races.
         std::random_device rd;
         std::mt19937 gen(rd());
         std::uniform_int_distribution<> dist(100, 1500);
-        const long hunterPress = dist(gen);   // 100–1500 ms
-        const long bountyPress = dist(gen);   // 100–1500 ms
+        const long hunterPress = dist(gen);
+        const long bountyPress = dist(gen);
 
         clock.set(duelStart + hunterPress);
         hunter.matchMgr->getDuelButtonPush()(hunter.matchMgr);

--- a/src/perf-main.cpp
+++ b/src/perf-main.cpp
@@ -1,0 +1,304 @@
+#if defined(NATIVE_BUILD) && defined(PERF_BUILD)
+
+/**
+ * Duel Performance Harness
+ *
+ * Runs a large volume of complete hunter-vs-bounty duel cycles using only the
+ * business logic layer. No GoogleTest, no GMock, no rendering, no I/O in the hot
+ * path. Stubs satisfy every interface with no-op or minimal implementations.
+ *
+ * Build:  pio run -e native_perf
+ * Run:    .pio/build/native_perf/program [NUM_DUELS]
+ * Profile:
+ *   valgrind --tool=callgrind --callgrind-out-file=callgrind.out \
+ *     .pio/build/native_perf/program 50000
+ *   callgrind_annotate --auto=yes callgrind.out > callgrind_report.txt
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cstdarg>
+#include <chrono>
+#include <functional>
+#include <string>
+
+#include "device/drivers/logger.hpp"
+#include "device/drivers/platform-clock.hpp"
+#include "device/drivers/peer-comms-interface.hpp"
+#include "device/drivers/storage-interface.hpp"
+#include "device/drivers/http-client-interface.hpp"
+#include "device/wireless-manager.hpp"
+#include "utils/simple-timer.hpp"
+#include "id-generator.hpp"
+#include "game/player.hpp"
+#include "game/match-manager.hpp"
+#include "game/match.hpp"
+#include "wireless/quickdraw-wireless-manager.hpp"
+
+// ============================================================
+// Null logger — suppresses all LOG_* output in the hot path
+// ============================================================
+
+class NullLogger : public LoggerInterface {
+public:
+    void vlog(LogLevel, const char*, const char*, int,
+              const char*, va_list) override {}
+};
+
+// ============================================================
+// Controllable fake clock — no syscall overhead
+// ============================================================
+
+class StepClock : public PlatformClock {
+public:
+    unsigned long milliseconds() override { return time_ms; }
+    void set(unsigned long t) { time_ms = t; }
+    void advance(unsigned long delta) { time_ms += delta; }
+    unsigned long time_ms = 0;
+};
+
+// ============================================================
+// Minimal no-op stubs for peripheral interfaces
+// ============================================================
+
+class StubPeerComms : public PeerCommsInterface {
+public:
+    int sendData(const uint8_t*, PktType,
+                 const uint8_t*, const size_t) override { return 1; }
+    void setPacketHandler(PktType, PacketCallback, void*) override {}
+    void clearPacketHandler(PktType) override {}
+    const uint8_t* getGlobalBroadcastAddress() override { return broadcast_; }
+    uint8_t* getMacAddress() override { return mac_; }
+    void removePeer(uint8_t*) override {}
+    void setPeerCommsState(PeerCommsState) override {}
+    PeerCommsState getPeerCommsState() override {
+        return PeerCommsState::CONNECTED;
+    }
+    void connect() override {}
+    void disconnect() override {}
+private:
+    uint8_t mac_[6] = {0};
+    uint8_t broadcast_[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+};
+
+class StubStorage : public StorageInterface {
+public:
+    size_t write(const std::string&, const std::string&) override { return 0; }
+    std::string read(const std::string&,
+                     const std::string& def) override { return def; }
+    bool remove(const std::string&) override { return true; }
+    bool clear() override { return true; }
+    void end() override {}
+    uint8_t readUChar(const std::string&, uint8_t def) override { return def; }
+    size_t writeUChar(const std::string&, uint8_t) override { return 0; }
+};
+
+class StubHttpClient : public HttpClientInterface {
+public:
+    void setWifiConfig(WifiConfig*) override {}
+    bool isConnected() override { return false; }
+    bool queueRequest(HttpRequest&) override { return false; }
+    void disconnect() override {}
+    void updateConfig(WifiConfig*) override {}
+    void retryConnection() override {}
+    uint8_t* getMacAddress() override { return mac_; }
+    void setHttpClientState(HttpClientState) override {}
+    HttpClientState getHttpClientState() override {
+        return HttpClientState::DISCONNECTED;
+    }
+private:
+    uint8_t mac_[6] = {0};
+};
+
+// ============================================================
+// Packet wire format (must stay in sync with
+// quickdraw-wireless-manager.cpp packed struct)
+// ============================================================
+
+struct PerfPacket {
+    char matchId[37];
+    char hunterId[5];
+    char bountyId[5];
+    long hunterDrawTime;
+    long bountyDrawTime;
+    int  command;
+} __attribute__((packed));
+
+static PerfPacket makePacket(const Match* m, int command) {
+    PerfPacket p;
+    strncpy(p.matchId,  m->getMatchId(),  36); p.matchId[36]  = '\0';
+    strncpy(p.hunterId, m->getHunterId(), 4);  p.hunterId[4]  = '\0';
+    strncpy(p.bountyId, m->getBountyId(), 4);  p.bountyId[4]  = '\0';
+    p.hunterDrawTime = m->getHunterDrawTime();
+    p.bountyDrawTime = m->getBountyDrawTime();
+    p.command        = command;
+    return p;
+}
+
+static void deliver(QuickdrawWirelessManager* target,
+                    const uint8_t mac[6],
+                    PerfPacket& pkt) {
+    target->processQuickdrawCommand(
+        mac,
+        reinterpret_cast<const uint8_t*>(&pkt),
+        sizeof(pkt));
+}
+
+// ============================================================
+// Device context — one per simulated device
+// ============================================================
+
+struct DeviceCtx {
+    StubPeerComms    peerComms;
+    StubStorage      storage;
+    StubHttpClient   httpClient;
+    WirelessManager* wirelessMgr   = nullptr;
+    QuickdrawWirelessManager* qdWireless = nullptr;
+    MatchManager*    matchMgr       = nullptr;
+    Player           player;
+
+    void init(const char* userId, bool isHunter, const char* opponentMac) {
+        char id[5];
+        strncpy(id, userId, 4); id[4] = '\0';
+        player.setUserID(id);
+        player.setIsHunter(isHunter);
+        player.setOpponentMacAddress(opponentMac);
+
+        wirelessMgr = new WirelessManager(&peerComms, &httpClient);
+        qdWireless  = new QuickdrawWirelessManager();
+        matchMgr    = new MatchManager();
+
+        qdWireless->initialize(&player, wirelessMgr, /*broadcastCooldown=*/0);
+        matchMgr->initialize(&player, &storage, &peerComms, qdWireless);
+    }
+
+    void armCallback() {
+        qdWireless->setPacketReceivedCallback(
+            std::bind(&MatchManager::listenForMatchResults,
+                      matchMgr, std::placeholders::_1));
+    }
+
+    void destroy() {
+        delete matchMgr;
+        delete qdWireless;
+        delete wirelessMgr;
+    }
+};
+
+// ============================================================
+// Main
+// ============================================================
+
+int main(int argc, char** argv) {
+    long numDuels = 10000;
+    if (argc >= 2) {
+        numDuels = atol(argv[1]);
+        if (numDuels < 1) numDuels = 1;
+    }
+
+    // Silence all LOG_* calls — prevents printf/stream overhead from
+    // drowning out the business-logic signal in the profile.
+    NullLogger nullLogger;
+    g_logger = &nullLogger;
+
+    StepClock clock;
+    SimpleTimer::setPlatformClock(&clock);
+
+    // Seed the ID generator with a fixed value for reproducibility
+    IdGenerator(42).seed(42);
+
+    DeviceCtx hunter, bounty;
+    hunter.init("hunt", true,  "BB:BB:BB:BB:BB:BB");
+    bounty.init("boun", false, "AA:AA:AA:AA:AA:AA");
+
+    // Wire each device's wireless manager to its own MatchManager callback
+    hunter.armCallback();
+    bounty.armCallback();
+
+    const uint8_t kHunterMac[6] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+    const uint8_t kBountyMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+
+    long hunterWins = 0, bountyWins = 0, errors = 0;
+
+    fprintf(stderr, "Running %ld duel cycles (no logging)...\n", numDuels);
+    const auto wallStart = std::chrono::steady_clock::now();
+
+    // --------------------------------------------------------
+    // Hot loop — this is what the profiler should see
+    // --------------------------------------------------------
+    for (long i = 0; i < numDuels; ++i) {
+        // Advance simulated time so each duel starts from a fresh baseline
+        clock.set(10000 + i * 5000UL);
+        const unsigned long duelStart = clock.time_ms;
+
+        // Create the match on both sides with a fixed ID per iteration.
+        // snprintf is the cheapest way to stamp a unique-enough ID without
+        // triggering UUID generation overhead (which we're not measuring).
+        char matchId[37];
+        snprintf(matchId, sizeof(matchId), "perf-%031ld", i);
+
+        hunter.matchMgr->createMatch(matchId, "hunt", "boun");
+        bounty.matchMgr->createMatch(matchId, "hunt", "boun");
+        hunter.matchMgr->setDuelLocalStartTime(duelStart);
+        bounty.matchMgr->setDuelLocalStartTime(duelStart);
+
+        // Vary press times so the profiler sees all result branches.
+        // Pattern covers: hunter faster, bounty faster, and close races.
+        const long hunterPress = 100 + (i % 401);   // 100–500 ms
+        const long bountyPress = 100 + (i % 397);   // 100–496 ms
+
+        clock.set(duelStart + hunterPress);
+        hunter.matchMgr->getDuelButtonPush()(hunter.matchMgr);
+
+        clock.set(duelStart + bountyPress);
+        bounty.matchMgr->getDuelButtonPush()(bounty.matchMgr);
+
+        // Exchange draw results (simulates the ESP-NOW packet crossing)
+        PerfPacket hunterPkt = makePacket(
+            hunter.matchMgr->getCurrentMatch(), QDCommand::DRAW_RESULT);
+        PerfPacket bountyPkt = makePacket(
+            bounty.matchMgr->getCurrentMatch(), QDCommand::DRAW_RESULT);
+
+        deliver(bounty.qdWireless, kHunterMac, hunterPkt);
+        deliver(hunter.qdWireless, kBountyMac, bountyPkt);
+
+        // Sanity check: both sides must agree on the winner
+        const bool hw = hunter.matchMgr->didWin();
+        const bool bw = bounty.matchMgr->didWin();
+        if (hw == bw) {
+            ++errors;
+        } else {
+            hw ? ++hunterWins : ++bountyWins;
+        }
+
+        // Reset for next iteration
+        hunter.matchMgr->clearCurrentMatch();
+        bounty.matchMgr->clearCurrentMatch();
+    }
+    // --------------------------------------------------------
+
+    const auto wallEnd = std::chrono::steady_clock::now();
+    const double wallMs =
+        std::chrono::duration<double, std::milli>(wallEnd - wallStart).count();
+
+    fprintf(stderr, "\n=== Duel Simulation Results ===\n");
+    fprintf(stderr, "Duels run:    %ld\n",       numDuels);
+    fprintf(stderr, "Hunter wins:  %ld (%.1f%%)\n", hunterWins,
+            100.0 * hunterWins / numDuels);
+    fprintf(stderr, "Bounty wins:  %ld (%.1f%%)\n", bountyWins,
+            100.0 * bountyWins / numDuels);
+    fprintf(stderr, "Errors:       %ld\n",        errors);
+    fprintf(stderr, "Wall time:    %.2f ms\n",    wallMs);
+    fprintf(stderr, "Avg/duel:     %.4f ms\n",    wallMs / numDuels);
+    fprintf(stderr, "Throughput:   %.0f duels/s\n",
+            numDuels / (wallMs / 1000.0));
+
+    hunter.destroy();
+    bounty.destroy();
+    SimpleTimer::setPlatformClock(nullptr);
+
+    return errors > 0 ? 1 : 0;
+}
+
+#endif // NATIVE_BUILD && PERF_BUILD

--- a/src/perf-main.cpp
+++ b/src/perf-main.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <functional>
 #include <string>
+#include <random>
 
 #include "device/drivers/logger.hpp"
 #include "device/drivers/platform-clock.hpp"
@@ -245,8 +246,11 @@ int main(int argc, char** argv) {
 
         // Vary press times so the profiler sees all result branches.
         // Pattern covers: hunter faster, bounty faster, and close races.
-        const long hunterPress = 100 + (i % 401);   // 100–500 ms
-        const long bountyPress = 100 + (i % 397);   // 100–496 ms
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> dist(100, 1500);
+        const long hunterPress = dist(gen);   // 100–1500 ms
+        const long bountyPress = dist(gen);   // 100–1500 ms
 
         clock.set(duelStart + hunterPress);
         hunter.matchMgr->getDuelButtonPush()(hunter.matchMgr);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1,6 +1,8 @@
 #include "game/player.hpp"
 #include <memory>
+#include <cstring>
 #include <ArduinoJson.h>
+#include "wireless/mac-functions.hpp"
 
 Player::Player(const std::string& id, Allegiance allegiance, bool isHunter) :
   id(id),
@@ -188,6 +190,13 @@ const std::string& Player::getCurrentOpponentId() const {
 
 void Player::setOpponentMacAddress(const std::string& macAddress) {
     opponentMacAddress = macAddress;
+    opponentMacValid = StringToMac(macAddress.c_str(), opponentMacBytes);
+}
+
+void Player::setOpponentMacAddress(const uint8_t* macBytes) {
+    memcpy(opponentMacBytes, macBytes, 6);
+    opponentMacValid = true;
+    opponentMacAddress = MacToString(macBytes);
 }
 
 std::string& Player::getOpponentMacAddress() {
@@ -196,6 +205,14 @@ std::string& Player::getOpponentMacAddress() {
 
 const std::string& Player::getOpponentMacAddress() const {
     return opponentMacAddress;
+}
+
+const uint8_t* Player::getOpponentMacBytes() const {
+    return opponentMacBytes;
+}
+
+bool Player::hasOpponentMac() const {
+    return opponentMacValid;
 }
 
 unsigned long Player::getLastReactionTime() {

--- a/src/wireless/quickdraw-wireless-manager.cpp
+++ b/src/wireless/quickdraw-wireless-manager.cpp
@@ -30,60 +30,42 @@ void QuickdrawWirelessManager::clearCallbacks() {
     packetReceivedCallback = nullptr;
 }
 
-void QuickdrawWirelessManager::setPacketReceivedCallback(const std::function<void (QuickdrawCommand)>& callback) {
+void QuickdrawWirelessManager::setPacketReceivedCallback(const std::function<void(const QuickdrawCommand&)>& callback) {
     packetReceivedCallback = callback;
 }
 
-int QuickdrawWirelessManager::broadcastPacket(const std::string& macAddress, 
-                                             int command, 
+int QuickdrawWirelessManager::broadcastPacket(const uint8_t* macAddress,
+                                             int command,
                                              const Match& match) {
-    
+    if (!macAddress) {
+        return -1;
+    }
+
     QuickdrawPacket qdPacket;
-    
-    // Set command
     qdPacket.command = command;
-    
-    // Copy the match ID (UUID)
-    strncpy(qdPacket.matchId, match.getMatchId().c_str(), IdGenerator::UUID_STRING_LENGTH);
-    qdPacket.matchId[IdGenerator::UUID_STRING_LENGTH] = '\0';  // Ensure null-termination
-    
-    // Copy the hunter ID (4 chars)
-    strncpy(qdPacket.hunterId, match.getHunterId().c_str(), 4);
-    qdPacket.hunterId[4] = '\0';  // Ensure null-termination
-    
-    // Copy the bounty ID (4 chars)
-    strncpy(qdPacket.bountyId, match.getBountyId().c_str(), 4);
-    qdPacket.bountyId[4] = '\0';  // Ensure null-termination
-    
-    // Set draw times
+
+    memcpy(qdPacket.matchId, match.getMatchId(), IdGenerator::UUID_STRING_LENGTH);
+    qdPacket.matchId[IdGenerator::UUID_STRING_LENGTH] = '\0';
+
+    memcpy(qdPacket.hunterId, match.getHunterId(), 4);
+    qdPacket.hunterId[4] = '\0';
+
+    memcpy(qdPacket.bountyId, match.getBountyId(), 4);
+    qdPacket.bountyId[4] = '\0';
+
     qdPacket.hunterDrawTime = match.getHunterDrawTime();
     qdPacket.bountyDrawTime = match.getBountyDrawTime();
 
-    LOG_I("QWM", "Sending command %i to %s", command, macAddress.c_str());
+    LOG_I("QWM", "Sending command %i to %s", command, MacToString(macAddress));
     LOG_I("QWM", "Match ID: %s", qdPacket.matchId);
-    LOG_I("QWM", "Hunter ID: %s", qdPacket.hunterId);
-    LOG_I("QWM", "Bounty ID: %s", qdPacket.bountyId);
-    LOG_I("QWM", "Hunter Draw Time: %ld", qdPacket.hunterDrawTime);
-    LOG_I("QWM", "Bounty Draw Time: %ld", qdPacket.bountyDrawTime);
+    LOG_I("QWM", "Hunter Draw Time: %ld, Bounty Draw Time: %ld",
+          qdPacket.hunterDrawTime, qdPacket.bountyDrawTime);
 
-    uint8_t dstMac[6];
-    const uint8_t* targetMac;
-
-    int ret;
-
-    if (!macAddress.empty() && StringToMac(macAddress.c_str(), dstMac)) {
-        targetMac = dstMac;
-
-        ret = wirelessManager->sendEspNowData(
-            targetMac,
-            PktType::kQuickdrawCommand,
-            (uint8_t*)&qdPacket,
-            sizeof(qdPacket));
-    } else {
-        ret = -1;
-    }
-
-    return ret;
+    return wirelessManager->sendEspNowData(
+        macAddress,
+        PktType::kQuickdrawCommand,
+        reinterpret_cast<const uint8_t*>(&qdPacket),
+        sizeof(qdPacket));
 }
 
 
@@ -97,49 +79,15 @@ int QuickdrawWirelessManager::processQuickdrawCommand(const uint8_t *macAddress,
         return -1;
     }
 
-    QuickdrawPacket *packet = (QuickdrawPacket *)data;
+    const QuickdrawPacket* packet = reinterpret_cast<const QuickdrawPacket*>(data);
 
-    Match match = Match(packet->matchId, packet->hunterId, packet->bountyId);
-    match.setHunterDrawTime(packet->hunterDrawTime);
-    match.setBountyDrawTime(packet->bountyDrawTime);
+    QuickdrawCommand command(macAddress, packet->command,
+                             packet->matchId, packet->hunterId, packet->bountyId,
+                             packet->hunterDrawTime, packet->bountyDrawTime);
 
-    QuickdrawCommand command = QuickdrawCommand(
-            MacToString(macAddress),
-            packet->command,
-            match);
-
-
-    logPacket(command);
     if(packetReceivedCallback) {
         packetReceivedCallback(command);
     }
 
     return 1;
 }
-
-void QuickdrawWirelessManager::clearPackets() {
-    commandTracker.clear();
-}
-
-void QuickdrawWirelessManager::clearPacket(int command) {
-    commandTracker.erase(command);
-}
-
-
-int QuickdrawWirelessManager::getPacketAckCount(int command) {
-    return 0;
-}
-
-
-void QuickdrawWirelessManager::logPacket(const QuickdrawCommand& packet) {
-    // if(commandTracker.find(packet.command) == commandTracker.end()) {
-        //No command found, place it in the tracker.
-        commandTracker[packet.command] = packet;
-    // } else {
-    //     if(std::memcmp(commandTracker[packet.command].wifiMacAddr, packet.wifiMacAddr, 6) == 0) {
-    //         //command came from the same user as the last one
-    //         commandTracker[packet.command]
-    //     }
-    // }
-}
-

--- a/test/test_core/integration-tests.hpp
+++ b/test/test_core/integration-tests.hpp
@@ -7,6 +7,7 @@
 #include "game/player.hpp"
 #include "device-mock.hpp"
 #include "id-generator.hpp"
+#include "utility-tests.hpp"
 
 // ============================================
 // Integration Test Fixture
@@ -22,6 +23,10 @@
 class DuelIntegrationTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        fakeClock = new FakePlatformClock();
+        SimpleTimer::setPlatformClock(fakeClock);
+        fakeClock->setTime(10000);
+
         // Seed ID generator for reproducible tests
         IdGenerator idGenerator = IdGenerator(54321);
         
@@ -47,6 +52,8 @@ public:
         delete matchManager;
         delete hunter;
         delete bounty;
+        SimpleTimer::setPlatformClock(nullptr);
+        delete fakeClock;
     }
 
     // Helper: Initialize match manager for hunter's device
@@ -61,6 +68,7 @@ public:
         matchManager->initialize(bounty, &bountyStorage, &bountyPeerComms, &bountyWirelessManager);
     }
 
+    FakePlatformClock* fakeClock = nullptr;
     Player* hunter;
     Player* bounty;
     MatchManager* matchManager;
@@ -85,7 +93,8 @@ inline void completeDuelFlowHunterWins(DuelIntegrationTestSuite* suite) {
     const unsigned long BOUNTY_REACTION_MS = 300;
     
     // Generate match ID
-    char* matchId = IdGenerator(54321).generateId();
+    IdGenerator idGen(54321);
+    char* matchId = idGen.generateId();
     std::string matchIdStr(matchId);
     
     // ========== HUNTER'S DEVICE ==========
@@ -168,7 +177,8 @@ inline void completeDuelFlowBountyWins(DuelIntegrationTestSuite* suite) {
     const unsigned long HUNTER_REACTION_MS = 350;
     const unsigned long BOUNTY_REACTION_MS = 180;
     
-    char* matchId = IdGenerator(54321).generateId();
+    IdGenerator idGen(54321);
+    char* matchId = idGen.generateId();
     std::string matchIdStr(matchId);
     
     // ========== HUNTER'S DEVICE ==========

--- a/test/test_core/integration-tests.hpp
+++ b/test/test_core/integration-tests.hpp
@@ -250,9 +250,9 @@ inline void matchSerializationRoundTrip() {
     EXPECT_EQ(bytesRead, MATCH_BINARY_SIZE);
 
     // Verify data integrity
-    EXPECT_EQ(receivedMatch.getMatchId(), originalMatch.getMatchId());
-    EXPECT_EQ(receivedMatch.getHunterId(), originalMatch.getHunterId());
-    EXPECT_EQ(receivedMatch.getBountyId(), originalMatch.getBountyId());
+    EXPECT_STREQ(receivedMatch.getMatchId(), originalMatch.getMatchId());
+    EXPECT_STREQ(receivedMatch.getHunterId(), originalMatch.getHunterId());
+    EXPECT_STREQ(receivedMatch.getBountyId(), originalMatch.getBountyId());
     EXPECT_EQ(receivedMatch.getHunterDrawTime(), 225);
     EXPECT_EQ(receivedMatch.getBountyDrawTime(), 310);
 
@@ -261,7 +261,7 @@ inline void matchSerializationRoundTrip() {
     Match jsonRestored;
     jsonRestored.fromJson(json);
 
-    EXPECT_EQ(jsonRestored.getMatchId(), originalMatch.getMatchId());
+    EXPECT_STREQ(jsonRestored.getMatchId(), originalMatch.getMatchId());
     EXPECT_EQ(jsonRestored.getHunterDrawTime(), 225);
 }
 

--- a/test/test_core/match-manager-tests.hpp
+++ b/test/test_core/match-manager-tests.hpp
@@ -49,9 +49,9 @@ inline void matchManagerCreatesMatchCorrectly(MatchManager* mm, Player* player) 
     Match* match = mm->createMatch("match-123", "hunter-uuid", "bounty-uuid");
 
     ASSERT_NE(match, nullptr);
-    EXPECT_EQ(match->getMatchId(), "match-123");
-    EXPECT_EQ(match->getHunterId(), "hunter-uuid");
-    EXPECT_EQ(match->getBountyId(), "bounty-uuid");
+    EXPECT_STREQ(match->getMatchId(), "match-123");
+    EXPECT_STREQ(match->getHunterId(), "hunter-uuid");
+    EXPECT_STREQ(match->getBountyId(), "bounty-uuid");
     EXPECT_EQ(match->getHunterDrawTime(), 0);
     EXPECT_EQ(match->getBountyDrawTime(), 0);
 }
@@ -65,7 +65,7 @@ inline void matchManagerPreventsMultipleActiveMatches(MatchManager* mm) {
     EXPECT_EQ(second, nullptr);
 
     // Current match should still be the first one
-    EXPECT_EQ(mm->getCurrentMatch()->getMatchId(), "match-1");
+    EXPECT_STREQ(mm->getCurrentMatch()->getMatchId(), "match-1");
 }
 
 inline void matchManagerReceiveMatchWorks(MatchManager* mm) {
@@ -76,7 +76,7 @@ inline void matchManagerReceiveMatchWorks(MatchManager* mm) {
     Match* received = mm->receiveMatch(incoming);
 
     ASSERT_NE(received, nullptr);
-    EXPECT_EQ(received->getMatchId(), "received-match");
+    EXPECT_STREQ(received->getMatchId(), "received-match");
     EXPECT_EQ(received->getHunterDrawTime(), 100);
     EXPECT_EQ(received->getBountyDrawTime(), 200);
 }

--- a/test/test_core/match-manager-tests.hpp
+++ b/test/test_core/match-manager-tests.hpp
@@ -46,12 +46,12 @@ protected:
 // ============================================
 
 inline void matchManagerCreatesMatchCorrectly(MatchManager* mm, Player* player) {
-    Match* match = mm->createMatch("match-123", "hunter-uuid", "bounty-uuid");
+    Match* match = mm->createMatch("match-123", "hunt", "boun");
 
     ASSERT_NE(match, nullptr);
     EXPECT_STREQ(match->getMatchId(), "match-123");
-    EXPECT_STREQ(match->getHunterId(), "hunter-uuid");
-    EXPECT_STREQ(match->getBountyId(), "bounty-uuid");
+    EXPECT_STREQ(match->getHunterId(), "hunt");
+    EXPECT_STREQ(match->getBountyId(), "boun");
     EXPECT_EQ(match->getHunterDrawTime(), 0);
     EXPECT_EQ(match->getBountyDrawTime(), 0);
 }

--- a/test/test_core/match-tests.hpp
+++ b/test/test_core/match-tests.hpp
@@ -30,9 +30,9 @@ inline void matchJsonRoundTripPreservesAllFields() {
     restored.fromJson(json);
 
     // Verify all fields preserved
-    EXPECT_EQ(restored.getMatchId(), original.getMatchId());
-    EXPECT_EQ(restored.getHunterId(), original.getHunterId());
-    EXPECT_EQ(restored.getBountyId(), original.getBountyId());
+    EXPECT_STREQ(restored.getMatchId(), original.getMatchId());
+    EXPECT_STREQ(restored.getHunterId(), original.getHunterId());
+    EXPECT_STREQ(restored.getBountyId(), original.getBountyId());
     EXPECT_EQ(restored.getHunterDrawTime(), 250);
     EXPECT_EQ(restored.getBountyDrawTime(), 300);
 }
@@ -84,9 +84,9 @@ inline void matchBinaryRoundTripPreservesAllFields() {
     EXPECT_EQ(bytesRead, MATCH_BINARY_SIZE);
 
     // Verify all fields preserved
-    EXPECT_EQ(restored.getMatchId(), original.getMatchId());
-    EXPECT_EQ(restored.getHunterId(), original.getHunterId());
-    EXPECT_EQ(restored.getBountyId(), original.getBountyId());
+    EXPECT_STREQ(restored.getMatchId(), original.getMatchId());
+    EXPECT_STREQ(restored.getHunterId(), original.getHunterId());
+    EXPECT_STREQ(restored.getBountyId(), original.getBountyId());
     EXPECT_EQ(restored.getHunterDrawTime(), 150);
     EXPECT_EQ(restored.getBountyDrawTime(), 275);
 }
@@ -112,7 +112,7 @@ inline void matchSetupClearsDrawTimes() {
 
     EXPECT_EQ(match.getHunterDrawTime(), 0);
     EXPECT_EQ(match.getBountyDrawTime(), 0);
-    EXPECT_EQ(match.getMatchId(), "new-match");
+    EXPECT_STREQ(match.getMatchId(), "new-match");
 }
 
 inline void matchDrawTimesSetCorrectly() {

--- a/test/test_core/quickdraw-integration-tests.hpp
+++ b/test/test_core/quickdraw-integration-tests.hpp
@@ -808,9 +808,9 @@ inline void handshakeCompleteBountyPerspective(HandshakeIntegrationTests* suite)
                                "handshake-match-id-1234567890", "hunt", "boun");
     
     EXPECT_EQ(receivedCommand.command, QDCommand::HUNTER_RECEIVE_MATCH);
-    EXPECT_EQ(receivedCommand.match.getMatchId(), "handshake-match-id-1234567890");
-    EXPECT_EQ(receivedCommand.match.getHunterId(), "hunt");
-    EXPECT_EQ(receivedCommand.match.getBountyId(), "boun");
+    EXPECT_STREQ(receivedCommand.match.getMatchId(), "handshake-match-id-1234567890");
+    EXPECT_STREQ(receivedCommand.match.getHunterId(), "hunt");
+    EXPECT_STREQ(receivedCommand.match.getBountyId(), "boun");
 }
 
 inline void handshakeCompleteHunterPerspective(HandshakeIntegrationTests* suite) {
@@ -823,7 +823,7 @@ inline void handshakeCompleteHunterPerspective(HandshakeIntegrationTests* suite)
                                "handshake-match-id-1234567890", "hunt", "boun");
     
     EXPECT_EQ(receivedCommand.command, QDCommand::CONNECTION_CONFIRMED);
-    EXPECT_EQ(receivedCommand.match.getMatchId(), "handshake-match-id-1234567890");
+    EXPECT_STREQ(receivedCommand.match.getMatchId(), "handshake-match-id-1234567890");
 }
 
 inline void handshakeTwoDeviceFullFlow(HandshakeIntegrationTests* suite) {
@@ -904,7 +904,7 @@ inline void handshakeSetsOpponentMacAddress(HandshakeIntegrationTests* suite) {
                                "mac-test-match-id-1234567890", "hunt", "boun");
     
     // The MAC address should be captured in the command
-    EXPECT_FALSE(receivedCommand.wifiMacAddr.empty());
+    EXPECT_TRUE(receivedCommand.wifiMacAddrValid);
 }
 
 inline void handshakeMatchDataPropagatedCorrectly(HandshakeIntegrationTests* suite) {
@@ -916,9 +916,9 @@ inline void handshakeMatchDataPropagatedCorrectly(HandshakeIntegrationTests* sui
     suite->hunterSendsToBounty(QDCommand::HUNTER_RECEIVE_MATCH,
                                "propagate-match-1234567890", "HNTR", "BNTY");
     
-    EXPECT_EQ(receivedCommand.match.getMatchId(), "propagate-match-1234567890");
-    EXPECT_EQ(receivedCommand.match.getHunterId(), "HNTR");
-    EXPECT_EQ(receivedCommand.match.getBountyId(), "BNTY");
+    EXPECT_STREQ(receivedCommand.match.getMatchId(), "propagate-match-1234567890");
+    EXPECT_STREQ(receivedCommand.match.getHunterId(), "HNTR");
+    EXPECT_STREQ(receivedCommand.match.getBountyId(), "BNTY");
 }
 
 inline void handshakePacketPreservesPlayerIds(HandshakeIntegrationTests* suite) {

--- a/test/test_core/quickdraw-tests.hpp
+++ b/test/test_core/quickdraw-tests.hpp
@@ -22,6 +22,8 @@ using ::testing::SaveArg;
 using ::testing::NiceMock;
 using ::testing::DoAll;
 
+static const uint8_t kTestMacBytes[] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
 // ============================================
 // Idle State Tests
 // ============================================
@@ -268,7 +270,7 @@ inline void handshakeBountyFlowSucceeds(HandshakeStateTests* suite) {
     
     // Simulate receiving HUNTER_RECEIVE_MATCH command
     Match receivedMatch("test-match-id", "5678", "1234");
-    QuickdrawCommand command("AA:BB:CC:DD:EE:FF", HUNTER_RECEIVE_MATCH, receivedMatch);
+    QuickdrawCommand command(kTestMacBytes, HUNTER_RECEIVE_MATCH, receivedMatch);
     bountyState.onQuickdrawCommandReceived(command);
     
     // Should now transition to connection successful
@@ -291,14 +293,14 @@ inline void handshakeHunterFlowSucceeds(HandshakeStateTests* suite) {
     
     // Simulate receiving CONNECTION_CONFIRMED command
     Match receivedMatch("test-match-id", "", "5678");
-    QuickdrawCommand connectionConfirmed("AA:BB:CC:DD:EE:FF", CONNECTION_CONFIRMED, receivedMatch);
+    QuickdrawCommand connectionConfirmed(kTestMacBytes, CONNECTION_CONFIRMED, receivedMatch);
     hunterState.onQuickdrawCommandReceived(connectionConfirmed);
     
     // Still not done - need BOUNTY_FINAL_ACK
     EXPECT_FALSE(hunterState.transitionToConnectionSuccessful());
     
     // Simulate receiving BOUNTY_FINAL_ACK
-    QuickdrawCommand finalAck("AA:BB:CC:DD:EE:FF", BOUNTY_FINAL_ACK, receivedMatch);
+    QuickdrawCommand finalAck(kTestMacBytes, BOUNTY_FINAL_ACK, receivedMatch);
     hunterState.onQuickdrawCommandReceived(finalAck);
     
     // Should now transition
@@ -345,10 +347,10 @@ inline void handshakeStatesClearOnDismount(HandshakeStateTests* suite) {
     
     // Receive commands to set transition flag
     Match receivedMatch("test-match-id", "", "5678");
-    QuickdrawCommand connectionConfirmed("AA:BB:CC:DD:EE:FF", CONNECTION_CONFIRMED, receivedMatch);
+    QuickdrawCommand connectionConfirmed(kTestMacBytes, CONNECTION_CONFIRMED, receivedMatch);
     hunterState.onQuickdrawCommandReceived(connectionConfirmed);
     
-    QuickdrawCommand finalAck("AA:BB:CC:DD:EE:FF", BOUNTY_FINAL_ACK, receivedMatch);
+    QuickdrawCommand finalAck(kTestMacBytes, BOUNTY_FINAL_ACK, receivedMatch);
     hunterState.onQuickdrawCommandReceived(finalAck);
     
     EXPECT_TRUE(hunterState.transitionToConnectionSuccessful());

--- a/test/test_core/state-machine-tests.hpp
+++ b/test/test_core/state-machine-tests.hpp
@@ -272,6 +272,11 @@ protected:
         stateMachine = new TestStateMachine();
     }
 
+    void TearDown() override {
+        delete stateMachine;
+        stateMachine = nullptr;
+    }
+
     void advanceStateMachineToState(int stateId) {
         int loopCount = 0;
         if(stateId == INITIAL_STATE) {

--- a/test/test_core/utility-tests.hpp
+++ b/test/test_core/utility-tests.hpp
@@ -96,7 +96,8 @@ inline void uuidRoundTripPreservesData() {
 }
 
 inline void uuidGeneratorProducesValidFormat() {
-    char* uuid = IdGenerator(42).generateId();
+    IdGenerator idGen(42);
+    char* uuid = idGen.generateId();
 
     std::string uuidStr(uuid);
     


### PR DESCRIPTION
Implemented two new build targets and a perf-main.cpp to run duel simulations.

Code changes are based off results from valgrind and ASAN analysis results.

Running Valgrind on the codebase before and after changes resulted in a significant reduction in instructions executed.

For a simulation of 50,000 duels, before optimization 1.6 billion instructions were executed, and after reduced to 160 million.