### PR TITLE
Update RDC to support multiple device types.

### DIFF
--- a/include/device/device-constants.hpp
+++ b/include/device/device-constants.hpp
@@ -45,6 +45,8 @@ const std::string YOU_DEFEATED_ME = "ydm";
 const std::string SERIAL_HEARTBEAT = "hb";
 
 const std::string SEND_MAC_ADDRESS = "smac";
+const char PORT_SEPARATOR = '#';
+const char DEVICE_TYPE_SEPARATOR = 't';
 
 constexpr char STRING_TERM = '\r';
 constexpr char STRING_START = '*';

--- a/include/device/device-type.hpp
+++ b/include/device/device-type.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+enum class DeviceType {
+    UNKNOWN = 0,
+    PDN = 1,
+    FDN = 2,   
+};

--- a/include/device/device.hpp
+++ b/include/device/device.hpp
@@ -12,6 +12,7 @@
 #include "wireless-manager.hpp"
 #include "state/state-types.hpp"
 #include <map>
+#include "device-type.hpp"
 
 class StateMachine;
 
@@ -41,6 +42,8 @@ public:
     virtual void setDeviceId(const std::string& deviceId) = 0;
 
     virtual std::string getDeviceId() = 0;
+
+    virtual DeviceType getDeviceType() = 0;
 
     virtual Display* getDisplay() = 0;
     virtual Haptics* getHaptics() = 0;

--- a/include/device/pdn.hpp
+++ b/include/device/pdn.hpp
@@ -37,6 +37,7 @@ public:
     void setDeviceId(const std::string& deviceId) override;
 
     std::string getDeviceId() override;
+    DeviceType getDeviceType() override;
 
     Display* getDisplay() override;
     Haptics* getHaptics() override;

--- a/include/device/remote-device-coordinator.hpp
+++ b/include/device/remote-device-coordinator.hpp
@@ -6,6 +6,7 @@
 #include "device/serial-manager.hpp"
 #include "utils/simple-timer.hpp"
 #include "wireless/handshake-wireless-manager.hpp"
+#include "device/device-type.hpp"
 
 class Device;
 class HandshakeApp;
@@ -51,6 +52,8 @@ public:
      * Prefer this over getPortState() when only the MAC address is needed.
      */
     const uint8_t* getPeerMac(SerialIdentifier port) const;
+
+    virtual DeviceType getPeerDeviceType(SerialIdentifier port) const;
 
 private:
     void notifyDisconnect();

--- a/include/state/connect-state.hpp
+++ b/include/state/connect-state.hpp
@@ -13,6 +13,10 @@ public:
         remoteDeviceCoordinator = nullptr;
     }
 
+    const DeviceType getPeerDeviceType(SerialIdentifier port) const {
+        return remoteDeviceCoordinator->getPeerDeviceType(port);
+    }
+
     bool isConnected() {
         return (isPrimaryRequired() && remoteDeviceCoordinator->getPortStatus(SerialIdentifier::OUTPUT_JACK) == PortStatus::CONNECTED) ||
                (isAuxRequired() && remoteDeviceCoordinator->getPortStatus(SerialIdentifier::INPUT_JACK) == PortStatus::CONNECTED);

--- a/include/wireless/handshake-wireless-manager.hpp
+++ b/include/wireless/handshake-wireless-manager.hpp
@@ -13,6 +13,7 @@
 #include "mac-functions.hpp"
 #include "device/wireless-manager.hpp"
 #include "device/serial-manager.hpp"
+#include "device/device-type.hpp"
 
 enum HSCommand {
     EXCHANGE_ID = 0,
@@ -24,19 +25,21 @@ enum HSCommand {
 struct Peer {
     std::array<uint8_t, 6> macAddr;
     SerialIdentifier sid;
+    DeviceType deviceType;
 };
 
 struct HandshakeCommand {
     uint8_t wifiMacAddr[6];
     bool wifiMacAddrValid;
+    int deviceType;
     int command;
     SerialIdentifier sendingJack;
     SerialIdentifier receivingJack;
 
     HandshakeCommand() = delete;
 
-    HandshakeCommand(const uint8_t* macAddress, int command, SerialIdentifier sendingJack, SerialIdentifier receivingJack)
-        : wifiMacAddrValid(macAddress != nullptr), command(command), sendingJack(sendingJack), receivingJack(receivingJack) {
+    HandshakeCommand(const uint8_t* macAddress, int command, int deviceType, SerialIdentifier sendingJack, SerialIdentifier receivingJack)
+        : wifiMacAddrValid(macAddress != nullptr), deviceType(deviceType), command(command), sendingJack(sendingJack), receivingJack(receivingJack) {
         if (macAddress) {
             memcpy(wifiMacAddr, macAddress, 6);
         } else {

--- a/src/apps/handshake/input-idle-state.cpp
+++ b/src/apps/handshake/input-idle-state.cpp
@@ -2,6 +2,7 @@
 #include "device/device.hpp"
 #include "device/device-constants.hpp"
 #include "device/drivers/serial-wrapper.hpp"
+#include "device/device-type.hpp"
 
 #define TAG "INPUT_IDLE_STATE"
 
@@ -21,7 +22,11 @@ void InputIdleState::onStateMounted(Device *PDN) {
 
 void InputIdleState::onStateLoop(Device *PDN) {
     if (emitMacTimer.expired()) {
-        PDN->getSerialManager()->writeString(SEND_MAC_ADDRESS + MacToString(PDN->getWirelessManager()->getMacAddress()) + "#" + std::to_string((int)SerialIdentifier::INPUT_JACK), SerialIdentifier::INPUT_JACK);
+        PDN->getSerialManager()->writeString(
+            SEND_MAC_ADDRESS + MacToString(PDN->getWirelessManager()->getMacAddress()) +
+            PORT_SEPARATOR + std::to_string((int)SerialIdentifier::INPUT_JACK) +
+            DEVICE_TYPE_SEPARATOR + std::to_string((int)PDN->getDeviceType()),
+            SerialIdentifier::INPUT_JACK);
         emitMacTimer.setTimer(emitMacInterval);
     }
 }
@@ -37,7 +42,7 @@ void InputIdleState::onHandshakeCommandReceived(HandshakeCommand command) {
         Peer peer;
         memcpy(peer.macAddr.data(), command.wifiMacAddr, 6);
         peer.sid = command.sendingJack;
-
+        peer.deviceType = static_cast<DeviceType>(command.deviceType);
         handshakeWirelessManager->setMacPeer(SerialIdentifier::INPUT_JACK, peer);
         transitionToSendIdState = true;
     }

--- a/src/apps/handshake/output-idle-state.cpp
+++ b/src/apps/handshake/output-idle-state.cpp
@@ -2,6 +2,7 @@
 #include "device/drivers/serial-wrapper.hpp"
 #include "device/wireless-manager.hpp"
 #include "device/device.hpp"
+#include "device/device-type.hpp"
 #include <functional>
 
 #define TAG "OUTPUT_IDLE_STATE"
@@ -34,9 +35,11 @@ void OutputIdleState::onConnectionStarted(std::string remoteMac) {
     if(remoteMac.rfind(SEND_MAC_ADDRESS, 0) == 0) {
         std::string payload = remoteMac.substr(SEND_MAC_ADDRESS.length());
         size_t portSeparatorIndex = payload.rfind('#');
+        size_t deviceTypeSeparatorIndex = payload.rfind('t');
 
         char portChar = payload[portSeparatorIndex + 1];
         int portNumber = portChar - '0';
+        int deviceType = std::stoi(payload.substr(deviceTypeSeparatorIndex + 1));
 
         SerialIdentifier serialPort = static_cast<SerialIdentifier>(portNumber);
         std::string mac = payload.substr(0, portSeparatorIndex);
@@ -48,6 +51,7 @@ void OutputIdleState::onConnectionStarted(std::string remoteMac) {
         Peer peer;
         std::copy(macBytes, macBytes + 6, peer.macAddr.begin());
         peer.sid = serialPort;
+        peer.deviceType = static_cast<DeviceType>(deviceType);
         handshakeWirelessManager->setMacPeer(SerialIdentifier::OUTPUT_JACK, peer);
         LOG_I(TAG, "Connection started with remote MAC: %s on port: %d", mac.c_str(), portNumber);
         transitionToOutputSendIdState = true;

--- a/src/device/pdn.cpp
+++ b/src/device/pdn.cpp
@@ -40,6 +40,10 @@ std::string PDN::getDeviceId() {
     return deviceId;
 }
 
+DeviceType PDN::getDeviceType() {
+    return DeviceType::PDN;
+}
+
 void PDN::loop() {
     Device::loop();
     lightManager->loop();

--- a/src/device/remote-device-coordinator.cpp
+++ b/src/device/remote-device-coordinator.cpp
@@ -74,6 +74,11 @@ PortState RemoteDeviceCoordinator::getPortState(SerialIdentifier port) {
     return PortState{ port, getPortStatus(port), peerAddresses };
 }
 
+DeviceType RemoteDeviceCoordinator::getPeerDeviceType(SerialIdentifier port) const {
+    const Peer* macPeer = handshakeWirelessManager.getMacPeer(port);
+    return macPeer ? macPeer->deviceType : DeviceType::UNKNOWN;
+}
+
 PortStatus RemoteDeviceCoordinator::mapHandshakeStateToStatus(SerialIdentifier port) {
     HandshakeApp* app = (port == SerialIdentifier::INPUT_JACK) ? inputPortHandshake : outputPortHandshake;
 

--- a/src/game/quickdraw-states/idle-state.cpp
+++ b/src/game/quickdraw-states/idle-state.cpp
@@ -57,12 +57,14 @@ void Idle::onStateLoop(Device *PDN) {
         displayIsDirty = false;
     }
 
-    if (isConnected() && player->isHunter() && !matchInitialized) {
-        const uint8_t* peerMac = remoteDeviceCoordinator->getPeerMac(SerialIdentifier::OUTPUT_JACK);
-        if (peerMac != nullptr) {
-            matchManager->initializeMatch(const_cast<uint8_t*>(peerMac));
-            matchInitialized = true;
-            matchInitializationTimer.setTimer(MATCH_INITIALIZATION_TIMEOUT);
+    if (isConnected() && getPeerDeviceType(SerialIdentifier::OUTPUT_JACK) == DeviceType::PDN && player->isHunter()) {
+        if (!matchInitialized) {
+            const uint8_t* peerMac = remoteDeviceCoordinator->getPeerMac(SerialIdentifier::OUTPUT_JACK);
+            if (peerMac != nullptr) {
+                matchManager->initializeMatch(const_cast<uint8_t*>(peerMac));
+                matchInitialized = true;
+                matchInitializationTimer.setTimer(MATCH_INITIALIZATION_TIMEOUT);
+            }
         }
     }
 

--- a/src/wireless/handshake-wireless-manager.cpp
+++ b/src/wireless/handshake-wireless-manager.cpp
@@ -8,14 +8,9 @@
 struct HandshakePacket {
     int sendingJack;
     int receicingJack;
+    int deviceType;
     int command;
 } __attribute__((packed));
-
-// Packets always travel OUTPUT<->INPUT, so the receiving port is always
-// the opposite of the sending port.
-static SerialIdentifier invertJack(SerialIdentifier jack) {
-    return jack == SerialIdentifier::OUTPUT_JACK ? SerialIdentifier::INPUT_JACK : SerialIdentifier::OUTPUT_JACK;
-}
 
 HandshakeWirelessManager::HandshakeWirelessManager() {}
 
@@ -93,7 +88,7 @@ int HandshakeWirelessManager::processHandshakeCommand(const uint8_t* macAddress,
 
     SerialIdentifier sendingJack = static_cast<SerialIdentifier>(packet->sendingJack);
     SerialIdentifier receivingJack = static_cast<SerialIdentifier>(packet->receicingJack);
-    HandshakeCommand command(macAddress, packet->command, sendingJack, receivingJack);
+    HandshakeCommand command(macAddress, packet->command, packet->deviceType, sendingJack, receivingJack);
 
     auto it = callbacks.find(receivingJack);
     if (it != callbacks.end() && it->second) {

--- a/test/test_core/device-mock.hpp
+++ b/test/test_core/device-mock.hpp
@@ -168,9 +168,22 @@ public:
         return PortStatus::DISCONNECTED;
     }
 
+    void setPeerDeviceType(SerialIdentifier id, DeviceType type) {
+        if (id == SerialIdentifier::OUTPUT_JACK) outputDeviceType = type;
+        else if (id == SerialIdentifier::INPUT_JACK) inputDeviceType = type;
+    }
+
+    DeviceType getPeerDeviceType(SerialIdentifier id) const override {
+        if (id == SerialIdentifier::OUTPUT_JACK) return outputDeviceType;
+        if (id == SerialIdentifier::INPUT_JACK) return inputDeviceType;
+        return DeviceType::UNKNOWN;
+    }
+
 private:
     PortStatus outputStatus = PortStatus::DISCONNECTED;
     PortStatus inputStatus = PortStatus::DISCONNECTED;
+    DeviceType outputDeviceType = DeviceType::UNKNOWN;
+    DeviceType inputDeviceType = DeviceType::UNKNOWN;
 };
 
 // Fake QuickdrawWirelessManager that captures outbound packets instead of transmitting them.
@@ -254,6 +267,7 @@ public:
     MOCK_METHOD(int, begin, (), (override));
     MOCK_METHOD(void, setDeviceId, (const std::string&), (override));
     MOCK_METHOD(std::string, getDeviceId, (), (override));
+    DeviceType getDeviceType() override { return DeviceType::PDN; }
 
     // Getters return mock instances
     Display* getDisplay() override { return mockDisplay; }

--- a/test/test_core/quickdraw-integration-tests.hpp
+++ b/test/test_core/quickdraw-integration-tests.hpp
@@ -828,7 +828,7 @@ public:
 
 // Test: EXCHANGE_ID sent by output (OUTPUT) is routed to the input INPUT callback
 inline void handshakeCompleteBountyPerspective(HandshakeIntegrationTests* suite) {
-    HandshakeCommand receivedCmd(nullptr, -1, SerialIdentifier::OUTPUT_JACK, SerialIdentifier::INPUT_JACK);
+    HandshakeCommand receivedCmd(nullptr, -1, 0, SerialIdentifier::OUTPUT_JACK, SerialIdentifier::INPUT_JACK);
     bool callbackFired = false;
 
     suite->inputHWM.setPacketReceivedCallback([&](HandshakeCommand cmd) {
@@ -846,7 +846,7 @@ inline void handshakeCompleteBountyPerspective(HandshakeIntegrationTests* suite)
 
 // Test: EXCHANGE_ID sent by input (INPUT) is routed to the output OUTPUT callback
 inline void handshakeCompleteHunterPerspective(HandshakeIntegrationTests* suite) {
-    HandshakeCommand receivedCmd(nullptr, -1, SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK);
+    HandshakeCommand receivedCmd(nullptr, -1, 0, SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK);
     bool callbackFired = false;
 
     suite->outputHWM.setPacketReceivedCallback([&](HandshakeCommand cmd) {
@@ -935,7 +935,7 @@ inline void handshakeIgnoresUnexpectedCommands(HandshakeIntegrationTests* suite)
 
 // Test: Sender MAC is captured in the HandshakeCommand
 inline void handshakeSetsOpponentMacAddress(HandshakeIntegrationTests* suite) {
-    HandshakeCommand receivedCmd(nullptr, -1, SerialIdentifier::OUTPUT_JACK, SerialIdentifier::INPUT_JACK);
+    HandshakeCommand receivedCmd(nullptr, -1, 0, SerialIdentifier::OUTPUT_JACK, SerialIdentifier::INPUT_JACK);
     suite->inputHWM.setPacketReceivedCallback([&](HandshakeCommand cmd) {
         receivedCmd = cmd;
     }, SerialIdentifier::INPUT_JACK);
@@ -948,7 +948,7 @@ inline void handshakeSetsOpponentMacAddress(HandshakeIntegrationTests* suite) {
 
 // Test: NOTIFY_DISCONNECT is routed correctly
 inline void handshakeMatchDataPropagatedCorrectly(HandshakeIntegrationTests* suite) {
-    HandshakeCommand receivedCmd(nullptr, -1, SerialIdentifier::OUTPUT_JACK, SerialIdentifier::INPUT_JACK);
+    HandshakeCommand receivedCmd(nullptr, -1, 0, SerialIdentifier::OUTPUT_JACK, SerialIdentifier::INPUT_JACK);
     suite->inputHWM.setPacketReceivedCallback([&](HandshakeCommand cmd) {
         receivedCmd = cmd;
     }, SerialIdentifier::INPUT_JACK);

--- a/test/test_core/quickdraw-tests.hpp
+++ b/test/test_core/quickdraw-tests.hpp
@@ -28,6 +28,7 @@ inline Peer makeHSPeer(const uint8_t* mac, SerialIdentifier sid) {
     Peer p;
     std::copy(mac, mac + 6, p.macAddr.begin());
     p.sid = sid;
+    p.deviceType = DeviceType::PDN;
     return p;
 }
 
@@ -185,11 +186,11 @@ public:
 
     // Simulate a remote device sending a HandshakePacket to this device.
     // receivingJack is the opposite of the sender's jack (packets always travel OUTPUT<->INPUT).
-    void deliverPacket(int command, SerialIdentifier senderJack) {
+    void deliverPacket(int command, SerialIdentifier senderJack, int deviceType = 0) {
         SerialIdentifier receivingJack = (senderJack == SerialIdentifier::OUTPUT_JACK)
             ? SerialIdentifier::INPUT_JACK : SerialIdentifier::OUTPUT_JACK;
-        struct RawPacket { int sendingJack; int receivingJack; int command; } __attribute__((packed));
-        RawPacket pkt{ static_cast<int>(senderJack), static_cast<int>(receivingJack), command };
+        struct RawPacket { int sendingJack; int receivingJack; int deviceType; int command; } __attribute__((packed));
+        RawPacket pkt{ static_cast<int>(senderJack), static_cast<int>(receivingJack), deviceType, command };
         uint8_t dummyMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
         handshakeWirelessManager.processHandshakeCommand(dummyMac,
             reinterpret_cast<const uint8_t*>(&pkt), sizeof(pkt));
@@ -207,8 +208,8 @@ inline void outputIdleTransitionsOnMacReceived(HandshakeStateTests* suite) {
 
     EXPECT_FALSE(idleState.transitionToOutputSendId());
 
-    // Simulate INPUT side sending "SEND_MAC:AA:BB:CC:DD:EE:FF" over the output jack serial
-    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF");
+    // Simulate INPUT side sending its MAC+port+deviceType over the output jack serial
+    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
 
     EXPECT_TRUE(idleState.transitionToOutputSendId());
 
@@ -345,7 +346,7 @@ inline void handshakeAppOutputJackTimeoutResetsToIdle(HandshakeStateTests* suite
     handshakeApp.onStateMounted(&suite->device);
 
     // Advance into PrimarySendId by delivering a MAC string over the output serial
-    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF");
+    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
     handshakeApp.onStateLoop(&suite->device);
 
     // Handshake timeout not yet reached
@@ -1388,6 +1389,7 @@ public:
         Peer peer;
         std::copy(std::begin(mac), std::end(mac), peer.macAddr.begin());
         peer.sid = SerialIdentifier::OUTPUT_JACK;
+        peer.deviceType = DeviceType::PDN;
         hwm.setMacPeer(SerialIdentifier::OUTPUT_JACK, peer);
     }
 

--- a/test/test_core/rdc-tests.hpp
+++ b/test/test_core/rdc-tests.hpp
@@ -18,6 +18,7 @@ inline Peer makeTestPeer(const uint8_t* mac, SerialIdentifier sid) {
     Peer p;
     std::copy(mac, mac + 6, p.macAddr.begin());
     p.sid = sid;
+    p.deviceType = DeviceType::PDN;
     return p;
 }
 
@@ -85,13 +86,13 @@ inline void hwmClearCallbacksRemovesAll(HWMUnitTests* suite) {
     suite->hwm.clearCallbacks();
 
     // Deliver a packet targeting INPUT_JACK (sent from OUTPUT_JACK)
-    struct RawPacket { int jack; int command; } __attribute__((packed));
+    struct RawPacket { int sendingJack; int receivingJack; int deviceType; int command; } __attribute__((packed));
     uint8_t dummyMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
 
-    RawPacket pkt{ static_cast<int>(SerialIdentifier::OUTPUT_JACK), HSCommand::EXCHANGE_ID };
+    RawPacket pkt{ static_cast<int>(SerialIdentifier::OUTPUT_JACK), static_cast<int>(SerialIdentifier::INPUT_JACK), 0, HSCommand::EXCHANGE_ID };
     suite->hwm.processHandshakeCommand(dummyMac, reinterpret_cast<const uint8_t*>(&pkt), sizeof(pkt));
 
-    RawPacket pkt2{ static_cast<int>(SerialIdentifier::INPUT_JACK), HSCommand::EXCHANGE_ID };
+    RawPacket pkt2{ static_cast<int>(SerialIdentifier::INPUT_JACK), static_cast<int>(SerialIdentifier::OUTPUT_JACK), 0, HSCommand::EXCHANGE_ID };
     suite->hwm.processHandshakeCommand(dummyMac, reinterpret_cast<const uint8_t*>(&pkt2), sizeof(pkt2));
 
     EXPECT_FALSE(inputFired);
@@ -102,8 +103,8 @@ inline void hwmProcessRejectsNegativeCommand(HWMUnitTests* suite) {
     bool callbackFired = false;
     suite->hwm.setPacketReceivedCallback([&](HandshakeCommand) { callbackFired = true; }, SerialIdentifier::INPUT_JACK);
 
-    struct RawPacket { int jack; int command; } __attribute__((packed));
-    RawPacket pkt{ static_cast<int>(SerialIdentifier::OUTPUT_JACK), -1 };
+    struct RawPacket { int sendingJack; int receivingJack; int deviceType; int command; } __attribute__((packed));
+    RawPacket pkt{ static_cast<int>(SerialIdentifier::OUTPUT_JACK), static_cast<int>(SerialIdentifier::INPUT_JACK), 0, -1 };
     uint8_t dummyMac[6] = {};
 
     int result = suite->hwm.processHandshakeCommand(dummyMac, reinterpret_cast<const uint8_t*>(&pkt), sizeof(pkt));
@@ -137,11 +138,11 @@ public:
         delete fakeClock;
     }
 
-    void deliverPacketViaRDC(int command, SerialIdentifier senderJack) {
+    void deliverPacketViaRDC(int command, SerialIdentifier senderJack, int deviceType = 0) {
         SerialIdentifier receivingJack = (senderJack == SerialIdentifier::OUTPUT_JACK)
             ? SerialIdentifier::INPUT_JACK : SerialIdentifier::OUTPUT_JACK;
-        struct RawPacket { int sendingJack; int receivingJack; int command; } __attribute__((packed));
-        RawPacket pkt{ static_cast<int>(senderJack), static_cast<int>(receivingJack), command };
+        struct RawPacket { int sendingJack; int receivingJack; int deviceType; int command; } __attribute__((packed));
+        RawPacket pkt{ static_cast<int>(senderJack), static_cast<int>(receivingJack), deviceType, command };
         uint8_t dummyMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
 
         ASSERT_NE(capturedHandler, nullptr);
@@ -163,7 +164,7 @@ inline void rdcBothPortsDisconnectedOnInit(RDCTests* suite) {
 
 inline void rdcOutputPortConnectingAfterMacReceived(RDCTests* suite) {
     // Simulate the foreign INPUT side sending its MAC over the output jack serial line
-    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF");
+    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
 
     // Sync to process the transition from OutputIdle -> OutputSendId
     suite->rdc.sync(&suite->device);
@@ -173,7 +174,7 @@ inline void rdcOutputPortConnectingAfterMacReceived(RDCTests* suite) {
 
 inline void rdcOutputPortConnectedAfterHandshakeComplete(RDCTests* suite) {
     // Step 1: Output receives MAC over serial -> transitions to OutputSendId
-    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF");
+    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
     suite->rdc.sync(&suite->device);
     ASSERT_EQ(suite->rdc.getPortStatus(SerialIdentifier::OUTPUT_JACK), PortStatus::CONNECTING);
 
@@ -195,7 +196,7 @@ inline void rdcPortStateReturnsEmptyPeersWhenDisconnected(RDCTests* suite) {
 }
 
 inline void rdcPortStateReturnsPeerWhenConnecting(RDCTests* suite) {
-    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF");
+    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
     suite->rdc.sync(&suite->device);
 
     PortState state = suite->rdc.getPortState(SerialIdentifier::OUTPUT_JACK);
@@ -207,7 +208,7 @@ inline void rdcPortStateReturnsPeerWhenConnecting(RDCTests* suite) {
 
 inline void rdcInputPortDisconnectedIndependentOfOutputPort(RDCTests* suite) {
     // Move output port to CONNECTING
-    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF");
+    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
     suite->rdc.sync(&suite->device);
 
     // Input port should remain unaffected
@@ -226,7 +227,7 @@ inline void rdcGetPeerMacReturnsNullWhenDisconnected(RDCTests* suite) {
 }
 
 inline void rdcGetPeerMacReturnsMacWhenConnecting(RDCTests* suite) {
-    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF");
+    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
     suite->rdc.sync(&suite->device);
 
     ASSERT_EQ(suite->rdc.getPortStatus(SerialIdentifier::OUTPUT_JACK), PortStatus::CONNECTING);
@@ -239,7 +240,7 @@ inline void rdcGetPeerMacReturnsMacWhenConnecting(RDCTests* suite) {
 
 inline void rdcGetPeerMacReturnsMacWhenConnected(RDCTests* suite) {
     // Complete the full handshake to reach CONNECTED
-    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF");
+    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
     suite->rdc.sync(&suite->device);
     suite->deliverPacketViaRDC(HSCommand::EXCHANGE_ID, SerialIdentifier::INPUT_JACK);
     suite->rdc.sync(&suite->device);
@@ -254,9 +255,27 @@ inline void rdcGetPeerMacReturnsMacWhenConnected(RDCTests* suite) {
     EXPECT_EQ(suite->rdc.getPeerMac(SerialIdentifier::INPUT_JACK), nullptr);
 }
 
+// ============================================
+// getPeerDeviceType Tests
+// ============================================
+
+inline void rdcGetPeerDeviceTypeReturnsUnknownWhenDisconnected(RDCTests* suite) {
+    EXPECT_EQ(suite->rdc.getPeerDeviceType(SerialIdentifier::OUTPUT_JACK), DeviceType::UNKNOWN);
+    EXPECT_EQ(suite->rdc.getPeerDeviceType(SerialIdentifier::INPUT_JACK), DeviceType::UNKNOWN);
+}
+
+inline void rdcGetPeerDeviceTypeReturnsPDNAfterMacReceived(RDCTests* suite) {
+    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
+    suite->rdc.sync(&suite->device);
+
+    ASSERT_EQ(suite->rdc.getPortStatus(SerialIdentifier::OUTPUT_JACK), PortStatus::CONNECTING);
+    EXPECT_EQ(suite->rdc.getPeerDeviceType(SerialIdentifier::OUTPUT_JACK), DeviceType::PDN);
+    EXPECT_EQ(suite->rdc.getPeerDeviceType(SerialIdentifier::INPUT_JACK), DeviceType::UNKNOWN);
+}
+
 inline void rdcConnectedPortDisconnectsOnHeartbeatTimeout(RDCTests* suite) {
     // Complete the output-port handshake
-    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF");
+    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
     suite->rdc.sync(&suite->device);
     suite->deliverPacketViaRDC(HSCommand::EXCHANGE_ID, SerialIdentifier::INPUT_JACK);
     suite->rdc.sync(&suite->device);

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1202,6 +1202,14 @@ TEST_F(RDCTests, getPeerMacReturnsMacWhenConnected) {
     rdcGetPeerMacReturnsMacWhenConnected(this);
 }
 
+TEST_F(RDCTests, getPeerDeviceTypeReturnsUnknownWhenDisconnected) {
+    rdcGetPeerDeviceTypeReturnsUnknownWhenDisconnected(this);
+}
+
+TEST_F(RDCTests, getPeerDeviceTypeReturnsPDNAfterMacReceived) {
+    rdcGetPeerDeviceTypeReturnsPDNAfterMacReceived(this);
+}
+
 // ============================================
 // MAIN
 // ============================================


### PR DESCRIPTION
Adds a new `DeviceType` enum class that is exchanged with connected peers in the RDC handshake flow. This is surfaced through rdc.getDeviceType(SerialIdentifier).

In applications that wish to provide different experiences based off connected device type, the first state in the application that requires a connection should not rely on ConnectState.isConnected() alone, but should guard against specific device types. In subsequent states, isConnected should be a sufficient indicator on its own.