### PR TITLE
ESP-NOW team coordination with chain duel support

### DIFF
--- a/include/apps/handshake/handshake-states.hpp
+++ b/include/apps/handshake/handshake-states.hpp
@@ -47,6 +47,8 @@ public:
 private:
     HandshakeWirelessManager* handshakeWirelessManager;
     bool transitionToConnectionSuccessfulState = false;
+    SimpleTimer retryTimer;
+    static constexpr int RETRY_INTERVAL_MS = 500;
 };
 
 class HandshakeConnectedState : public State {
@@ -60,7 +62,7 @@ public:
     bool transitionToIdle();
 
     void heartbeatMonitorStringCallback(const std::string& message);
-    void listenForNotifyDisconnectCommand(HandshakeCommand command);
+    void listenForHandshakeCommand(HandshakeCommand command);
 
 private:
     HandshakeWirelessManager* handshakeWirelessManager;
@@ -109,4 +111,6 @@ public:
 private:
     HandshakeWirelessManager* handshakeWirelessManager;
     bool transitionToConnectedState = false;
+    SimpleTimer retryTimer;
+    static constexpr int RETRY_INTERVAL_MS = 500;
 };

--- a/include/device/drivers/esp32-s3/esp-now-driver.hpp
+++ b/include/device/drivers/esp32-s3/esp-now-driver.hpp
@@ -82,6 +82,13 @@ public:
             return;
         }
 
+        // Drain the send queue — callbacks will never fire after deinit
+        while (!m_sendQueue.empty()) {
+            free(m_sendQueue.front().ptr);
+            m_sendQueue.pop();
+        }
+        m_curRetries = 0;
+
         peerCommsState = PeerCommsState::DISCONNECTED;
     }
 
@@ -260,6 +267,8 @@ private:
 
     // Actually initializes ESP-NOW - must be called after WiFi is configured
     int initializeEspNow() {
+        esp_read_mac(macAddress_, ESP_MAC_WIFI_STA);
+
         // Initialize ESP-NOW
         esp_err_t err = esp_now_init();
         if(err != ESP_OK)
@@ -320,6 +329,12 @@ private:
     //ESP-NOW callbacks
     static void EspNowRecvCallback(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int data_len) {
         EspNowManager* manager = EspNowManager::GetInstance();
+
+        // Drop packets not addressed to us or broadcast
+        if (memcmp(esp_now_info->des_addr, PEER_BROADCAST_ADDR, 6) != 0 &&
+            memcmp(esp_now_info->des_addr, manager->macAddress_, 6) != 0) {
+            return;
+        }
 
 #if DEBUG_PRINT_ESP_NOW
         ESP_LOGD("ENC", "ESPNOW Recv Callback len %i from %X:%X:%X:%X:%X:%X\n", data_len,

--- a/include/device/remote-device-coordinator.hpp
+++ b/include/device/remote-device-coordinator.hpp
@@ -51,7 +51,7 @@ public:
      * Returns a pointer to the peer's MAC address for the given port, or nullptr if no peer is connected.
      * Prefer this over getPortState() when only the MAC address is needed.
      */
-    const uint8_t* getPeerMac(SerialIdentifier port) const;
+    virtual const uint8_t* getPeerMac(SerialIdentifier port) const;
 
     virtual DeviceType getPeerDeviceType(SerialIdentifier port) const;
 

--- a/include/game/jack-roles.hpp
+++ b/include/game/jack-roles.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "game/player.hpp"
+#include "device/drivers/serial-wrapper.hpp"
+
+// Hunter: opponent on OUTPUT_JACK, supporter on INPUT_JACK
+// Bounty: opponent on INPUT_JACK, supporter on OUTPUT_JACK
+inline SerialIdentifier opponentJack(const Player* p) {
+    return p->isHunter() ? SerialIdentifier::OUTPUT_JACK : SerialIdentifier::INPUT_JACK;
+}
+
+inline SerialIdentifier supporterJack(const Player* p) {
+    return p->isHunter() ? SerialIdentifier::INPUT_JACK : SerialIdentifier::OUTPUT_JACK;
+}

--- a/include/game/match-manager.hpp
+++ b/include/game/match-manager.hpp
@@ -25,6 +25,7 @@ struct ActiveDuelState {
     bool hasReceivedDrawResult = false;
     bool hasPressedButton = false;
     bool gracePeriodExpiredNoResult = false;
+    bool opponentNeverPressed = false;
     unsigned long duelLocalStartTime = 0;
     unsigned long BUTTON_MASHER_PENALTY_MS = 75;
     int buttonMasherCount = 0;
@@ -100,7 +101,11 @@ public:
      */
     size_t getStoredMatchCount();
 
-    void clearCurrentMatch();
+    void clearCurrentMatch(const char* caller = nullptr);
+
+    void setBoost(int boostMs);
+    int getBoost() const { return boostMs_; }
+    void setOpponentNeverPressed() { activeDuelState.opponentNeverPressed = true; }
 
     void listenForMatchEvents(const QuickdrawCommand& command);
 
@@ -121,6 +126,7 @@ public:
 private:
 
     Player* player;
+    int boostMs_ = 0;
 
     ActiveDuelState activeDuelState;
 

--- a/include/game/quickdraw-states.hpp
+++ b/include/game/quickdraw-states.hpp
@@ -10,11 +10,16 @@
 #include "device/drivers/http-client-interface.hpp"
 #include "game/quickdraw-resources.hpp"
 #include <cstdlib>
+#include <functional>
 #include <queue>
 #include <string>
 #include "device/remote-device-coordinator.hpp"
+#include "wireless/team-packet.hpp"
 
-enum QuickdrawStateId {    
+class Quickdraw;
+#include "device/drivers/peer-comms-interface.hpp"
+
+enum QuickdrawStateId {
     SLEEP = 6,
     AWAKEN_SEQUENCE = 7,
     IDLE = 8,
@@ -25,7 +30,8 @@ enum QuickdrawStateId {
     DUEL_RESULT = 17,
     WIN = 18,
     LOSE = 19,
-    UPLOAD_MATCHES = 20
+    UPLOAD_MATCHES = 20,
+    SUPPORTER_READY = 21
 };
 
 class Sleep : public State {
@@ -69,7 +75,9 @@ private:
 
 class Idle : public ConnectState {
 public:
-    Idle(Player *player, MatchManager* matchManager, RemoteDeviceCoordinator* remoteDeviceCoordinator);
+    Idle(Player *player, MatchManager* matchManager, RemoteDeviceCoordinator* remoteDeviceCoordinator,
+         std::function<int()> getSupporterCount, std::function<void()> clearChainState,
+         std::function<bool()> isInviteRejected);
     ~Idle();
 
     void onStateMounted(Device *PDN) override;
@@ -81,10 +89,12 @@ public:
 private:
     Player *player;
     MatchManager* matchManager;
+    std::function<int()> getSupporterCount_;
+    std::function<void()> clearChainState_;
+    std::function<bool()> isInviteRejected_;
     bool matchInitialized = false;
     bool displayIsDirty = false;
     int statsIndex = 0;
-    int statsCount = 5;
 
     bool isPrimaryRequired() override;
     bool isAuxRequired() override;
@@ -92,7 +102,9 @@ private:
     SimpleTimer matchInitializationTimer;
     const int MATCH_INITIALIZATION_TIMEOUT = 1000;
 
-    // void serialEventCallbacks(const std::string& message);
+    SimpleTimer inviteRetryTimer_;
+    static constexpr int INVITE_RETRY_MS = 2000;
+    int lastSupporterCount_ = 0;
 };
 
 
@@ -304,4 +316,50 @@ private:
     std::string matchesJson;
     bool transitionToSleepState = false;
     bool shouldRetryUpload = false;
+};
+
+class SupporterReady : public ConnectState {
+public:
+    SupporterReady(Player* player, RemoteDeviceCoordinator* rdc, Quickdraw* quickdraw);
+    ~SupporterReady();
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToWin();
+    bool transitionToLose();
+    bool transitionToIdle();
+
+    void setChampionMac(const uint8_t* mac) { memcpy(championMac_, mac, 6); }
+    void setChampionName(const char* name) { strncpy(championName_, name, CHAMPION_NAME_MAX - 1); championName_[CHAMPION_NAME_MAX - 1] = '\0'; }
+    void setPosition(uint8_t pos) { position_ = pos; }
+    void setChampionIsHunter(bool h) { championIsHunter_ = h; }
+    void handleGameEvent(GameEventType evt);
+
+    bool isPrimaryRequired() override;
+    bool isAuxRequired() override;
+
+private:
+    static void onButtonPressed(void* ctx);
+    void renderDisplay(const char* status);
+
+    Player* player_;
+    Quickdraw* quickdraw_;
+    Device* device_ = nullptr;
+    PeerCommsInterface* peerComms_ = nullptr;
+    uint8_t championMac_[6] = {};
+    char championName_[CHAMPION_NAME_MAX] = {};
+    uint8_t position_ = 0;
+    bool championIsHunter_ = false;
+    bool transitionToWin_ = false;
+    bool transitionToLose_ = false;
+    bool transitionToIdle_ = false;
+    bool hasConfirmed_ = false;
+    bool duelActive_ = false;
+    bool downstreamInvited_ = false;
+    bool registered_ = false;
+    SimpleTimer retryTimer_;
+    SimpleTimer safetyTimeout_;
+    static constexpr int RETRY_MS = 2000;
+    static constexpr unsigned long SAFETY_TIMEOUT_MS = 300000;
 };

--- a/include/game/quickdraw.hpp
+++ b/include/game/quickdraw.hpp
@@ -10,6 +10,8 @@
 #include "device/drivers/http-client-interface.hpp"
 #include "device/drivers/storage-interface.hpp"
 #include "wireless/remote-debug-manager.hpp"
+#include "wireless/team-packet.hpp"
+#include <functional>
 
 constexpr size_t MATCH_SIZE = sizeof(Match);
 
@@ -17,12 +19,32 @@ constexpr int QUICKDRAW_APP_ID = 1;
 
 class Quickdraw : public StateMachine {
 public:
+    using GameEventCallback = std::function<void(GameEventType)>;
+
     Quickdraw(Player *player, Device *PDN, QuickdrawWirelessManager* quickdrawWirelessManager, RemoteDebugManager* remoteDebugManager);
     ~Quickdraw();
 
     void populateStateMap() override;
+    void onStateLoop(Device* PDN) override;
+
+    void onTeamPacketReceived(const uint8_t* src, const uint8_t* data, size_t len);
+
+    bool hasTeamInvite() const { return hasTeamInvite_; }
+    const uint8_t* getInviteChampionMac() const { return inviteChampionMac_; }
+    uint8_t getInvitePosition() const { return invitePosition_; }
+    void setGameEventCallback(GameEventCallback cb) { gameEventCallback_ = cb; }
+    void clearGameEventCallback() { gameEventCallback_ = nullptr; }
+    bool isInviteRejected() const { return inviteRejected_; }
+    int getSupporterCount() const { return supporterMacCount_; }
+    int getConfirmedSupporters() const { return confirmedSupporters_; }
+    void clearChainState();
+
+    bool shouldTransitionToSupporter(SupporterReady* supporterReady);
 
 private:
+    void onStateChanged(int newStateId);
+    int findSupporterIndex(const uint8_t* mac) const;
+
     std::vector<Match> matches;
     int numMatches = 0;
     MatchManager* matchManager;
@@ -33,4 +55,19 @@ private:
     RemoteDeviceCoordinator* remoteDeviceCoordinator;
     QuickdrawWirelessManager* quickdrawWirelessManager;
     RemoteDebugManager* remoteDebugManager;
+
+    // Chain state
+    static constexpr int MAX_SUPPORTERS = 255;
+    int confirmedSupporters_ = 0;
+    uint8_t supporterMacs_[MAX_SUPPORTERS][6] = {};
+    int supporterMacCount_ = 0;
+    int lastStateId_ = -1;
+    bool hasTeamInvite_ = false;
+    uint8_t inviteChampionMac_[6] = {};
+    uint8_t inviteSenderMac_[6] = {};
+    char inviteChampionName_[CHAMPION_NAME_MAX] = {};
+    uint8_t invitePosition_ = 0;
+    bool inviteChampionIsHunter_ = false;
+    bool inviteRejected_ = false;
+    GameEventCallback gameEventCallback_ = nullptr;
 };

--- a/include/wireless/peer-comms-types.hpp
+++ b/include/wireless/peer-comms-types.hpp
@@ -9,6 +9,7 @@ enum class PktType : uint8_t
     kQuickdrawCommand = 1,
     kDebugPacket = 2,
     kHandshakeCommand = 3,
+    kTeamCommand = 4,
     kNumPacketTypes //Not a real packet type, DO NOT USE
 };
 

--- a/include/wireless/team-packet.hpp
+++ b/include/wireless/team-packet.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include "wireless/peer-comms-types.hpp"
+
+enum class TeamCommandType : uint8_t { REGISTER = 0, DEREGISTER = 1, CONFIRM = 2, GAME_EVENT = 3, REGISTER_INVITE = 4, INVITE_REJECT = 5 };
+enum class GameEventType : uint8_t { COUNTDOWN = 0, DRAW = 1, WIN = 2, LOSS = 3 };
+
+// Wire format: 2 bytes. For GAME_EVENT, eventType is GameEventType.
+// For REGISTER/DEREGISTER/CONFIRM, eventType carries chain position.
+struct TeamPacket {
+    uint8_t commandType;
+    uint8_t eventType;
+} __attribute__((packed));
+
+inline void sendTeamPacket(PeerCommsInterface* peerComms, const uint8_t* dst,
+                           TeamCommandType cmd, uint8_t payload = 0) {
+    TeamPacket pkt{static_cast<uint8_t>(cmd), payload};
+    peerComms->sendData(dst, PktType::kTeamCommand,
+        reinterpret_cast<const uint8_t*>(&pkt), sizeof(pkt));
+}
+
+static constexpr int CHAMPION_NAME_MAX = 16;
+
+// REGISTER_INVITE carries the champion MAC and name so forwarded invites preserve the original champion.
+struct RegisterInvitePacket {
+    uint8_t commandType;
+    uint8_t position;
+    uint8_t championIsHunter;
+    uint8_t championMac[6];
+    char championName[CHAMPION_NAME_MAX];
+} __attribute__((packed));
+
+inline void sendRegisterInvite(PeerCommsInterface* peerComms, const uint8_t* dst,
+                               uint8_t position, bool championIsHunter,
+                               const uint8_t* championMac, const char* championName) {
+    RegisterInvitePacket pkt{static_cast<uint8_t>(TeamCommandType::REGISTER_INVITE), position,
+        static_cast<uint8_t>(championIsHunter ? 1 : 0), {}, {}};
+    memcpy(pkt.championMac, championMac, 6);
+    strncpy(pkt.championName, championName, CHAMPION_NAME_MAX - 1);
+    pkt.championName[CHAMPION_NAME_MAX - 1] = '\0';
+    peerComms->sendData(dst, PktType::kTeamCommand,
+        reinterpret_cast<const uint8_t*>(&pkt), sizeof(pkt));
+}
+
+inline void broadcastTeamEvent(PeerCommsInterface* peerComms, GameEventType evt) {
+    sendTeamPacket(peerComms, peerComms->getGlobalBroadcastAddress(),
+                   TeamCommandType::GAME_EVENT, static_cast<uint8_t>(evt));
+}

--- a/src/apps/handshake/handshake-connected-state.cpp
+++ b/src/apps/handshake/handshake-connected-state.cpp
@@ -1,6 +1,7 @@
 #include "apps/handshake/handshake-states.hpp"
 #include "game/quickdraw-resources.hpp"
 #include "device/device.hpp"
+#include "device/device-type.hpp"
 
 HandshakeConnectedState::HandshakeConnectedState(HandshakeWirelessManager* handshakeWirelessManager, SerialIdentifier jack, int stateId)
     : State(stateId), jack(jack) {
@@ -15,7 +16,7 @@ void HandshakeConnectedState::onStateMounted(Device *PDN) {
     PDN->getSerialManager()->setOnStringReceivedCallback(
         std::bind(&HandshakeConnectedState::heartbeatMonitorStringCallback, this, std::placeholders::_1), jack);
     handshakeWirelessManager->setPacketReceivedCallback(
-        std::bind(&HandshakeConnectedState::listenForNotifyDisconnectCommand, this, std::placeholders::_1), jack);
+        std::bind(&HandshakeConnectedState::listenForHandshakeCommand, this, std::placeholders::_1), jack);
 
     emitHeartbeatTimer.setTimer(emitHeartbeatInterval);
     heartbeatMonitorTimer.setTimer(firstHeartbeatTimeout);
@@ -50,9 +51,15 @@ void HandshakeConnectedState::heartbeatMonitorStringCallback(const std::string& 
     }
 }
 
-void HandshakeConnectedState::listenForNotifyDisconnectCommand(HandshakeCommand command) {
+void HandshakeConnectedState::listenForHandshakeCommand(HandshakeCommand command) {
     if (command.command == HSCommand::NOTIFY_DISCONNECT) {
         transitionToIdleState = true;
+    } else if (command.command == HSCommand::EXCHANGE_ID) {
+        Peer peer;
+        memcpy(peer.macAddr.data(), command.wifiMacAddr, 6);
+        peer.sid = command.sendingJack;
+        peer.deviceType = static_cast<DeviceType>(command.deviceType);
+        handshakeWirelessManager->setMacPeer(jack, peer);
     }
 }
 

--- a/src/apps/handshake/input-send-id-state.cpp
+++ b/src/apps/handshake/input-send-id-state.cpp
@@ -19,6 +19,7 @@ void InputSendIdState::onStateMounted(Device *PDN) {
         SerialIdentifier::INPUT_JACK);
 
     handshakeWirelessManager->sendPacket(HSCommand::EXCHANGE_ID, SerialIdentifier::INPUT_JACK);
+    retryTimer.setTimer(RETRY_INTERVAL_MS);
 }
 
 void InputSendIdState::onHandshakeCommandReceived(HandshakeCommand command) {
@@ -27,10 +28,17 @@ void InputSendIdState::onHandshakeCommandReceived(HandshakeCommand command) {
     }
 }
 
-void InputSendIdState::onStateLoop(Device *PDN) {}
+void InputSendIdState::onStateLoop(Device *PDN) {
+    retryTimer.updateTime();
+    if (retryTimer.expired()) {
+        handshakeWirelessManager->sendPacket(HSCommand::EXCHANGE_ID, SerialIdentifier::INPUT_JACK);
+        retryTimer.setTimer(RETRY_INTERVAL_MS);
+    }
+}
 
 void InputSendIdState::onStateDismounted(Device *PDN) {
     transitionToConnectedState = false;
+    retryTimer.invalidate();
     handshakeWirelessManager->clearCallback(SerialIdentifier::INPUT_JACK);
 }
 

--- a/src/apps/handshake/output-send-id-state.cpp
+++ b/src/apps/handshake/output-send-id-state.cpp
@@ -16,6 +16,7 @@ void OutputSendIdState::onStateMounted(Device *PDN) {
     handshakeWirelessManager->setPacketReceivedCallback(std::bind(&OutputSendIdState::onHandshakeCommandReceived, this, std::placeholders::_1), SerialIdentifier::OUTPUT_JACK);
 
     handshakeWirelessManager->sendPacket(HSCommand::EXCHANGE_ID, SerialIdentifier::OUTPUT_JACK);
+    retryTimer.setTimer(RETRY_INTERVAL_MS);
 }
 
 void OutputSendIdState::onHandshakeCommandReceived(HandshakeCommand command) {
@@ -25,12 +26,18 @@ void OutputSendIdState::onHandshakeCommandReceived(HandshakeCommand command) {
     }
 }
 
-
-void OutputSendIdState::onStateLoop(Device *PDN) {}
+void OutputSendIdState::onStateLoop(Device *PDN) {
+    retryTimer.updateTime();
+    if (retryTimer.expired()) {
+        handshakeWirelessManager->sendPacket(HSCommand::EXCHANGE_ID, SerialIdentifier::OUTPUT_JACK);
+        retryTimer.setTimer(RETRY_INTERVAL_MS);
+    }
+}
 
 void OutputSendIdState::onStateDismounted(Device *PDN) {
     LOG_I(TAG, "State dismounted");
     transitionToConnectionSuccessfulState = false;
+    retryTimer.invalidate();
     handshakeWirelessManager->clearCallback(SerialIdentifier::OUTPUT_JACK);
 }
 

--- a/src/game/match-manager.cpp
+++ b/src/game/match-manager.cpp
@@ -1,4 +1,5 @@
 #include "game/match-manager.hpp"
+#include <algorithm>
 #include <ArduinoJson.h>
 #include "device/drivers/logger.hpp"
 #include "wireless/quickdraw-wireless-manager.hpp"
@@ -21,16 +22,18 @@ MatchManager::~MatchManager() {
     }
 }
 
-void MatchManager::clearCurrentMatch() {
+void MatchManager::clearCurrentMatch(const char* caller) {
     if (activeDuelState.match) {
-        LOG_I(MATCH_MANAGER_TAG, "Clearing current match");
+        LOG_W(MATCH_MANAGER_TAG, "CLEAR[%s] id=%s", caller ? caller : "?", activeDuelState.match->getMatchId());
         activeDuelState.match.reset();
         activeDuelState.hasReceivedDrawResult = false;
         activeDuelState.hasPressedButton = false;
         activeDuelState.duelLocalStartTime = 0;
         activeDuelState.gracePeriodExpiredNoResult = false;
+        activeDuelState.opponentNeverPressed = false;
         activeDuelState.buttonMasherCount = 0;
         activeDuelState.matchIsReady = false;
+        boostMs_ = 0;
     }
 }
 
@@ -88,11 +91,16 @@ bool MatchManager::matchResultsAreIn() {
     }
        
     return (activeDuelState.hasReceivedDrawResult && activeDuelState.hasPressedButton)
-    || (activeDuelState.gracePeriodExpiredNoResult && activeDuelState.hasPressedButton);
+    || (activeDuelState.opponentNeverPressed && activeDuelState.hasPressedButton)
+    || (activeDuelState.gracePeriodExpiredNoResult && activeDuelState.hasReceivedDrawResult);
 }
 
 void MatchManager::setNeverPressed() {
     activeDuelState.gracePeriodExpiredNoResult = true;
+}
+
+void MatchManager::setBoost(int boostMs) {
+    boostMs_ = boostMs;
 }
 
 bool MatchManager::didWin() {
@@ -100,18 +108,17 @@ bool MatchManager::didWin() {
         return false;
     }
 
-    if(player->isHunter() && activeDuelState.match->getBountyDrawTime() == 0) {
+    long hunterTime = activeDuelState.match->getHunterDrawTime();
+    long bountyTime = activeDuelState.match->getBountyDrawTime();
+
+    if (activeDuelState.opponentNeverPressed) {
         return true;
     }
-
-    if(!player->isHunter() && activeDuelState.match->getHunterDrawTime() == 0) {
-        return true;
+    if (activeDuelState.gracePeriodExpiredNoResult) {
+        return false;
     }
 
-    
-    return player->isHunter() ? 
-    activeDuelState.match->getHunterDrawTime() < activeDuelState.match->getBountyDrawTime() :
-    activeDuelState.match->getBountyDrawTime() < activeDuelState.match->getHunterDrawTime();
+    return player->isHunter() ? hunterTime < bountyTime : bountyTime < hunterTime;
 }
 
 bool MatchManager::finalizeMatch() {
@@ -126,7 +133,7 @@ bool MatchManager::finalizeMatch() {
     if (appendMatchToStorage(&*activeDuelState.match)) {
         // Update stored count
         updateStoredMatchCount(getStoredMatchCount() + 1);
-        clearCurrentMatch();
+        clearCurrentMatch("finalize");
         LOG_I(MATCH_MANAGER_TAG, "Successfully finalized match %s\n", match_id.c_str());
         return true;
     }
@@ -319,20 +326,26 @@ void MatchManager::initialize(Player* player, StorageInterface* storage, Quickdr
         if(activeDuelState->buttonMasherCount > 0) {
             reactionTimeMs = reactionTimeMs + activeDuelState->calculateButtonMasherPenalty();
         }
+        unsigned long duelTimeMs = reactionTimeMs;
+        int boost = matchManager->getBoost();
+        if (boost > 0) {
+            duelTimeMs = (reactionTimeMs > (unsigned long)boost)
+                ? reactionTimeMs - boost : 0;
+        }
 
-        LOG_I(MATCH_MANAGER_TAG, "Button pressed! Reaction time: %lu ms for %s", 
-                reactionTimeMs, player->isHunter() ? "Hunter" : "Bounty");
+        LOG_I(MATCH_MANAGER_TAG, "Button pressed! Reaction time: %lu ms (boost: %d) for %s",
+                reactionTimeMs, boost, player->isHunter() ? "Hunter" : "Bounty");
 
-        player->isHunter() ? 
-        matchManager->setHunterDrawTime(reactionTimeMs) 
-        : matchManager->setBountyDrawTime(reactionTimeMs);
-
-        LOG_I(MATCH_MANAGER_TAG, "Stored reaction time in MatchManager");
+        // Store boosted time for didWin() agreement, raw time for player stats
+        player->isHunter() ?
+        matchManager->setHunterDrawTime(duelTimeMs)
+        : matchManager->setBountyDrawTime(duelTimeMs);
+        player->addReactionTime(reactionTimeMs);
 
         LOG_I(MATCH_MANAGER_TAG, "Broadcasting DRAW_RESULT to opponent MAC: %s",
                 MacToString(activeDuelState->opponentMac.data()));
 
-        QuickdrawCommand command(activeDuelState->opponentMac.data(), QDCommand::DRAW_RESULT, matchManager->getCurrentMatch()->getMatchId(), player->getUserID().c_str(), reactionTimeMs, player->isHunter());
+        QuickdrawCommand command(activeDuelState->opponentMac.data(), QDCommand::DRAW_RESULT, matchManager->getCurrentMatch()->getMatchId(), player->getUserID().c_str(), duelTimeMs, player->isHunter());
 
         quickdrawWirelessManager->broadcastPacket(activeDuelState->opponentMac.data(), command);
 
@@ -364,12 +377,13 @@ void MatchManager::listenForMatchEvents(const QuickdrawCommand& command) {
     if(command.command == QDCommand::SEND_MATCH_ID) {
         LOG_I(MATCH_MANAGER_TAG, "Received SEND_MATCH_ID command from opponent");
         if(player->isHunter() == command.isHunter) {
-            // Same role on both sides — not a valid hunter/bounty pairing.
             sendMatchRoleMismatch();
             return;
-        } else {
-            receiveMatch(command.matchId, command.playerId, command.isHunter, const_cast<uint8_t*>(command.wifiMacAddr));
         }
+        if (activeDuelState.match.has_value()) {
+            return;
+        }
+        receiveMatch(command.matchId, command.playerId, command.isHunter, const_cast<uint8_t*>(command.wifiMacAddr));
     } else if(command.command == QDCommand::MATCH_ID_ACK) {
         LOG_I(MATCH_MANAGER_TAG, "Received MATCH_ID_ACK command from opponent");
         if(activeDuelState.match.has_value() && strcmp(command.matchId, activeDuelState.match->getMatchId()) == 0) {
@@ -378,20 +392,32 @@ void MatchManager::listenForMatchEvents(const QuickdrawCommand& command) {
             activeDuelState.matchIsReady = true;
         }
     } else if(command.command == QDCommand::MATCH_ROLE_MISMATCH) {
-        LOG_I(MATCH_MANAGER_TAG, "Received MATCH_ROLE_MISMATCH command from opponent");
-        clearCurrentMatch();
-
+        if (player->isHunter() &&
+            activeDuelState.match.has_value() &&
+            strcmp(command.matchId, activeDuelState.match->getMatchId()) == 0) {
+            clearCurrentMatch("mismatch");
+        }
         return;
     } else if(command.command == QDCommand::DRAW_RESULT || command.command == QDCommand::NEVER_PRESSED) {
+        if (!activeDuelState.match.has_value() ||
+            strcmp(command.matchId, activeDuelState.match->getMatchId()) != 0 ||
+            memcmp(command.wifiMacAddr, activeDuelState.opponentMac.data(), 6) != 0) {
+            return;
+        }
+
         LOG_I(MATCH_MANAGER_TAG, "Received DRAW_RESULT command from opponent");
-        
+
         long opponentTime = command.playerDrawTime;
-            
+
         LOG_I(MATCH_MANAGER_TAG, "Opponent reaction time: %ld ms", opponentTime);
-        
-        command.isHunter ? 
-        setHunterDrawTime(opponentTime) 
+
+        command.isHunter ?
+        setHunterDrawTime(opponentTime)
         : setBountyDrawTime(opponentTime);
+
+        if (command.command == QDCommand::NEVER_PRESSED) {
+            activeDuelState.opponentNeverPressed = true;
+        }
 
         setReceivedDrawResult();
     } else {

--- a/src/game/quickdraw-states/duel-countdown-state.cpp
+++ b/src/game/quickdraw-states/duel-countdown-state.cpp
@@ -79,9 +79,10 @@ ImageType DuelCountdown::getImageIdForStep(CountdownStep step) {
 
 void DuelCountdown::onStateDismounted(Device *PDN) {
     if (!doBattle) {
-        matchManager->clearCurrentMatch();
+        matchManager->clearCurrentMatch("countdown-dismount");
     }
 
+    PDN->getHaptics()->setIntensity(0);
     doBattle = false;
     currentStepIndex = 0;
     countdownTimer.invalidate();

--- a/src/game/quickdraw-states/duel-pushed-state.cpp
+++ b/src/game/quickdraw-states/duel-pushed-state.cpp
@@ -34,7 +34,7 @@ void DuelPushed::onStateDismounted(Device *PDN) {
     LOG_I(DUEL_PUSHED_TAG, "DuelPushed state dismounted");
 
     if (!isConnected()) {
-        matchManager->clearCurrentMatch();
+        matchManager->clearCurrentMatch("pushed-dc");
     }
 
     gracePeriodTimer.invalidate();
@@ -53,5 +53,10 @@ bool DuelPushed::disconnectedBackToIdle() {
 }
 
 bool DuelPushed::transitionToDuelResult() {
-    return matchManager->matchResultsAreIn() || gracePeriodTimer.expired();
+    if (matchManager->matchResultsAreIn()) return true;
+    if (gracePeriodTimer.expired()) {
+        matchManager->setOpponentNeverPressed();
+        return true;
+    }
+    return false;
 }

--- a/src/game/quickdraw-states/duel-result-received-state.cpp
+++ b/src/game/quickdraw-states/duel-result-received-state.cpp
@@ -34,7 +34,7 @@ void DuelReceivedResult::onStateLoop(Device *PDN) {
 
     buttonPushGraceTimer.updateTime();
 
-    if(buttonPushGraceTimer.expired()) {
+    if(buttonPushGraceTimer.expired() && !matchManager->getHasPressedButton()) {
         LOG_I(DUEL_RESULT_RECEIVED_TAG, "Button push grace period expired");
 
         unsigned long pityTime = SimpleTimer::getPlatformClock()->milliseconds() - matchManager->getDuelLocalStartTime();
@@ -48,7 +48,7 @@ void DuelReceivedResult::onStateDismounted(Device *PDN) {
     LOG_I(DUEL_RESULT_RECEIVED_TAG, "Duel result received state dismounted");
 
     if (!isConnected()) {
-        matchManager->clearCurrentMatch();
+        matchManager->clearCurrentMatch("recv-result-dc");
     }
 
     transitionToDuelResultState = false;

--- a/src/game/quickdraw-states/duel-result-state.cpp
+++ b/src/game/quickdraw-states/duel-result-state.cpp
@@ -36,14 +36,7 @@ void DuelResult::onStateMounted(Device *PDN) {
 
     PDN->getHaptics()->setIntensity(0);
 
-    // Store reaction time before finalizing match
-    if(player->isHunter()) {
-        player->addReactionTime(matchManager->getCurrentMatch()->getHunterDrawTime());
-    } else {
-        player->addReactionTime(matchManager->getCurrentMatch()->getBountyDrawTime());
-    }
-
-    // Now it's safe to finalize the match, which might clear the current match
+    // Raw reaction time already stored in button press handler
     matchManager->finalizeMatch();
 
     PDN->getDisplay()->invalidateScreen()->render();
@@ -62,8 +55,6 @@ void DuelResult::onStateDismounted(Device *PDN) {
 
     PDN->getPrimaryButton()->removeButtonCallbacks();
     PDN->getSecondaryButton()->removeButtonCallbacks();
-
-    quickdrawWirelessManager->clearCallbacks();
              
     wonBattle = false;
     captured = false;

--- a/src/game/quickdraw-states/duel-state.cpp
+++ b/src/game/quickdraw-states/duel-state.cpp
@@ -88,7 +88,7 @@ bool Duel::transitionToDuelReceivedResult() {
 void Duel::onStateDismounted(Device *PDN) {
     if(transitionToIdleState) {
         PDN->getHaptics()->off();
-        matchManager->clearCurrentMatch();
+        matchManager->clearCurrentMatch("duel-state");
         PDN->getPrimaryButton()->removeButtonCallbacks();
         PDN->getSecondaryButton()->removeButtonCallbacks();
     } else if(transitionToDuelReceivedResultState) {

--- a/src/game/quickdraw-states/idle-state.cpp
+++ b/src/game/quickdraw-states/idle-state.cpp
@@ -1,14 +1,21 @@
 #include "game/quickdraw-states.hpp"
-#include "game/quickdraw.hpp"
 #include "game/quickdraw-resources.hpp"
+#include "device/device.hpp"
 #include "game/match-manager.hpp"
 #include "device/drivers/logger.hpp"
 #include "wireless/mac-functions.hpp"
+#include "wireless/team-packet.hpp"
+#include "game/jack-roles.hpp"
 #include "state/connect-state.hpp"
 
-Idle::Idle(Player* player, MatchManager* matchManager, RemoteDeviceCoordinator* remoteDeviceCoordinator) : ConnectState(remoteDeviceCoordinator, IDLE) {
-    this->matchManager = matchManager;
-    this->player = player;
+Idle::Idle(Player* player, MatchManager* matchManager, RemoteDeviceCoordinator* remoteDeviceCoordinator,
+           std::function<int()> getSupporterCount, std::function<void()> clearChainState,
+           std::function<bool()> isInviteRejected)
+    : ConnectState(remoteDeviceCoordinator, IDLE),
+      player(player), matchManager(matchManager),
+      getSupporterCount_(std::move(getSupporterCount)),
+      clearChainState_(std::move(clearChainState)),
+      isInviteRejected_(std::move(isInviteRejected)) {
 }
 
 Idle::~Idle() {
@@ -17,7 +24,6 @@ Idle::~Idle() {
 }
 
 void Idle::onStateMounted(Device *PDN) {
-
     // Switch to ESP-NOW mode for peer-to-peer communication
     PDN->getWirelessManager()->enablePeerCommsMode();
 
@@ -52,25 +58,51 @@ void Idle::onStateMounted(Device *PDN) {
 }
 
 void Idle::onStateLoop(Device *PDN) {
+    int supporters = getSupporterCount_();
+    if (supporters != lastSupporterCount_) {
+        lastSupporterCount_ = supporters;
+        statsIndex = 6;
+        displayIsDirty = true;
+    }
+
     if(displayIsDirty) {
         cycleStats(PDN);
         displayIsDirty = false;
     }
 
-    if (isConnected() && getPeerDeviceType(SerialIdentifier::OUTPUT_JACK) == DeviceType::PDN && player->isHunter()) {
-        if (!matchInitialized) {
-            const uint8_t* peerMac = remoteDeviceCoordinator->getPeerMac(SerialIdentifier::OUTPUT_JACK);
-            if (peerMac != nullptr) {
-                matchManager->initializeMatch(const_cast<uint8_t*>(peerMac));
-                matchInitialized = true;
-                matchInitializationTimer.setTimer(MATCH_INITIALIZATION_TIMEOUT);
-            }
+    SerialIdentifier sJack = supporterJack(player);
+    SerialIdentifier oJack = opponentJack(player);
+
+    bool sConnected = remoteDeviceCoordinator->getPortStatus(sJack) == PortStatus::CONNECTED;
+    const uint8_t* supporterMac = sConnected ? remoteDeviceCoordinator->getPeerMac(sJack) : nullptr;
+
+    const uint8_t* myMac = PDN->getWirelessManager()->getMacAddress();
+    if (supporterMac && !(isInviteRejected_ && isInviteRejected_())) {
+        inviteRetryTimer_.updateTime();
+        if (!inviteRetryTimer_.isRunning() || inviteRetryTimer_.expired()) {
+            sendRegisterInvite(PDN->getPeerComms(), supporterMac, 0, player->isHunter(),
+                               myMac, player->getName().c_str());
+            inviteRetryTimer_.setTimer(INVITE_RETRY_MS);
+        }
+    } else if (inviteRetryTimer_.isRunning()) {
+        inviteRetryTimer_.invalidate();
+        clearChainState_();
+    }
+
+    // Only hunters initiate duels
+    if (player->isHunter() && isConnected() && !matchInitialized) {
+        const uint8_t* peerMac = remoteDeviceCoordinator->getPeerMac(oJack);
+        static const uint8_t zeroMac[6] = {};
+        if (peerMac != nullptr && memcmp(peerMac, zeroMac, 6) != 0) {
+            matchManager->initializeMatch(const_cast<uint8_t*>(peerMac));
+            matchInitialized = true;
+            matchInitializationTimer.setTimer(MATCH_INITIALIZATION_TIMEOUT);
         }
     }
 
     if(matchInitializationTimer.expired()) {
         matchInitialized = false;
-        matchManager->clearCurrentMatch();
+        matchManager->clearCurrentMatch("idle-timer");
     }
 }
 
@@ -78,6 +110,8 @@ void Idle::onStateDismounted(Device *PDN) {
     statsIndex = 0;
     matchInitializationTimer.invalidate();
     matchInitialized = false;
+    inviteRetryTimer_.invalidate();
+    lastSupporterCount_ = 0;
     PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
     PDN->getPrimaryButton()->removeButtonCallbacks();
     PDN->getSecondaryButton()->removeButtonCallbacks();
@@ -109,14 +143,14 @@ void Idle::cycleStats(Device *PDN) {
     } else if(statsIndex == 5) {
         PDN->getDisplay()->setGlyphMode(FontMode::TEXT_INVERTED_SMALL)->drawText("Average",70, 20)->drawText("Reaction", 70, 35);
         PDN->getDisplay()->setGlyphMode(FontMode::TEXT_INVERTED_LARGE)->drawText(std::to_string(player->getAverageReactionTime()).c_str(), 80, 55);
+    } else if(statsIndex == 6) {
+        PDN->getDisplay()->setGlyphMode(FontMode::TEXT_INVERTED_SMALL)->drawText("Support",70, 20);
+        PDN->getDisplay()->setGlyphMode(FontMode::TEXT_INVERTED_LARGE)->drawText(std::to_string(getSupporterCount_()).c_str(), 88, 40);
     }
 
     PDN->getDisplay()->render();
 
-    statsIndex++;
-    if(statsIndex > statsCount) {
-        statsIndex = 0;
-    }
+    statsIndex = (statsIndex + 1) % 7;
 }
 
 bool Idle::isPrimaryRequired() {

--- a/src/game/quickdraw-states/sleep-state.cpp
+++ b/src/game/quickdraw-states/sleep-state.cpp
@@ -27,6 +27,7 @@ void Sleep::onStateMounted(Device *PDN) {
         render();
 
     dormantTimer.setTimer(SLEEP_DURATION);
+    transitionToAwakenSequenceState = false;
 }
 
 void Sleep::onStateLoop(Device *PDN) {

--- a/src/game/quickdraw-states/supporter-ready-state.cpp
+++ b/src/game/quickdraw-states/supporter-ready-state.cpp
@@ -1,0 +1,161 @@
+#include "game/quickdraw-states.hpp"
+#include "game/quickdraw.hpp"
+#include "game/quickdraw-resources.hpp"
+#include "game/jack-roles.hpp"
+#include "device/device.hpp"
+#include "wireless/team-packet.hpp"
+#include <string>
+
+SupporterReady::SupporterReady(Player* player, RemoteDeviceCoordinator* rdc, Quickdraw* quickdraw)
+    : ConnectState(rdc, SUPPORTER_READY), player_(player), quickdraw_(quickdraw) {}
+
+SupporterReady::~SupporterReady() = default;
+
+void SupporterReady::onButtonPressed(void* ctx) {
+    auto* state = static_cast<SupporterReady*>(ctx);
+    if (!state->duelActive_ || state->hasConfirmed_) return;
+    state->hasConfirmed_ = true;
+    sendTeamPacket(state->peerComms_, state->championMac_, TeamCommandType::CONFIRM, state->position_);
+    state->renderDisplay("Sent!");
+}
+
+void SupporterReady::renderDisplay(const char* status) {
+    if (!device_) return;
+    device_->getDisplay()->invalidateScreen();
+    device_->getDisplay()->drawImage(getImageForAllegiance(player_->getAllegiance(), ImageType::IDLE));
+    device_->getDisplay()->setGlyphMode(FontMode::TEXT_INVERTED_SMALL)->drawText(championName_[0] ? championName_ : "Support", 68, 20);
+    device_->getDisplay()->setGlyphMode(FontMode::TEXT_INVERTED_SMALL)->drawText(status, 68, 40);
+    device_->getDisplay()->render();
+}
+
+void SupporterReady::onStateMounted(Device* PDN) {
+    device_ = PDN;
+    peerComms_ = PDN->getPeerComms();
+    hasConfirmed_ = false;
+    duelActive_ = false;
+    transitionToWin_ = false;
+    transitionToLose_ = false;
+    transitionToIdle_ = false;
+
+    if (quickdraw_) {
+        quickdraw_->setGameEventCallback([this](GameEventType evt) {
+            handleGameEvent(evt);
+        });
+    }
+
+    AnimationConfig config;
+    if(player_->isHunter()) {
+        config.type = AnimationType::IDLE;
+        config.speed = 16;
+        config.curve = EaseCurve::LINEAR;
+        config.initialState = HUNTER_IDLE_STATE_ALTERNATE;
+        config.loopDelayMs = 0;
+        config.loop = true;
+    } else {
+        config.type = AnimationType::VERTICAL_CHASE;
+        config.speed = 5;
+        config.curve = EaseCurve::ELASTIC;
+        config.initialState = BOUNTY_IDLE_STATE;
+        config.loopDelayMs = 1500;
+        config.loop = true;
+    }
+    PDN->getLightManager()->startAnimation(config);
+
+    PDN->getPrimaryButton()->setButtonPress(onButtonPressed, this, ButtonInteraction::CLICK);
+    PDN->getSecondaryButton()->setButtonPress(onButtonPressed, this, ButtonInteraction::CLICK);
+
+    downstreamInvited_ = false;
+    registered_ = false;
+    retryTimer_.setTimer(RETRY_MS);
+
+    renderDisplay("Ready");
+    safetyTimeout_.setTimer(SAFETY_TIMEOUT_MS);
+}
+
+void SupporterReady::onStateLoop(Device* PDN) {
+    (void)PDN;
+
+    if (safetyTimeout_.expired()) {
+        sendTeamPacket(peerComms_, championMac_, TeamCommandType::DEREGISTER, position_);
+        transitionToIdle_ = true;
+        return;
+    }
+
+    retryTimer_.updateTime();
+    bool shouldRetry = retryTimer_.expired();
+
+    // Send/retry REGISTER to champion
+    if (!registered_ || shouldRetry) {
+        sendTeamPacket(peerComms_, championMac_, TeamCommandType::REGISTER, position_);
+        registered_ = true;
+    }
+
+    // Forward/retry invite to downstream peer
+    SerialIdentifier downstreamJack = supporterJack(player_);
+    if (remoteDeviceCoordinator->getPortStatus(downstreamJack) == PortStatus::CONNECTED) {
+        if (!downstreamInvited_ || shouldRetry) {
+            const uint8_t* downstreamMac = remoteDeviceCoordinator->getPeerMac(downstreamJack);
+            if (downstreamMac && memcmp(downstreamMac, championMac_, 6) != 0) {
+                sendRegisterInvite(peerComms_, downstreamMac, position_, championIsHunter_,
+                                   championMac_, championName_);
+                downstreamInvited_ = true;
+            }
+        }
+    }
+
+    if (shouldRetry) retryTimer_.setTimer(RETRY_MS);
+
+    if (quickdraw_ && quickdraw_->hasTeamInvite()) {
+        if (memcmp(quickdraw_->getInviteChampionMac(), championMac_, 6) != 0) {
+            // Chain merge: different champion, re-register under the new one
+            sendTeamPacket(peerComms_, championMac_, TeamCommandType::DEREGISTER, position_);
+            transitionToIdle_ = true;
+            return;
+        }
+        // Same champion re-invited: new duel cycle, reset supporter state
+        hasConfirmed_ = false;
+        duelActive_ = false;
+        registered_ = false;
+        renderDisplay("Ready");
+    }
+
+    SerialIdentifier championJack = opponentJack(player_);
+    if (!transitionToIdle_ && remoteDeviceCoordinator->getPortStatus(championJack) == PortStatus::DISCONNECTED) {
+        sendTeamPacket(peerComms_, championMac_, TeamCommandType::DEREGISTER, position_);
+        transitionToIdle_ = true;
+    }
+}
+
+void SupporterReady::handleGameEvent(GameEventType evt) {
+    switch (evt) {
+        case GameEventType::COUNTDOWN:
+        case GameEventType::DRAW:
+            duelActive_ = true;
+            if (!hasConfirmed_) renderDisplay("Press!");
+            break;
+        case GameEventType::WIN:
+            renderDisplay("WIN!");
+            transitionToWin_ = true;
+            break;
+        case GameEventType::LOSS:
+            renderDisplay("LOSS");
+            transitionToLose_ = true;
+            break;
+    }
+}
+
+void SupporterReady::onStateDismounted(Device* PDN) {
+    if (quickdraw_) quickdraw_->clearGameEventCallback();
+    PDN->getPrimaryButton()->removeButtonCallbacks();
+    PDN->getSecondaryButton()->removeButtonCallbacks();
+    retryTimer_.invalidate();
+    safetyTimeout_.invalidate();
+    PDN->getPeerComms()->removePeer(const_cast<uint8_t*>(championMac_));
+    device_ = nullptr;
+}
+
+bool SupporterReady::transitionToWin() { return transitionToWin_; }
+bool SupporterReady::transitionToLose() { return transitionToLose_; }
+bool SupporterReady::transitionToIdle() { return transitionToIdle_; }
+bool SupporterReady::isPrimaryRequired() { return false; }
+bool SupporterReady::isAuxRequired() { return false; }

--- a/src/game/quickdraw.cpp
+++ b/src/game/quickdraw.cpp
@@ -1,4 +1,5 @@
 #include "../../include/game/quickdraw.hpp"
+#include "game/jack-roles.hpp"
 
 Quickdraw::Quickdraw(Player* player, Device* PDN, QuickdrawWirelessManager* quickdrawWirelessManager, RemoteDebugManager* remoteDebugManager): StateMachine(QUICKDRAW_APP_ID) {
     this->player = player;
@@ -15,6 +16,11 @@ Quickdraw::Quickdraw(Player* player, Device* PDN, QuickdrawWirelessManager* quic
     quickdrawWirelessManager->setPacketReceivedCallback(
         std::bind(&MatchManager::listenForMatchEvents, matchManager, std::placeholders::_1)
     );
+
+    PDN->getPeerComms()->setPacketHandler(PktType::kTeamCommand,
+        [](const uint8_t* src, const uint8_t* data, size_t len, void* ctx) {
+            static_cast<Quickdraw*>(ctx)->onTeamPacketReceived(src, data, len);
+        }, this);
 }
 
 Quickdraw::~Quickdraw() {
@@ -25,7 +31,168 @@ Quickdraw::~Quickdraw() {
     matchManager = nullptr;
     storageManager = nullptr;
     peerComms = nullptr;
-    matches.clear();
+}
+
+void Quickdraw::onTeamPacketReceived(const uint8_t* src, const uint8_t* data, size_t len) {
+    if (len < 1) return;
+    auto cmd = static_cast<TeamCommandType>(data[0]);
+
+    // REGISTER_INVITE uses a larger packet with champion MAC
+    if (cmd == TeamCommandType::REGISTER_INVITE) {
+        if (len == sizeof(RegisterInvitePacket)) {
+            auto* invite = reinterpret_cast<const RegisterInvitePacket*>(data);
+            // Reject invite to support ourselves — ring detected
+            const uint8_t* myMac = peerComms->getMacAddress();
+            if (myMac && memcmp(invite->championMac, myMac, 6) == 0) return;
+            // Reject invite from different-role champion
+            bool champIsHunter = invite->championIsHunter != 0;
+            if (champIsHunter != player->isHunter()) {
+                sendTeamPacket(peerComms, src, TeamCommandType::INVITE_REJECT, 0);
+                return;
+            }
+            memcpy(inviteChampionMac_, invite->championMac, 6);
+            memcpy(inviteSenderMac_, src, 6);
+            strncpy(inviteChampionName_, invite->championName, CHAMPION_NAME_MAX - 1);
+            inviteChampionName_[CHAMPION_NAME_MAX - 1] = '\0';
+            invitePosition_ = invite->position < 255 ? invite->position + 1 : 255;
+            inviteChampionIsHunter_ = invite->championIsHunter != 0;
+            hasTeamInvite_ = true;
+        }
+        return;
+    }
+
+    if (cmd == TeamCommandType::INVITE_REJECT) {
+        inviteRejected_ = true;
+        return;
+    }
+
+    if (len != sizeof(TeamPacket)) return;
+    auto* pkt = reinterpret_cast<const TeamPacket*>(data);
+    int position = pkt->eventType;
+
+    switch (cmd) {
+        case TeamCommandType::REGISTER:
+            if (findSupporterIndex(src) < 0 && supporterMacCount_ < MAX_SUPPORTERS) {
+                memcpy(supporterMacs_[supporterMacCount_++], src, 6);
+            }
+            break;
+        case TeamCommandType::DEREGISTER: {
+            int idx = findSupporterIndex(src);
+            if (idx >= 0) {
+                memmove(&supporterMacs_[idx], &supporterMacs_[idx+1], (supporterMacCount_ - idx - 1) * 6);
+                supporterMacCount_--;
+                if (confirmedSupporters_ > supporterMacCount_) confirmedSupporters_ = supporterMacCount_;
+                matchManager->setBoost(confirmedSupporters_ * 15);
+            }
+            break;
+        }
+        case TeamCommandType::CONFIRM:
+            if (findSupporterIndex(src) < 0) break;
+            if (confirmedSupporters_ >= supporterMacCount_) break;
+            confirmedSupporters_++;
+            matchManager->setBoost(confirmedSupporters_ * 15);
+            break;
+        case TeamCommandType::GAME_EVENT:
+            if (position > static_cast<int>(GameEventType::LOSS)) break;
+            if (memcmp(src, inviteChampionMac_, 6) != 0) break;
+            if (gameEventCallback_) gameEventCallback_(static_cast<GameEventType>(position));
+            break;
+    }
+}
+
+// Detect state transitions to broadcast game events to supporters
+void Quickdraw::onStateLoop(Device* PDN) {
+    StateMachine::onStateLoop(PDN);
+    int sid = getCurrentState() ? getCurrentState()->getStateId() : -1;
+    if (sid != lastStateId_) {
+        LOG_W("QD", "State %d -> %d", lastStateId_, sid);
+        onStateChanged(sid);
+        lastStateId_ = sid;
+    }
+}
+
+void Quickdraw::onStateChanged(int newStateId) {
+    if (supporterMacCount_ > 0) {
+        switch (newStateId) {
+            case DUEL_COUNTDOWN: broadcastTeamEvent(peerComms, GameEventType::COUNTDOWN); break;
+            case DUEL:           broadcastTeamEvent(peerComms, GameEventType::DRAW); break;
+            case WIN:            broadcastTeamEvent(peerComms, GameEventType::WIN); break;
+            case LOSE:           broadcastTeamEvent(peerComms, GameEventType::LOSS); break;
+            default: break;
+        }
+    }
+
+    if (newStateId == IDLE) {
+        LOG_W("QD", "-> IDLE, clearing chain+match");
+        clearChainState();
+        matchManager->clearCurrentMatch("onIdle");
+    }
+}
+
+void Quickdraw::clearChainState() {
+    confirmedSupporters_ = 0;
+    supporterMacCount_ = 0;
+    memset(supporterMacs_, 0, sizeof(supporterMacs_));
+    hasTeamInvite_ = false;
+    invitePosition_ = 0;
+    memset(inviteChampionMac_, 0, 6);
+    memset(inviteSenderMac_, 0, 6);
+    inviteChampionName_[0] = '\0';
+    inviteChampionIsHunter_ = false;
+    inviteRejected_ = false;
+}
+
+int Quickdraw::findSupporterIndex(const uint8_t* mac) const {
+    for (int i = 0; i < supporterMacCount_; i++) {
+        if (memcmp(supporterMacs_[i], mac, 6) == 0) return i;
+    }
+    return -1;
+}
+
+bool Quickdraw::shouldTransitionToSupporter(SupporterReady* supporterReady) {
+    if (!hasTeamInvite_) return false;
+    auto reject = [&]() {
+        const uint8_t* senderMac = remoteDeviceCoordinator->getPeerMac(opponentJack(player));
+        if (senderMac) {
+            sendTeamPacket(peerComms, senderMac, TeamCommandType::INVITE_REJECT, 0);
+        }
+        hasTeamInvite_ = false;
+    };
+
+    // Don't become supporter if a match is ready to duel
+    if (matchManager->isMatchReady()) {
+        reject();
+        return false;
+    }
+
+    // Invite must come from the device on our opponent jack (physical chain neighbor)
+    SerialIdentifier oJack = opponentJack(player);
+    const uint8_t* oJackMac = remoteDeviceCoordinator->getPeerMac(oJack);
+    if (!oJackMac || memcmp(inviteSenderMac_, oJackMac, 6) != 0) {
+        reject();
+        return false;
+    }
+
+    // Champion must be same role as us
+    if (inviteChampionIsHunter_ != player->isHunter()) {
+        reject();
+        return false;
+    }
+
+    // Reject if champion is on our supporter jack — that's a loop
+    SerialIdentifier sJack = supporterJack(player);
+    const uint8_t* sPeerMac = remoteDeviceCoordinator->getPeerMac(sJack);
+    if (sPeerMac && memcmp(inviteChampionMac_, sPeerMac, 6) == 0) {
+        reject();
+        return false;
+    }
+
+    supporterReady->setChampionMac(inviteChampionMac_);
+    supporterReady->setChampionName(inviteChampionName_);
+    supporterReady->setPosition(invitePosition_);
+    supporterReady->setChampionIsHunter(inviteChampionIsHunter_);
+    hasTeamInvite_ = false;
+    return true;
 }
 
 void Quickdraw::populateStateMap() {
@@ -34,7 +201,12 @@ void Quickdraw::populateStateMap() {
     PlayerRegistrationApp* playerRegistration = new PlayerRegistrationApp(player, wirelessManager, matchManager, remoteDebugManager);
     // Quickdraw gameplay states
     AwakenSequence* awakenSequence = new AwakenSequence(player);
-    Idle* idle = new Idle(player, matchManager, remoteDeviceCoordinator);
+    Idle* idle = new Idle(player, matchManager, remoteDeviceCoordinator,
+        [this]() { return getSupporterCount(); },
+        [this]() { clearChainState(); },
+        [this]() { return isInviteRejected(); });
+
+    SupporterReady* supporterReady = new SupporterReady(player, remoteDeviceCoordinator, this);
 
     DuelCountdown* duelCountdown = new DuelCountdown(player, matchManager, remoteDeviceCoordinator);
     Duel* duel = new Duel(player, matchManager, remoteDeviceCoordinator);
@@ -64,6 +236,23 @@ void Quickdraw::populateStateMap() {
         new StateTransition(
             std::bind(&Idle::transitionToDuelCountdown, idle),
             duelCountdown));
+    idle->addTransition(new StateTransition(
+        std::bind(&Quickdraw::shouldTransitionToSupporter, this, supporterReady),
+        supporterReady));
+
+    // --- Supporter ready transitions ---
+    supporterReady->addTransition(
+        new StateTransition(
+            std::bind(&SupporterReady::transitionToWin, supporterReady),
+            win));
+    supporterReady->addTransition(
+        new StateTransition(
+            std::bind(&SupporterReady::transitionToLose, supporterReady),
+            lose));
+    supporterReady->addTransition(
+        new StateTransition(
+            std::bind(&SupporterReady::transitionToIdle, supporterReady),
+            idle));
 
     // --- Duel flow ---
     duelCountdown->addTransition(
@@ -155,4 +344,5 @@ void Quickdraw::populateStateMap() {
     stateMap.push_back(lose);
     stateMap.push_back(uploadMatches);
     stateMap.push_back(sleep);
+    stateMap.push_back(supporterReady);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,7 +155,7 @@ void setup() {
     setupEspNow(quickdrawWirelessManager, remoteDebugManager, peerCommsDriver);
     
     game = new Quickdraw(player, pdn, quickdrawWirelessManager, remoteDebugManager);
-    
+
     pdn->getDisplay()->
     invalidateScreen()->
         drawImage(getImageForAllegiance(Allegiance::ALLEYCAT, ImageType::LOGO_LEFT))->

--- a/src/wireless/handshake-wireless-manager.cpp
+++ b/src/wireless/handshake-wireless-manager.cpp
@@ -60,7 +60,6 @@ int HandshakeWirelessManager::sendPacket(int command, SerialIdentifier jack) {
     hsPacket.command = command;
     hsPacket.sendingJack = static_cast<int>(jack);
     hsPacket.receicingJack = static_cast<int>(it->second.sid);
-
     LOG_I("HWM", "Sending command %i to port %i", command, static_cast<int>(jack));
 
     return wirelessManager->sendEspNowData(

--- a/test/test_core/chain-tests.hpp
+++ b/test/test_core/chain-tests.hpp
@@ -1,0 +1,1025 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "game/match-manager.hpp"
+#include "game/quickdraw.hpp"
+#include "game/quickdraw-states.hpp"
+#include "wireless/team-packet.hpp"
+#include "wireless/remote-debug-manager.hpp"
+#include "device-mock.hpp"
+#include "utility-tests.hpp"
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::Invoke;
+using ::testing::SaveArg;
+using ::testing::NiceMock;
+using ::testing::DoAll;
+
+// ============================================
+// MatchManager boost
+// ============================================
+
+class MatchManagerBoostTests : public testing::Test {
+public:
+    void SetUp() override {
+        fakeClock = new FakePlatformClock();
+        SimpleTimer::setPlatformClock(fakeClock);
+        fakeClock->setTime(10000);
+
+        player = new Player();
+        char pid[] = "hunt";
+        player->setUserID(pid);
+        player->setIsHunter(true);
+
+        ON_CALL(peerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+        deviceWirelessManager = new WirelessManager(&peerComms, &httpClient);
+        wirelessManager = new FakeQuickdrawWirelessManager();
+        wirelessManager->initialize(player, deviceWirelessManager, 100);
+        matchManager = new MatchManager();
+        matchManager->initialize(player, &storage, wirelessManager);
+
+        uint8_t opponentMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+        matchManager->initializeMatch(opponentMac);
+        matchManager->setDuelLocalStartTime(10000);
+    }
+
+    void TearDown() override {
+        matchManager->clearCurrentMatch();
+        delete matchManager;
+        delete wirelessManager;
+        delete deviceWirelessManager;
+        delete player;
+        SimpleTimer::setPlatformClock(nullptr);
+        delete fakeClock;
+    }
+
+    NiceMock<MockPeerComms> peerComms;
+    MockHttpClient httpClient;
+    NiceMock<MockStorage> storage;
+    Player* player = nullptr;
+    MatchManager* matchManager = nullptr;
+    FakeQuickdrawWirelessManager* wirelessManager = nullptr;
+    WirelessManager* deviceWirelessManager = nullptr;
+    FakePlatformClock* fakeClock = nullptr;
+};
+
+inline void boostTurnsLossIntoWin(MatchManagerBoostTests* suite) {
+    // Set boost BEFORE pressing — boost is applied at button press time
+    suite->matchManager->setBoost(60); // 4 supporters * 15ms
+
+    suite->fakeClock->advance(300);
+    // Button press: raw time 300ms, boost 60ms, sent time = 240ms
+    suite->matchManager->getDuelButtonPush()(suite->matchManager);
+
+    suite->wirelessManager->setPacketReceivedCallback(
+        std::bind(&MatchManager::listenForMatchEvents, suite->matchManager, std::placeholders::_1));
+
+    // Opponent pressed at 250ms (no boost)
+    TestQuickdrawPacket pkt;
+    strncpy(pkt.matchId, suite->matchManager->getCurrentMatch()->getMatchId(), 36);
+    pkt.matchId[36] = '\0';
+    strncpy(pkt.playerId, "boun", 4);
+    pkt.playerId[4] = '\0';
+    pkt.isHunter = false;
+    pkt.playerDrawTime = 250;
+    pkt.command = QDCommand::DRAW_RESULT;
+
+    uint8_t mac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+    suite->wirelessManager->processQuickdrawCommand(mac, reinterpret_cast<uint8_t*>(&pkt), sizeof(pkt));
+
+    ASSERT_TRUE(suite->matchManager->matchResultsAreIn());
+    // Hunter sent 240ms (300-60), bounty sent 250ms → hunter wins
+    EXPECT_TRUE(suite->matchManager->didWin());
+}
+
+// ============================================
+// SupporterReady
+// ============================================
+
+class SupporterReadyTests : public testing::Test {
+public:
+    void SetUp() override {
+        fakeClock = new FakePlatformClock();
+        SimpleTimer::setPlatformClock(fakeClock);
+        fakeClock->setTime(10000);
+
+        player = new Player();
+        char pid[] = "supp";
+        player->setUserID(pid);
+        player->setIsHunter(false);
+
+        device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
+
+        ON_CALL(*device.mockDisplay, invalidateScreen()).WillByDefault(Return(device.mockDisplay));
+        ON_CALL(*device.mockDisplay, setGlyphMode(_)).WillByDefault(Return(device.mockDisplay));
+        ON_CALL(*device.mockDisplay, drawText(_, _, _)).WillByDefault(Return(device.mockDisplay));
+        ON_CALL(*device.mockDisplay, drawImage(_)).WillByDefault(Return(device.mockDisplay));
+    }
+
+    void TearDown() override {
+        delete player;
+        SimpleTimer::setPlatformClock(nullptr);
+        delete fakeClock;
+    }
+
+    FakePlatformClock* fakeClock = nullptr;
+    Player* player = nullptr;
+    MockDevice device;
+};
+
+inline void supporterReadyWinFromChampion(SupporterReadyTests* suite) {
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+
+    uint8_t champMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    SupporterReady state(suite->player, &suite->device.fakeRemoteDeviceCoordinator, nullptr);
+    state.setChampionMac(champMac);
+    state.onStateMounted(&suite->device);
+
+    state.handleGameEvent(GameEventType::WIN);
+
+    EXPECT_TRUE(state.transitionToWin());
+}
+
+inline void supporterReadyLossTransition(SupporterReadyTests* suite) {
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+
+    uint8_t champMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    SupporterReady state(suite->player, &suite->device.fakeRemoteDeviceCoordinator, nullptr);
+    state.setChampionMac(champMac);
+    state.onStateMounted(&suite->device);
+
+    // LOSS event should set transitionToLose, not transitionToWin
+    state.handleGameEvent(GameEventType::LOSS);
+
+    EXPECT_FALSE(state.transitionToWin());
+    EXPECT_TRUE(state.transitionToLose());
+}
+
+// ============================================
+// Loop detection
+// ============================================
+
+class LoopDetectionTests : public testing::Test {
+public:
+    void SetUp() override {
+        fakeClock = new FakePlatformClock();
+        SimpleTimer::setPlatformClock(fakeClock);
+        fakeClock->setTime(10000);
+
+        player = new Player();
+        char pid[] = "hunt";
+        player->setUserID(pid);
+        player->setIsHunter(true);
+
+        ON_CALL(*device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+        ON_CALL(*device.mockDisplay, invalidateScreen()).WillByDefault(Return(device.mockDisplay));
+        ON_CALL(*device.mockDisplay, setGlyphMode(_)).WillByDefault(Return(device.mockDisplay));
+        ON_CALL(*device.mockDisplay, drawText(_, _, _)).WillByDefault(Return(device.mockDisplay));
+        ON_CALL(*device.mockDisplay, drawImage(_)).WillByDefault(Return(device.mockDisplay));
+
+        wirelessManager = new FakeQuickdrawWirelessManager();
+        wirelessManager->initialize(player, device.wirelessManager, 100);
+
+        remoteDebugManager = new RemoteDebugManager(device.mockPeerComms);
+
+        quickdraw = new Quickdraw(player, &device, wirelessManager, remoteDebugManager);
+    }
+
+    void TearDown() override {
+        delete quickdraw;
+        delete remoteDebugManager;
+        delete wirelessManager;
+        delete player;
+        SimpleTimer::setPlatformClock(nullptr);
+        delete fakeClock;
+    }
+
+    FakePlatformClock* fakeClock = nullptr;
+    Player* player = nullptr;
+    MockDevice device;
+    FakeQuickdrawWirelessManager* wirelessManager = nullptr;
+    RemoteDebugManager* remoteDebugManager = nullptr;
+    Quickdraw* quickdraw = nullptr;
+};
+
+inline void loopRejectsInviteFromSupporterJackPeer(LoopDetectionTests* suite) {
+    uint8_t deviceBMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+
+    // Both jacks connected to same-role peers (loop topology)
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::CONNECTED);
+    // Supporter jack (INPUT for hunter) peer is device B
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::INPUT_JACK, deviceBMac);
+
+    // Receive invite with champion MAC = device B (same as supporter-jack peer)
+    RegisterInvitePacket invite{static_cast<uint8_t>(TeamCommandType::REGISTER_INVITE), 0, 1, {}, {}};
+    memcpy(invite.championMac, deviceBMac, 6);
+    strncpy(invite.championName, "B", CHAMPION_NAME_MAX - 1);
+    suite->quickdraw->onTeamPacketReceived(deviceBMac,
+        reinterpret_cast<const uint8_t*>(&invite), sizeof(invite));
+
+    SupporterReady sr(suite->player, &suite->device.fakeRemoteDeviceCoordinator, suite->quickdraw);
+    EXPECT_FALSE(suite->quickdraw->shouldTransitionToSupporter(&sr));
+}
+
+inline void loopAcceptsInviteFromNonSupporterJackPeer(LoopDetectionTests* suite) {
+    uint8_t champMac[6] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+    uint8_t downstreamMac[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+
+    // Normal chain: opponent jack has upstream same-role peer, supporter jack has different device
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::OUTPUT_JACK, champMac);
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::INPUT_JACK, downstreamMac);
+
+    // Receive invite from champion (NOT the supporter-jack peer)
+    RegisterInvitePacket invite{static_cast<uint8_t>(TeamCommandType::REGISTER_INVITE), 0, 1, {}, {}};
+    memcpy(invite.championMac, champMac, 6);
+    strncpy(invite.championName, "A", CHAMPION_NAME_MAX - 1);
+    suite->quickdraw->onTeamPacketReceived(champMac,
+        reinterpret_cast<const uint8_t*>(&invite), sizeof(invite));
+
+    SupporterReady sr(suite->player, &suite->device.fakeRemoteDeviceCoordinator, suite->quickdraw);
+    EXPECT_TRUE(suite->quickdraw->shouldTransitionToSupporter(&sr));
+}
+
+inline void deregisterRemovesSingleSupporter(LoopDetectionTests* suite) {
+    uint8_t macA[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    uint8_t macB[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
+    // Two supporters register
+    TeamPacket regA{static_cast<uint8_t>(TeamCommandType::REGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(macA,
+        reinterpret_cast<const uint8_t*>(&regA), sizeof(regA));
+    TeamPacket regB{static_cast<uint8_t>(TeamCommandType::REGISTER), 2};
+    suite->quickdraw->onTeamPacketReceived(macB,
+        reinterpret_cast<const uint8_t*>(&regB), sizeof(regB));
+    ASSERT_EQ(suite->quickdraw->getSupporterCount(), 2);
+
+    // A deregisters
+    TeamPacket dereg{static_cast<uint8_t>(TeamCommandType::DEREGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(macA,
+        reinterpret_cast<const uint8_t*>(&dereg), sizeof(dereg));
+
+    EXPECT_EQ(suite->quickdraw->getSupporterCount(), 1);
+
+    // B is still registered — can still confirm
+    TeamPacket confirm{static_cast<uint8_t>(TeamCommandType::CONFIRM), 0};
+    suite->quickdraw->onTeamPacketReceived(macB,
+        reinterpret_cast<const uint8_t*>(&confirm), sizeof(confirm));
+    EXPECT_EQ(suite->quickdraw->getConfirmedSupporters(), 1);
+}
+
+inline void confirmRejectedFromUnregisteredMac(LoopDetectionTests* suite) {
+    uint8_t rogueMAC[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01};
+    TeamPacket pkt{static_cast<uint8_t>(TeamCommandType::CONFIRM), 0};
+
+    suite->quickdraw->onTeamPacketReceived(rogueMAC,
+        reinterpret_cast<const uint8_t*>(&pkt), sizeof(pkt));
+
+    // Boost stays at 0 — unregistered MAC is ignored
+    EXPECT_FALSE(suite->quickdraw->hasTeamInvite());
+}
+
+inline void confirmFromRegisteredMacSucceeds(LoopDetectionTests* suite) {
+    uint8_t supporterMAC[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+
+    //Register first
+    TeamPacket reg{static_cast<uint8_t>(TeamCommandType::REGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(supporterMAC,
+        reinterpret_cast<const uint8_t*>(&reg), sizeof(reg));
+
+    // Now confirm from same MAC
+    TeamPacket confirm{static_cast<uint8_t>(TeamCommandType::CONFIRM), 0};
+    suite->quickdraw->onTeamPacketReceived(supporterMAC,
+        reinterpret_cast<const uint8_t*>(&confirm), sizeof(confirm));
+
+    EXPECT_EQ(suite->quickdraw->getConfirmedSupporters(), 1);
+}
+
+// ============================================
+// Ring topology
+// ============================================
+
+inline void ringInviteNotForwardedToChampion(SupporterReadyTests* suite) {
+    std::vector<size_t> sendSizes;
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _))
+        .WillByDefault(Invoke([&](const uint8_t*, PktType, const uint8_t*, size_t len) -> int {
+            sendSizes.push_back(len);
+            return 1;
+        }));
+
+    // Supporter (bounty) with downstream peer MAC == champion MAC (ring)
+    uint8_t champMac[6] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+
+    // Supporter jack for bounty is OUTPUT
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::OUTPUT_JACK, champMac);
+
+    SupporterReady state(suite->player, &suite->device.fakeRemoteDeviceCoordinator, nullptr);
+    state.setChampionMac(champMac);
+    state.setPosition(1);
+    state.onStateMounted(&suite->device);
+
+    suite->fakeClock->advance(2100);
+    state.onStateLoop(&suite->device);
+
+    // REGISTER packets (2 bytes) are expected, but no REGISTER_INVITE (24 bytes)
+    for (size_t len : sendSizes) {
+        EXPECT_NE(len, sizeof(RegisterInvitePacket))
+            << "Invite was forwarded to champion MAC — ring not detected";
+    }
+}
+
+inline void inviteForwardedToNonChampionPeer(SupporterReadyTests* suite) {
+    std::vector<size_t> sendSizes;
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _))
+        .WillByDefault(Invoke([&](const uint8_t*, PktType, const uint8_t*, size_t len) -> int {
+            sendSizes.push_back(len);
+            return 1;
+        }));
+
+    uint8_t champMac[6] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+    uint8_t downstreamMac[6] = {0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD};
+
+    // Downstream peer is NOT the champion
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::OUTPUT_JACK, downstreamMac);
+
+    SupporterReady state(suite->player, &suite->device.fakeRemoteDeviceCoordinator, nullptr);
+    state.setChampionMac(champMac);
+    state.setPosition(1);
+    state.onStateMounted(&suite->device);
+
+    suite->fakeClock->advance(2100);
+    state.onStateLoop(&suite->device);
+
+    bool inviteSent = false;
+    for (size_t len : sendSizes) {
+        if (len == sizeof(RegisterInvitePacket)) { inviteSent = true; break; }
+    }
+    EXPECT_TRUE(inviteSent) << "Invite should be forwarded to non-champion downstream peer";
+}
+
+// ============================================
+// Chain state lifecycle
+// ============================================
+
+inline void supporterCountClearsOnDisconnect(LoopDetectionTests* suite) {
+    uint8_t supporterMAC[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    uint8_t supporterMAC2[6] = {0x22, 0x33, 0x44, 0x55, 0x66, 0x77};
+
+    //Two supporters register
+    TeamPacket reg1{static_cast<uint8_t>(TeamCommandType::REGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(supporterMAC,
+        reinterpret_cast<const uint8_t*>(&reg1), sizeof(reg1));
+    TeamPacket reg2{static_cast<uint8_t>(TeamCommandType::REGISTER), 2};
+    suite->quickdraw->onTeamPacketReceived(supporterMAC2,
+        reinterpret_cast<const uint8_t*>(&reg2), sizeof(reg2));
+
+    ASSERT_EQ(suite->quickdraw->getSupporterCount(), 2);
+
+    // Clear chain state (simulates supporter jack disconnect)
+    suite->quickdraw->clearChainState();
+
+    EXPECT_EQ(suite->quickdraw->getSupporterCount(), 0);
+    EXPECT_EQ(suite->quickdraw->getConfirmedSupporters(), 0);
+    EXPECT_FALSE(suite->quickdraw->hasTeamInvite());
+}
+
+inline void registerIsIdempotent(LoopDetectionTests* suite) {
+    uint8_t supporterMAC[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+
+    //Same MAC registers three times
+    for (int i = 0; i < 3; i++) {
+        TeamPacket reg{static_cast<uint8_t>(TeamCommandType::REGISTER), 1};
+        suite->quickdraw->onTeamPacketReceived(supporterMAC,
+            reinterpret_cast<const uint8_t*>(&reg), sizeof(reg));
+    }
+
+    EXPECT_EQ(suite->quickdraw->getSupporterCount(), 1);
+}
+
+inline void confirmCappedAtSupporterCount(LoopDetectionTests* suite) {
+    uint8_t supporterMAC[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+
+    //Register one supporter
+    TeamPacket reg{static_cast<uint8_t>(TeamCommandType::REGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(supporterMAC,
+        reinterpret_cast<const uint8_t*>(&reg), sizeof(reg));
+
+    // Send CONFIRM three times from same registered MAC
+    for (int i = 0; i < 3; i++) {
+        TeamPacket confirm{static_cast<uint8_t>(TeamCommandType::CONFIRM), 0};
+        suite->quickdraw->onTeamPacketReceived(supporterMAC,
+            reinterpret_cast<const uint8_t*>(&confirm), sizeof(confirm));
+    }
+
+    // Only 1 supporter registered, so confirmed should cap at 1
+    EXPECT_EQ(suite->quickdraw->getConfirmedSupporters(), 1);
+}
+
+// ============================================
+// Idle lifecycle with connection changes
+// ============================================
+
+class ChampionIdleLifecycleTests : public testing::Test {
+public:
+    void SetUp() override {
+        fakeClock = new FakePlatformClock();
+        SimpleTimer::setPlatformClock(fakeClock);
+        fakeClock->setTime(10000);
+
+        player = new Player();
+        char pid[] = "hunt";
+        player->setUserID(pid);
+        player->setIsHunter(true);
+
+        ON_CALL(*device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+        ON_CALL(*device.mockDisplay, invalidateScreen()).WillByDefault(Return(device.mockDisplay));
+        ON_CALL(*device.mockDisplay, setGlyphMode(_)).WillByDefault(Return(device.mockDisplay));
+        ON_CALL(*device.mockDisplay, drawText(_, _, _)).WillByDefault(Return(device.mockDisplay));
+        ON_CALL(*device.mockDisplay, drawImage(_)).WillByDefault(Return(device.mockDisplay));
+        ON_CALL(*device.mockPrimaryButton, setButtonPress(testing::A<parameterizedCallbackFunction>(), _, _))
+            .WillByDefault(Return());
+        ON_CALL(*device.mockSecondaryButton, setButtonPress(testing::A<parameterizedCallbackFunction>(), _, _))
+            .WillByDefault(Return());
+        ON_CALL(*device.mockPrimaryButton, removeButtonCallbacks()).WillByDefault(Return());
+        ON_CALL(*device.mockSecondaryButton, removeButtonCallbacks()).WillByDefault(Return());
+
+        // Set device MAC so Quickdraw can identify itself
+        static uint8_t myMac[6] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+        ON_CALL(*device.mockPeerComms, getMacAddress()).WillByDefault(Return(myMac));
+
+        wirelessManager = new FakeQuickdrawWirelessManager();
+        wirelessManager->initialize(player, device.wirelessManager, 100);
+        remoteDebugManager = new RemoteDebugManager(device.mockPeerComms);
+        quickdraw = new Quickdraw(player, &device, wirelessManager, remoteDebugManager);
+        quickdraw->populateStateMap();
+
+        matchManager = new MatchManager();
+        matchManager->initialize(player, &storage, wirelessManager);
+        idle = new Idle(player, matchManager, &device.fakeRemoteDeviceCoordinator,
+            [this]() { return quickdraw->getSupporterCount(); },
+            [this]() { quickdraw->clearChainState(); },
+            [this]() { return quickdraw->isInviteRejected(); });
+    }
+
+    void TearDown() override {
+        delete idle;
+        delete matchManager;
+        delete quickdraw;
+        delete remoteDebugManager;
+        delete wirelessManager;
+        delete player;
+        SimpleTimer::setPlatformClock(nullptr);
+        delete fakeClock;
+    }
+
+    void tickIdle(int ms) {
+        fakeClock->advance(ms);
+        idle->onStateLoop(&device);
+    }
+
+    FakePlatformClock* fakeClock = nullptr;
+    Player* player = nullptr;
+    MockDevice device;
+    NiceMock<MockStorage> storage;
+    FakeQuickdrawWirelessManager* wirelessManager = nullptr;
+    RemoteDebugManager* remoteDebugManager = nullptr;
+    Quickdraw* quickdraw = nullptr;
+    MatchManager* matchManager = nullptr;
+    Idle* idle = nullptr;
+};
+
+inline void championSendsInviteWhenSupporterConnects(ChampionIdleLifecycleTests* suite) {
+    uint8_t supporterMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+
+    suite->idle->onStateMounted(&suite->device);
+
+    // Pass stabilization
+    suite->tickIdle(600);
+
+    // No supporter yet — no invites
+    EXPECT_EQ(suite->quickdraw->getSupporterCount(), 0);
+
+    // Supporter connects on INPUT jack (supporter jack for hunter)
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::INPUT_JACK, supporterMac);
+
+    // Tick — should send invite
+    EXPECT_CALL(*suite->device.mockPeerComms,
+        sendData(_, PktType::kTeamCommand, _, sizeof(RegisterInvitePacket))).Times(1);
+    suite->tickIdle(100);
+
+    testing::Mock::VerifyAndClearExpectations(suite->device.mockPeerComms);
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+
+    // --- Invite retry after INVITE_RETRY_MS ---
+    EXPECT_CALL(*suite->device.mockPeerComms,
+        sendData(_, PktType::kTeamCommand, _, sizeof(RegisterInvitePacket))).Times(1);
+    suite->tickIdle(2100);
+
+    testing::Mock::VerifyAndClearExpectations(suite->device.mockPeerComms);
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+
+    // --- HandleInviteRejected: reject stops retries ---
+    TeamPacket reject{static_cast<uint8_t>(TeamCommandType::INVITE_REJECT), 0};
+    suite->quickdraw->onTeamPacketReceived(supporterMac,
+        reinterpret_cast<const uint8_t*>(&reject), sizeof(reject));
+
+    EXPECT_CALL(*suite->device.mockPeerComms,
+        sendData(_, PktType::kTeamCommand, _, sizeof(RegisterInvitePacket))).Times(0);
+    suite->tickIdle(2100);
+
+    testing::Mock::VerifyAndClearExpectations(suite->device.mockPeerComms);
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+
+    // --- Peer change clears rejection: disconnect then reconnect ---
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::DISCONNECTED);
+    suite->tickIdle(100);
+
+    uint8_t newPeerMac[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::INPUT_JACK, newPeerMac);
+
+    EXPECT_CALL(*suite->device.mockPeerComms,
+        sendData(_, PktType::kTeamCommand, _, sizeof(RegisterInvitePacket))).Times(1);
+    suite->tickIdle(100);
+
+    suite->idle->onStateDismounted(&suite->device);
+}
+
+inline void championClearsChainWhenSupporterDisconnects(ChampionIdleLifecycleTests* suite) {
+    uint8_t supporterMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+
+    suite->idle->onStateMounted(&suite->device);
+    suite->tickIdle(600); // pass stabilization
+
+    // Supporter connects
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::INPUT_JACK, supporterMac);
+
+    suite->tickIdle(100); // sends invite
+
+    // Supporter registers
+    TeamPacket reg{static_cast<uint8_t>(TeamCommandType::REGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(supporterMac,
+        reinterpret_cast<const uint8_t*>(&reg), sizeof(reg));
+    ASSERT_EQ(suite->quickdraw->getSupporterCount(), 1);
+
+    // Supporter disconnects
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::DISCONNECTED);
+
+    suite->tickIdle(100);
+
+    EXPECT_EQ(suite->quickdraw->getSupporterCount(), 0);
+
+    suite->idle->onStateDismounted(&suite->device);
+}
+
+inline void championIgnoresInviteWithOwnMacViaPacketHandler(ChampionIdleLifecycleTests* suite) {
+    uint8_t myMac[6] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+    uint8_t otherMac[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+
+    // Set up opponent jack connected (required for shouldTransitionToSupporter)
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
+
+    // Receive an invite where champion MAC == our MAC (looped ring)
+    RegisterInvitePacket invite{static_cast<uint8_t>(TeamCommandType::REGISTER_INVITE), 0, 1, {}, {}};
+    memcpy(invite.championMac, myMac, 6);
+    strncpy(invite.championName, "Me", CHAMPION_NAME_MAX - 1);
+    suite->quickdraw->onTeamPacketReceived(otherMac,
+        reinterpret_cast<const uint8_t*>(&invite), sizeof(invite));
+
+    // Self-invite rejected at packet level — ring detected
+    EXPECT_FALSE(suite->quickdraw->hasTeamInvite());
+}
+
+inline void hunterIgnoresInviteFromBountyChampion(ChampionIdleLifecycleTests* suite) {
+    uint8_t bountyMac[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+
+    // Receive invite where champion is bounty (hunter=0) but we are hunter
+    RegisterInvitePacket invite{static_cast<uint8_t>(TeamCommandType::REGISTER_INVITE), 0, 0, {}, {}};
+    memcpy(invite.championMac, bountyMac, 6);
+    strncpy(invite.championName, "Bounty", CHAMPION_NAME_MAX - 1);
+    suite->quickdraw->onTeamPacketReceived(bountyMac,
+        reinterpret_cast<const uint8_t*>(&invite), sizeof(invite));
+
+    // Wrong-role invite rejected at packet level
+    EXPECT_FALSE(suite->quickdraw->hasTeamInvite());
+}
+
+// ============================================
+// Two-device packet exchange
+// ============================================
+
+inline void twoDeviceChainRegistrationFlow(LoopDetectionTests* suite) {
+    uint8_t championMac[6] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+    uint8_t supporterMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+
+    //--- Champion side: send invite ---
+    // Champion's supporter jack (INPUT for hunter) has supporter
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::INPUT_JACK, supporterMac);
+
+    // --- Supporter side: receive invite, send REGISTER ---
+    RegisterInvitePacket invite{static_cast<uint8_t>(TeamCommandType::REGISTER_INVITE), 0, 1, {}, {}};
+    memcpy(invite.championMac, championMac, 6);
+    strncpy(invite.championName, "Champ", CHAMPION_NAME_MAX - 1);
+
+    // Simulate supporter receiving the invite
+    suite->quickdraw->onTeamPacketReceived(championMac,
+        reinterpret_cast<const uint8_t*>(&invite), sizeof(invite));
+    EXPECT_TRUE(suite->quickdraw->hasTeamInvite());
+    EXPECT_EQ(suite->quickdraw->getInvitePosition(), 1);
+
+    // --- Champion side: receive REGISTER from supporter ---
+    TeamPacket reg{static_cast<uint8_t>(TeamCommandType::REGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(supporterMac,
+        reinterpret_cast<const uint8_t*>(&reg), sizeof(reg));
+    EXPECT_EQ(suite->quickdraw->getSupporterCount(), 1);
+
+    // --- Champion side: receive CONFIRM from supporter ---
+    TeamPacket confirm{static_cast<uint8_t>(TeamCommandType::CONFIRM), 0};
+    suite->quickdraw->onTeamPacketReceived(supporterMac,
+        reinterpret_cast<const uint8_t*>(&confirm), sizeof(confirm));
+    EXPECT_EQ(suite->quickdraw->getConfirmedSupporters(), 1);
+}
+
+inline void midChainDeviceSendsInviteDownstream(ChampionIdleLifecycleTests* suite) {
+    uint8_t upstreamMac[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+    uint8_t downstreamMac[6] = {0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD};
+
+    suite->idle->onStateMounted(&suite->device);
+    suite->tickIdle(600); // pass stabilization
+
+    // Both jacks connected → mid-chain
+    // Opponent jack (OUTPUT for hunter)
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::OUTPUT_JACK, upstreamMac);
+    // Supporter jack (INPUT for hunter)
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::INPUT_JACK, downstreamMac);
+
+    // Idle now sends invites to any connected supporter-jack peer;
+    // mid-chain rejection happens on the receiver side via shouldTransitionToSupporter
+    EXPECT_CALL(*suite->device.mockPeerComms,
+        sendData(_, PktType::kTeamCommand, _, sizeof(RegisterInvitePacket))).Times(1);
+
+    suite->tickIdle(100);
+
+    suite->idle->onStateDismounted(&suite->device);
+}
+
+// ============================================
+// Systematic topology × event tests
+// ============================================
+
+// --- Topology: single supporter connects then disconnects (no deregister sent) ---
+// Covers: supporter crashes or cable yanked without clean deregister
+inline void supporterDisappearsWithoutDeregister(ChampionIdleLifecycleTests* suite) {
+    uint8_t supporterMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+
+    suite->idle->onStateMounted(&suite->device);
+    suite->tickIdle(600);
+
+    // Supporter connects
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::INPUT_JACK, supporterMac);
+    suite->tickIdle(100);
+
+    // Supporter registers wirelessly
+    TeamPacket reg{static_cast<uint8_t>(TeamCommandType::REGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(supporterMac,
+        reinterpret_cast<const uint8_t*>(&reg), sizeof(reg));
+    ASSERT_EQ(suite->quickdraw->getSupporterCount(), 1);
+
+    // Cable yanked — no DEREGISTER sent, just jack goes disconnected
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::DISCONNECTED);
+    suite->tickIdle(100);
+
+    // Chain state should be fully cleared
+    EXPECT_EQ(suite->quickdraw->getSupporterCount(), 0);
+
+    suite->idle->onStateDismounted(&suite->device);
+}
+
+// --- Topology: two supporters, first one deregisters ---
+inline void twoSupportersOneDeregisters(LoopDetectionTests* suite) {
+    uint8_t macA[6] = {0x11, 0x11, 0x11, 0x11, 0x11, 0x11};
+    uint8_t macB[6] = {0x22, 0x22, 0x22, 0x22, 0x22, 0x22};
+
+    TeamPacket regA{static_cast<uint8_t>(TeamCommandType::REGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(macA,
+        reinterpret_cast<const uint8_t*>(&regA), sizeof(regA));
+    TeamPacket regB{static_cast<uint8_t>(TeamCommandType::REGISTER), 2};
+    suite->quickdraw->onTeamPacketReceived(macB,
+        reinterpret_cast<const uint8_t*>(&regB), sizeof(regB));
+
+    // Both confirm
+    TeamPacket confA{static_cast<uint8_t>(TeamCommandType::CONFIRM), 0};
+    suite->quickdraw->onTeamPacketReceived(macA,
+        reinterpret_cast<const uint8_t*>(&confA), sizeof(confA));
+    TeamPacket confB{static_cast<uint8_t>(TeamCommandType::CONFIRM), 0};
+    suite->quickdraw->onTeamPacketReceived(macB,
+        reinterpret_cast<const uint8_t*>(&confB), sizeof(confB));
+    ASSERT_EQ(suite->quickdraw->getConfirmedSupporters(), 2);
+
+    // A deregisters
+    TeamPacket dereg{static_cast<uint8_t>(TeamCommandType::DEREGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(macA,
+        reinterpret_cast<const uint8_t*>(&dereg), sizeof(dereg));
+
+    EXPECT_EQ(suite->quickdraw->getSupporterCount(), 1);
+    EXPECT_EQ(suite->quickdraw->getConfirmedSupporters(), 1);
+}
+
+// --- Topology: deregister from unknown MAC (never registered) ---
+inline void deregisterFromUnknownMacIsIgnored(LoopDetectionTests* suite) {
+    uint8_t knownMac[6] = {0x11, 0x11, 0x11, 0x11, 0x11, 0x11};
+    uint8_t unknownMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00};
+
+    TeamPacket reg{static_cast<uint8_t>(TeamCommandType::REGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(knownMac,
+        reinterpret_cast<const uint8_t*>(&reg), sizeof(reg));
+    ASSERT_EQ(suite->quickdraw->getSupporterCount(), 1);
+
+    // Deregister from a MAC that never registered
+    TeamPacket dereg{static_cast<uint8_t>(TeamCommandType::DEREGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(unknownMac,
+        reinterpret_cast<const uint8_t*>(&dereg), sizeof(dereg));
+
+    // Count unchanged
+    EXPECT_EQ(suite->quickdraw->getSupporterCount(), 1);
+}
+
+// --- Topology: supporter re-registers after deregister ---
+inline void supporterCanReregisterAfterDeregister(LoopDetectionTests* suite) {
+    uint8_t mac[6] = {0x11, 0x11, 0x11, 0x11, 0x11, 0x11};
+
+    TeamPacket reg{static_cast<uint8_t>(TeamCommandType::REGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(mac,
+        reinterpret_cast<const uint8_t*>(&reg), sizeof(reg));
+    ASSERT_EQ(suite->quickdraw->getSupporterCount(), 1);
+
+    TeamPacket dereg{static_cast<uint8_t>(TeamCommandType::DEREGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(mac,
+        reinterpret_cast<const uint8_t*>(&dereg), sizeof(dereg));
+    ASSERT_EQ(suite->quickdraw->getSupporterCount(), 0);
+
+    // Re-register
+    suite->quickdraw->onTeamPacketReceived(mac,
+        reinterpret_cast<const uint8_t*>(&reg), sizeof(reg));
+    EXPECT_EQ(suite->quickdraw->getSupporterCount(), 1);
+}
+
+// --- Topology: game event from non-champion MAC is ignored ---
+inline void gameEventFromNonChampionIgnored(LoopDetectionTests* suite) {
+    uint8_t champMac[6] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+    uint8_t otherMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+
+    // Set up invite so we have a champion MAC
+    RegisterInvitePacket invite{static_cast<uint8_t>(TeamCommandType::REGISTER_INVITE), 0, 1, {}, {}};
+    memcpy(invite.championMac, champMac, 6);
+    strncpy(invite.championName, "A", CHAMPION_NAME_MAX - 1);
+    suite->quickdraw->onTeamPacketReceived(champMac,
+        reinterpret_cast<const uint8_t*>(&invite), sizeof(invite));
+
+    bool eventFired = false;
+    suite->quickdraw->setGameEventCallback([&](GameEventType) { eventFired = true; });
+
+    // Game event from wrong MAC
+    TeamPacket evt{static_cast<uint8_t>(TeamCommandType::GAME_EVENT),
+        static_cast<uint8_t>(GameEventType::WIN)};
+    suite->quickdraw->onTeamPacketReceived(otherMac,
+        reinterpret_cast<const uint8_t*>(&evt), sizeof(evt));
+    EXPECT_FALSE(eventFired);
+
+    // Game event from correct champion MAC
+    suite->quickdraw->onTeamPacketReceived(champMac,
+        reinterpret_cast<const uint8_t*>(&evt), sizeof(evt));
+    EXPECT_TRUE(eventFired);
+
+    suite->quickdraw->clearGameEventCallback();
+}
+
+// --- Topology: champion with opponent disconnected can't transition to supporter ---
+inline void noSupporterTransitionWithoutOpponent(LoopDetectionTests* suite) {
+    uint8_t champMac[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+
+    // Receive invite but opponent jack is disconnected
+    RegisterInvitePacket invite{static_cast<uint8_t>(TeamCommandType::REGISTER_INVITE), 0, 1, {}, {}};
+    memcpy(invite.championMac, champMac, 6);
+    strncpy(invite.championName, "C", CHAMPION_NAME_MAX - 1);
+    suite->quickdraw->onTeamPacketReceived(champMac,
+        reinterpret_cast<const uint8_t*>(&invite), sizeof(invite));
+    ASSERT_TRUE(suite->quickdraw->hasTeamInvite());
+
+    // Opponent jack disconnected
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::OUTPUT_JACK, PortStatus::DISCONNECTED);
+
+    SupporterReady sr(suite->player, &suite->device.fakeRemoteDeviceCoordinator, suite->quickdraw);
+    EXPECT_FALSE(suite->quickdraw->shouldTransitionToSupporter(&sr));
+    EXPECT_FALSE(suite->quickdraw->hasTeamInvite()); // cleared on rejection
+}
+
+// --- Topology: invite from opposite-role champion can't transition to supporter ---
+inline void noSupporterTransitionWithOppositeRoleOpponent(LoopDetectionTests* suite) {
+    uint8_t champMac[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+
+    // Invite with championIsHunter=false but our player is hunter
+    RegisterInvitePacket invite{static_cast<uint8_t>(TeamCommandType::REGISTER_INVITE), 0, 0, {}, {}};
+    memcpy(invite.championMac, champMac, 6);
+    strncpy(invite.championName, "C", CHAMPION_NAME_MAX - 1);
+    suite->quickdraw->onTeamPacketReceived(champMac,
+        reinterpret_cast<const uint8_t*>(&invite), sizeof(invite));
+
+    // Opponent jack connected
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
+
+    SupporterReady sr(suite->player, &suite->device.fakeRemoteDeviceCoordinator, suite->quickdraw);
+    EXPECT_FALSE(suite->quickdraw->shouldTransitionToSupporter(&sr));
+}
+
+// --- Integration: same-role peer triggers supporter transition within bounded iterations ---
+// Covers: match init oscillation doesn't block invite acceptance
+inline void sameRolePeerTransitionsToSupporterPromptly(ChampionIdleLifecycleTests* suite) {
+    uint8_t peerMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+
+    suite->idle->onStateMounted(&suite->device);
+    suite->tickIdle(600);
+
+    // Same-role hunter on opponent jack (OUTPUT for hunter)
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
+    suite->device.fakeRemoteDeviceCoordinator.setPeerMac(SerialIdentifier::OUTPUT_JACK, peerMac);
+
+    // Run idle loop — match init will fire and eventually fail
+    // Tick past match initialization timeout (1000ms)
+    for (int i = 0; i < 12; i++) {
+        suite->tickIdle(100);
+    }
+
+    // Simulate receiving invite from the peer with a different champion upstream
+    uint8_t championMac[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+    RegisterInvitePacket invite{static_cast<uint8_t>(TeamCommandType::REGISTER_INVITE), 0, 1, {}, {}};
+    memcpy(invite.championMac, championMac, 6);
+    strncpy(invite.championName, "Test", CHAMPION_NAME_MAX - 1);
+    suite->quickdraw->onTeamPacketReceived(peerMac,
+        reinterpret_cast<const uint8_t*>(&invite), sizeof(invite));
+    ASSERT_TRUE(suite->quickdraw->hasTeamInvite());
+
+    // shouldTransitionToSupporter must succeed — match is not ready (same-role = mismatch)
+    SupporterReady sr(suite->player, &suite->device.fakeRemoteDeviceCoordinator, suite->quickdraw);
+    EXPECT_TRUE(suite->quickdraw->shouldTransitionToSupporter(&sr));
+
+    suite->idle->onStateDismounted(&suite->device);
+}
+
+// --- Chain merge: supporter switches to new champion when forwarded invite arrives ---
+inline void supporterMergesWhenNewChampionInviteArrives(ChampionIdleLifecycleTests* suite) {
+    uint8_t oldChampMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+    uint8_t newChampMac[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+    uint8_t senderMac[6] = {0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD};
+
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+
+    SupporterReady state(suite->player, &suite->device.fakeRemoteDeviceCoordinator, suite->quickdraw);
+    state.setChampionMac(oldChampMac);
+    state.setChampionName("OldChamp");
+    state.setPosition(1);
+    state.setChampionIsHunter(true);
+    state.onStateMounted(&suite->device);
+
+    // New invite arrives from a different champion
+    RegisterInvitePacket invite{static_cast<uint8_t>(TeamCommandType::REGISTER_INVITE), 1, 1, {}, {}};
+    memcpy(invite.championMac, newChampMac, 6);
+    strncpy(invite.championName, "NewChamp", CHAMPION_NAME_MAX - 1);
+    suite->quickdraw->onTeamPacketReceived(senderMac,
+        reinterpret_cast<const uint8_t*>(&invite), sizeof(invite));
+
+    // Expect DEREGISTER sent to old champion
+    EXPECT_CALL(*suite->device.mockPeerComms,
+        sendData(_, PktType::kTeamCommand, _, sizeof(TeamPacket))).Times(testing::AtLeast(1));
+
+    state.onStateLoop(&suite->device);
+
+    // Should transition to idle to re-accept under new champion
+    EXPECT_TRUE(state.transitionToIdle());
+
+    state.onStateDismounted(&suite->device);
+}
+
+// --- 3-device chain: mid-chain forwards invite, tail registers with champion ---
+inline void threeDeviceChainFormation(LoopDetectionTests* suite) {
+    uint8_t championMac[6] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+    uint8_t midMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+    uint8_t tailMac[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+
+    // Mid-chain receives invite from champion at position 0
+    RegisterInvitePacket invite{static_cast<uint8_t>(TeamCommandType::REGISTER_INVITE), 0, 1, {}, {}};
+    memcpy(invite.championMac, championMac, 6);
+    strncpy(invite.championName, "Champ", CHAMPION_NAME_MAX - 1);
+    suite->quickdraw->onTeamPacketReceived(championMac,
+        reinterpret_cast<const uint8_t*>(&invite), sizeof(invite));
+    ASSERT_TRUE(suite->quickdraw->hasTeamInvite());
+    EXPECT_EQ(suite->quickdraw->getInvitePosition(), 1);
+
+    // Champion receives REGISTER from mid-chain (position 1)
+    TeamPacket regMid{static_cast<uint8_t>(TeamCommandType::REGISTER), 1};
+    suite->quickdraw->onTeamPacketReceived(midMac,
+        reinterpret_cast<const uint8_t*>(&regMid), sizeof(regMid));
+    EXPECT_EQ(suite->quickdraw->getSupporterCount(), 1);
+
+    // Champion receives REGISTER from tail (position 2)
+    TeamPacket regTail{static_cast<uint8_t>(TeamCommandType::REGISTER), 2};
+    suite->quickdraw->onTeamPacketReceived(tailMac,
+        reinterpret_cast<const uint8_t*>(&regTail), sizeof(regTail));
+    EXPECT_EQ(suite->quickdraw->getSupporterCount(), 2);
+
+    // Both confirm
+    TeamPacket confMid{static_cast<uint8_t>(TeamCommandType::CONFIRM), 0};
+    suite->quickdraw->onTeamPacketReceived(midMac,
+        reinterpret_cast<const uint8_t*>(&confMid), sizeof(confMid));
+    EXPECT_EQ(suite->quickdraw->getConfirmedSupporters(), 1);
+
+    TeamPacket confTail{static_cast<uint8_t>(TeamCommandType::CONFIRM), 0};
+    suite->quickdraw->onTeamPacketReceived(tailMac,
+        reinterpret_cast<const uint8_t*>(&confTail), sizeof(confTail));
+    EXPECT_EQ(suite->quickdraw->getConfirmedSupporters(), 2);
+}
+
+// ============================================
+// SupporterReady button behavior
+// ============================================
+
+inline void supporterReadyButtonSendsConfirm(SupporterReadyTests* suite) {
+    parameterizedCallbackFunction btnCallback = nullptr;
+    void* btnCtx = nullptr;
+    ON_CALL(*suite->device.mockPrimaryButton, setButtonPress(testing::A<parameterizedCallbackFunction>(), _, _))
+        .WillByDefault(DoAll(SaveArg<0>(&btnCallback), SaveArg<1>(&btnCtx)));
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+
+    uint8_t champMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    SupporterReady state(suite->player, &suite->device.fakeRemoteDeviceCoordinator, nullptr);
+    state.setChampionMac(champMac);
+    state.onStateMounted(&suite->device);
+
+    ASSERT_NE(btnCallback, nullptr);
+
+    // Button press before duel is active should be ignored
+    btnCallback(btnCtx);
+
+    // Simulate champion starting countdown
+    state.handleGameEvent(GameEventType::COUNTDOWN);
+
+    EXPECT_CALL(*suite->device.mockPeerComms,
+        sendData(_, PktType::kTeamCommand, _, _)).Times(1);
+
+    btnCallback(btnCtx);
+
+    testing::Mock::VerifyAndClearExpectations(suite->device.mockPeerComms);
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+
+    // Second press should NOT send another CONFIRM
+    EXPECT_CALL(*suite->device.mockPeerComms,
+        sendData(_, PktType::kTeamCommand, _, _)).Times(0);
+    btnCallback(btnCtx);
+}
+
+inline void supporterDisconnectsFromChampion(SupporterReadyTests* suite) {
+    std::vector<size_t> sendSizes;
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _))
+        .WillByDefault(Invoke([&](const uint8_t*, PktType, const uint8_t*, size_t len) -> int {
+            sendSizes.push_back(len);
+            return 1;
+        }));
+
+    uint8_t champMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    SupporterReady state(suite->player, &suite->device.fakeRemoteDeviceCoordinator, nullptr);
+    state.setChampionMac(champMac);
+    state.onStateMounted(&suite->device);
+
+    // Champion jack for bounty supporter = INPUT_JACK
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::CONNECTED);
+    suite->fakeClock->advance(100);
+    state.onStateLoop(&suite->device);
+    ASSERT_FALSE(state.transitionToIdle());
+
+    // Clear sends from REGISTER, then disconnect champion
+    sendSizes.clear();
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(SerialIdentifier::INPUT_JACK, PortStatus::DISCONNECTED);
+    suite->fakeClock->advance(100);
+    state.onStateLoop(&suite->device);
+
+    EXPECT_TRUE(state.transitionToIdle());
+
+    // DEREGISTER packet sent after disconnect (sizeof(TeamPacket) = 2 bytes)
+    bool deregisterSent = false;
+    for (size_t len : sendSizes) {
+        if (len == sizeof(TeamPacket)) { deregisterSent = true; break; }
+    }
+    EXPECT_TRUE(deregisterSent) << "DEREGISTER should be sent when champion disconnects";
+}

--- a/test/test_core/device-mock.hpp
+++ b/test/test_core/device-mock.hpp
@@ -179,11 +179,26 @@ public:
         return DeviceType::UNKNOWN;
     }
 
+    void setPeerMac(SerialIdentifier id, const uint8_t* mac) {
+        if (id == SerialIdentifier::OUTPUT_JACK) { memcpy(outputMac, mac, 6); hasOutputMac = true; }
+        else if (id == SerialIdentifier::INPUT_JACK) { memcpy(inputMac, mac, 6); hasInputMac = true; }
+    }
+
+    const uint8_t* getPeerMac(SerialIdentifier id) const override {
+        if (id == SerialIdentifier::OUTPUT_JACK) return hasOutputMac ? outputMac : nullptr;
+        if (id == SerialIdentifier::INPUT_JACK) return hasInputMac ? inputMac : nullptr;
+        return nullptr;
+    }
+
 private:
     PortStatus outputStatus = PortStatus::DISCONNECTED;
     PortStatus inputStatus = PortStatus::DISCONNECTED;
     DeviceType outputDeviceType = DeviceType::UNKNOWN;
     DeviceType inputDeviceType = DeviceType::UNKNOWN;
+    uint8_t outputMac[6] = {};
+    uint8_t inputMac[6] = {};
+    bool hasOutputMac = false;
+    bool hasInputMac = false;
 };
 
 // Fake QuickdrawWirelessManager that captures outbound packets instead of transmitting them.

--- a/test/test_core/integration-tests.hpp
+++ b/test/test_core/integration-tests.hpp
@@ -265,9 +265,12 @@ inline void duelWithOpponentTimeout(DuelIntegrationTestSuite* suite) {
     suite->performHandshake();
 
     suite->hunterMatchManager->setHunterDrawTime(300);
-    suite->hunterMatchManager->setBountyDrawTime(0);  // opponent never pressed
     suite->hunterMatchManager->setReceivedButtonPush();
-    suite->hunterMatchManager->setNeverPressed();
+    // Opponent (bounty) sends NEVER_PRESSED
+    uint8_t bountyMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+    QuickdrawCommand neverPressed(bountyMac, QDCommand::NEVER_PRESSED,
+        suite->hunterMatchManager->getCurrentMatch()->getMatchId(), "boun", 5000, false);
+    suite->hunterMatchManager->listenForMatchEvents(neverPressed);
 
     EXPECT_TRUE(suite->hunterMatchManager->matchResultsAreIn());
     EXPECT_TRUE(suite->hunterMatchManager->didWin());

--- a/test/test_core/match-manager-tests.hpp
+++ b/test/test_core/match-manager-tests.hpp
@@ -140,7 +140,10 @@ inline void matchManagerHunterWinsWhenBountyNeverPressed(MatchManager* mm, Playe
     uint8_t dummyMac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
     mm->initializeMatch(dummyMac);
     mm->setHunterDrawTime(250);
-    mm->setBountyDrawTime(0);  // bounty never pressed
+    mm->setReceivedButtonPush();
+    // Opponent (bounty) sends NEVER_PRESSED
+    QuickdrawCommand neverPressed(dummyMac, QDCommand::NEVER_PRESSED, mm->getCurrentMatch()->getMatchId(), "boun", 5000, false);
+    mm->listenForMatchEvents(neverPressed);
 
     EXPECT_TRUE(mm->didWin());
 }
@@ -150,8 +153,11 @@ inline void matchManagerBountyWinsWhenHunterNeverPressed(MatchManager* mm, Playe
     static const uint8_t dummyMac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
     QuickdrawCommand cmd(dummyMac, QDCommand::SEND_MATCH_ID, "duel-6", "hunt", 0, true);
     mm->listenForMatchEvents(cmd);
-    mm->setHunterDrawTime(0);  // hunter never pressed
     mm->setBountyDrawTime(300);
+    mm->setReceivedButtonPush();
+    // Opponent (hunter) sends NEVER_PRESSED
+    QuickdrawCommand neverPressed(dummyMac, QDCommand::NEVER_PRESSED, "duel-6", "hunt", 5000, true);
+    mm->listenForMatchEvents(neverPressed);
 
     EXPECT_TRUE(mm->didWin());
 }
@@ -184,7 +190,9 @@ inline void matchManagerGracePeriodPath(MatchManager* mm, Player* player) {
     mm->initializeMatch(dummyMac);
 
     mm->setReceivedButtonPush();
-    mm->setNeverPressed();
+    // Opponent sends NEVER_PRESSED
+    QuickdrawCommand neverPressed(dummyMac, QDCommand::NEVER_PRESSED, mm->getCurrentMatch()->getMatchId(), "boun", 5000, false);
+    mm->listenForMatchEvents(neverPressed);
 
     EXPECT_TRUE(mm->matchResultsAreIn());
 }

--- a/test/test_core/quickdraw-integration-tests.hpp
+++ b/test/test_core/quickdraw-integration-tests.hpp
@@ -88,7 +88,9 @@ public:
         cleanupClock();
     }
 
-    virtual std::string getMatchId() const { return "test-match-uuid-1234567890"; }
+    std::string getActiveMatchId() const {
+        return matchManager->getCurrentMatch()->getMatchId();
+    }
 
     virtual void setupDefaultMockExpectations() {
         ON_CALL(peerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
@@ -96,18 +98,19 @@ public:
 
     // Creates a packet as if sent by the local player's opponent.
     TestQuickdrawPacket createPacket(int command, long hunterTime = 0, long bountyTime = 0) {
+        std::string mid = getActiveMatchId();
         if (player->isHunter()) {
             // Opponent is the bounty: send bountyTime with isHunter=false
-            return createTestPacket(getMatchId(), DEFAULT_BOUNTY_ID, command, bountyTime, false);
+            return createTestPacket(mid, DEFAULT_BOUNTY_ID, command, bountyTime, false);
         } else {
             // Opponent is the hunter: send hunterTime with isHunter=true
-            return createTestPacket(getMatchId(), DEFAULT_HUNTER_ID, command, hunterTime, true);
+            return createTestPacket(mid, DEFAULT_HUNTER_ID, command, hunterTime, true);
         }
     }
 
     void processPacket(const TestQuickdrawPacket& packet, 
                       const uint8_t macAddr[6] = nullptr) {
-        uint8_t defaultMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+        uint8_t defaultMac[6] = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
         const uint8_t* mac = macAddr ? macAddr : defaultMac;
         wirelessManager->processQuickdrawCommand(
             mac,
@@ -197,7 +200,9 @@ public:
         cleanupClock();
     }
 
-    virtual std::string getMatchId() const { return "two-device-match-id-123456"; }
+    std::string getHunterActiveMatchId() const {
+        return hunterMatchManager->getCurrentMatch()->getMatchId();
+    }
 
     virtual void setupDefaultMockExpectations() {
         ON_CALL(hunterPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
@@ -326,8 +331,6 @@ private:
 // ============================================
 
 class PacketParsingTests : public SingleDeviceTestFixture {
-public:
-    std::string getMatchId() const override { return "test-match-uuid-1234567890"; }
 };
 
 inline void packetParsingDrawResultInvokesCallback(PacketParsingTests* suite) {
@@ -434,8 +437,6 @@ inline void listenForMatchResultsIgnoresUnexpectedCommands(PacketParsingTests* s
 
 class CallbackChainTests : public SingleDeviceTestFixture {
 public:
-    std::string getMatchId() const override { return "callback-test-match-id-12345"; }
-
     void setupDefaultMockExpectations() override {
         SingleDeviceTestFixture::setupDefaultMockExpectations();
         ON_CALL(*device.mockDisplay, invalidateScreen()).WillByDefault(Return(device.mockDisplay));
@@ -502,8 +503,6 @@ inline void callbackChainButtonPressBroadcasts(CallbackChainTests* suite) {
 
 class StateFlowIntegrationTests : public SingleDeviceTestFixture {
 public:
-    std::string getMatchId() const override { return "flow-test-match-id-1234567890"; }
-
     void setupDefaultMockExpectations() override {
         SingleDeviceTestFixture::setupDefaultMockExpectations();
         ON_CALL(*device.mockDisplay, invalidateScreen()).WillByDefault(Return(device.mockDisplay));
@@ -703,8 +702,6 @@ inline void stateFlowDuelToLose(StateFlowIntegrationTests* suite) {
 // ============================================
 
 class TwoDeviceSimulationTests : public TwoDeviceTestFixture {
-public:
-    std::string getMatchId() const override { return "two-device-match-id-123456"; }
 };
 
 inline void twoDeviceHunterPressesFirstBothAgree(TwoDeviceSimulationTests* suite) {
@@ -780,7 +777,7 @@ inline void twoDeviceCloseRaceCorrectWinner(TwoDeviceSimulationTests* suite) {
 // simulating an output (OUTPUT_JACK) device and an input (INPUT_JACK) device.
 class HandshakeIntegrationTests : public testing::Test {
 public:
-    struct RawHSPacket { int sendingJack; int receivingJack; int command; } __attribute__((packed));
+    struct RawHSPacket { int sendingJack; int receivingJack; int deviceType; int command; } __attribute__((packed));
 
     void SetUp() override {
         ON_CALL(outputPeerComms, sendData(_, _, _, _))
@@ -926,6 +923,7 @@ inline void handshakeIgnoresUnexpectedCommands(HandshakeIntegrationTests* suite)
     HandshakeIntegrationTests::RawHSPacket pkt{
         static_cast<int>(SerialIdentifier::OUTPUT_JACK),
         static_cast<int>(SerialIdentifier::INPUT_JACK),
+        0,
         HSCommand::HS_COMMAND_COUNT  // one past the valid range
     };
     suite->deliverRawToInput(reinterpret_cast<const uint8_t*>(&pkt), sizeof(pkt));

--- a/test/test_core/quickdraw-tests.hpp
+++ b/test/test_core/quickdraw-tests.hpp
@@ -54,7 +54,8 @@ public:
         wirelessManager = new FakeQuickdrawWirelessManager();
         matchManager->initialize(player, &storage, wirelessManager);
 
-        idleState = new Idle(player, matchManager, &device.fakeRemoteDeviceCoordinator);
+        idleState = new Idle(player, matchManager, &device.fakeRemoteDeviceCoordinator,
+            []() { return 0; }, []() {}, []() { return false; });
 
         ON_CALL(*device.mockDisplay, invalidateScreen()).WillByDefault(Return(device.mockDisplay));
         ON_CALL(*device.mockDisplay, drawImage(_)).WillByDefault(Return(device.mockDisplay));
@@ -130,36 +131,6 @@ inline void idleButtonCallbacksRegisteredAndRemoved(IdleStateTests* suite) {
     EXPECT_CALL(*suite->device.mockSecondaryButton, removeButtonCallbacks()).Times(1);
 
     suite->idleState->onStateDismounted(&suite->device);
-}
-
-// Test: transitionToDuelCountdown stays false while match exists but ACK not yet received
-inline void idleDoesNotTransitionWithMatchButNotReady(IdleStateTests* suite) {
-    EXPECT_CALL(*suite->device.mockPrimaryButton, setButtonPress(_, _, _)).Times(1);
-    EXPECT_CALL(*suite->device.mockSecondaryButton, setButtonPress(_, _, _)).Times(1);
-    suite->idleState->onStateMounted(&suite->device);
-
-    // Hunter initiates but has not yet received MATCH_ID_ACK
-    uint8_t dummyMac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
-    suite->matchManager->initializeMatch(dummyMac);
-
-    ASSERT_TRUE(suite->matchManager->getCurrentMatch().has_value());
-    EXPECT_FALSE(suite->idleState->transitionToDuelCountdown());
-}
-
-// Test: transitionToDuelCountdown returns true once matchIsReady is set via the full handshake
-inline void idleTransitionsToDuelCountdownWhenMatchIsReady(IdleStateTests* suite) {
-    EXPECT_CALL(*suite->device.mockPrimaryButton, setButtonPress(_, _, _)).Times(1);
-    EXPECT_CALL(*suite->device.mockSecondaryButton, setButtonPress(_, _, _)).Times(1);
-    suite->idleState->onStateMounted(&suite->device);
-
-    // Hunter initiates match, then receives ACK from bounty
-    uint8_t dummyMac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
-    suite->matchManager->initializeMatch(dummyMac);
-    const char* matchId = suite->matchManager->getCurrentMatch()->getMatchId();
-    QuickdrawCommand ack(dummyMac, QDCommand::MATCH_ID_ACK, matchId, "boun", 0, false);
-    suite->matchManager->listenForMatchEvents(ack);
-
-    EXPECT_TRUE(suite->idleState->transitionToDuelCountdown());
 }
 
 // ============================================
@@ -350,11 +321,11 @@ inline void handshakeAppOutputJackTimeoutResetsToIdle(HandshakeStateTests* suite
     handshakeApp.onStateLoop(&suite->device);
 
     // Handshake timeout not yet reached
-    suite->fakeClock->advance(400);
+    suite->fakeClock->advance(1500);
     handshakeApp.onStateLoop(&suite->device);
 
-    // Past the 500ms handshakeTimeout → should reset to idle
-    suite->fakeClock->advance(200);
+    // Past the 2000ms handshakeTimeout → should reset to idle
+    suite->fakeClock->advance(1000);
     handshakeApp.onStateLoop(&suite->device);
 
     // After reset, HandshakeApp should be back in OutputIdleState (stateId == OUTPUT_IDLE_STATE)
@@ -854,12 +825,14 @@ inline void duelPushedGracePeriodExpiresTransitions(DuelStateTests* suite) {
 // Test: Opponent timeout means win
 inline void duelOpponentTimeoutMeansWin(DuelStateTests* suite) {
     suite->player->setIsHunter(true);
-    
+
     suite->matchManager->setReceivedButtonPush();
     suite->matchManager->setHunterDrawTime(200);
-    // Bounty draw time stays at 0 (never pressed)
-    suite->matchManager->setNeverPressed();
-    
+    // Opponent (bounty) sends NEVER_PRESSED
+    uint8_t dummyMac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+    QuickdrawCommand neverPressed(dummyMac, QDCommand::NEVER_PRESSED, suite->matchManager->getCurrentMatch()->getMatchId(), "boun", 5000, false);
+    suite->matchManager->listenForMatchEvents(neverPressed);
+
     EXPECT_TRUE(suite->matchManager->didWin());
 }
 
@@ -1013,10 +986,11 @@ inline void resultOpponentTimeoutMeansAutoWin(DuelResultTests* suite) {
     uint8_t dummyMac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
     suite->matchManager->initializeMatch(dummyMac);
     suite->matchManager->setHunterDrawTime(300);
-    suite->matchManager->setBountyDrawTime(0); // Bounty never pressed
     suite->matchManager->setReceivedButtonPush();
-    suite->matchManager->setNeverPressed();
-    
+    // Opponent (bounty) sends NEVER_PRESSED
+    QuickdrawCommand neverPressed(dummyMac, QDCommand::NEVER_PRESSED, suite->matchManager->getCurrentMatch()->getMatchId(), "boun", 5000, false);
+    suite->matchManager->listenForMatchEvents(neverPressed);
+
     EXPECT_TRUE(suite->matchManager->didWin());
 }
 
@@ -1177,7 +1151,8 @@ public:
 
 // Test: Idle state clears button callbacks on dismount
 inline void cleanupIdleClearsButtonCallbacks(StateCleanupTests* suite) {
-    Idle idleState(suite->player, suite->matchManager, &suite->device.fakeRemoteDeviceCoordinator);
+    Idle idleState(suite->player, suite->matchManager, &suite->device.fakeRemoteDeviceCoordinator,
+        []() { return 0; }, []() {}, []() { return false; });
     
     EXPECT_CALL(*suite->device.mockPrimaryButton, setButtonPress(_, _, _)).Times(1);
     EXPECT_CALL(*suite->device.mockSecondaryButton, setButtonPress(_, _, _)).Times(1);

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -15,6 +15,7 @@
 #include "quickdraw-tests.hpp"
 #include "quickdraw-integration-tests.hpp"
 #include "rdc-tests.hpp"
+#include "chain-tests.hpp"
 
 #if defined(ARDUINO)
 #include <Arduino.h>
@@ -753,13 +754,6 @@ TEST_F(IdleStateTests, buttonCallbacksRegisteredAndRemoved) {
     idleButtonCallbacksRegisteredAndRemoved(this);
 }
 
-TEST_F(IdleStateTests, doesNotTransitionWithMatchButNotReady) {
-    idleDoesNotTransitionWithMatchButNotReady(this);
-}
-
-TEST_F(IdleStateTests, transitionsToDuelCountdownWhenMatchIsReady) {
-    idleTransitionsToDuelCountdownWhenMatchIsReady(this);
-}
 
 // ============================================
 // QUICKDRAW STATE TESTS - HANDSHAKE
@@ -1208,6 +1202,134 @@ TEST_F(RDCTests, getPeerDeviceTypeReturnsUnknownWhenDisconnected) {
 
 TEST_F(RDCTests, getPeerDeviceTypeReturnsPDNAfterMacReceived) {
     rdcGetPeerDeviceTypeReturnsPDNAfterMacReceived(this);
+}
+
+// ============================================
+// CHAIN TESTS
+// ============================================
+
+TEST_F(MatchManagerBoostTests, boostTurnsLossIntoWin) {
+    boostTurnsLossIntoWin(this);
+}
+
+TEST_F(SupporterReadyTests, winFromChampion) {
+    supporterReadyWinFromChampion(this);
+}
+
+TEST_F(SupporterReadyTests, lossTransition) {
+    supporterReadyLossTransition(this);
+}
+
+TEST_F(SupporterReadyTests, buttonSendsConfirm) {
+    supporterReadyButtonSendsConfirm(this);
+}
+
+TEST_F(LoopDetectionTests, deregisterRemovesSingleSupporter) {
+    deregisterRemovesSingleSupporter(this);
+}
+
+TEST_F(LoopDetectionTests, confirmRejectedFromUnregisteredMac) {
+    confirmRejectedFromUnregisteredMac(this);
+}
+
+TEST_F(LoopDetectionTests, confirmFromRegisteredMacSucceeds) {
+    confirmFromRegisteredMacSucceeds(this);
+}
+
+TEST_F(LoopDetectionTests, rejectsInviteFromSupporterJackPeer) {
+    loopRejectsInviteFromSupporterJackPeer(this);
+}
+
+TEST_F(LoopDetectionTests, acceptsInviteFromNonSupporterJackPeer) {
+    loopAcceptsInviteFromNonSupporterJackPeer(this);
+}
+
+TEST_F(SupporterReadyTests, ringInviteNotForwardedToChampion) {
+    ringInviteNotForwardedToChampion(this);
+}
+
+TEST_F(SupporterReadyTests, inviteForwardedToNonChampionPeer) {
+    inviteForwardedToNonChampionPeer(this);
+}
+
+TEST_F(SupporterReadyTests, disconnectsFromChampion) {
+    supporterDisconnectsFromChampion(this);
+}
+
+TEST_F(LoopDetectionTests, supporterCountClearsOnDisconnect) {
+    supporterCountClearsOnDisconnect(this);
+}
+
+TEST_F(LoopDetectionTests, registerIsIdempotent) {
+    registerIsIdempotent(this);
+}
+
+TEST_F(LoopDetectionTests, confirmCappedAtSupporterCount) {
+    confirmCappedAtSupporterCount(this);
+}
+
+TEST_F(ChampionIdleLifecycleTests, sendsInviteWhenSupporterConnects) {
+    championSendsInviteWhenSupporterConnects(this);
+}
+
+TEST_F(ChampionIdleLifecycleTests, clearsChainWhenSupporterDisconnects) {
+    championClearsChainWhenSupporterDisconnects(this);
+}
+
+TEST_F(ChampionIdleLifecycleTests, ignoresInviteWithOwnMac) {
+    championIgnoresInviteWithOwnMacViaPacketHandler(this);
+}
+
+TEST_F(LoopDetectionTests, twoDeviceChainRegistrationFlow) {
+    twoDeviceChainRegistrationFlow(this);
+}
+
+TEST_F(ChampionIdleLifecycleTests, hunterIgnoresInviteFromBountyChampion) {
+    hunterIgnoresInviteFromBountyChampion(this);
+}
+
+TEST_F(ChampionIdleLifecycleTests, midChainDeviceSendsInviteDownstream) {
+    midChainDeviceSendsInviteDownstream(this);
+}
+
+TEST_F(ChampionIdleLifecycleTests, supporterDisappearsWithoutDeregister) {
+    supporterDisappearsWithoutDeregister(this);
+}
+
+TEST_F(ChampionIdleLifecycleTests, sameRolePeerTransitionsToSupporterPromptly) {
+    sameRolePeerTransitionsToSupporterPromptly(this);
+}
+
+TEST_F(LoopDetectionTests, twoSupportersOneDeregisters) {
+    twoSupportersOneDeregisters(this);
+}
+
+TEST_F(LoopDetectionTests, deregisterFromUnknownMacIsIgnored) {
+    deregisterFromUnknownMacIsIgnored(this);
+}
+
+TEST_F(LoopDetectionTests, supporterCanReregisterAfterDeregister) {
+    supporterCanReregisterAfterDeregister(this);
+}
+
+TEST_F(LoopDetectionTests, gameEventFromNonChampionIgnored) {
+    gameEventFromNonChampionIgnored(this);
+}
+
+TEST_F(LoopDetectionTests, noSupporterTransitionWithoutOpponent) {
+    noSupporterTransitionWithoutOpponent(this);
+}
+
+TEST_F(LoopDetectionTests, noSupporterTransitionWithOppositeRoleOpponent) {
+    noSupporterTransitionWithOppositeRoleOpponent(this);
+}
+
+TEST_F(ChampionIdleLifecycleTests, mergesWhenNewChampionInviteArrives) {
+    supporterMergesWhenNewChampionInviteArrives(this);
+}
+
+TEST_F(LoopDetectionTests, threeDeviceChainFormation) {
+    threeDeviceChainFormation(this);
 }
 
 // ============================================


### PR DESCRIPTION
The chain duel feature required some changes at layers below the game. 

The RDC handshake now exchanges game role (isHunter) alongside device type, so getPeerIsHunter is available to any game. This touched the handshake wireless manager, the serial MAC string format in both input/output idle states, and the connected state handler to accept late EXCHANGE_ID packets for role exchange. A new kTeamCommand packet type was added to the peer comms layer, with the handler registered in main.cpp rather than inside Quickdraw. The ESP-NOW driver gained a destination MAC filter to drop stray broadcast packets not addressed to the local device, and a send queue drain on deinit to prevent leaked allocations.