### PR TITLE
Create a thread safe drain queue for processing incoming ESP-NOW packets.

### DIFF
--- a/include/device/drivers/esp32-s3/esp-now-driver.hpp
+++ b/include/device/drivers/esp32-s3/esp-now-driver.hpp
@@ -152,8 +152,7 @@ public:
             bytesLeft -= thisBuffer;
         }
 
-        //Before we start filling the send queue, see if we'll need to start
-        //sending afterwards
+        xSemaphoreTake(sendMutex_, portMAX_DELAY);
         bool willNeedToStartSend = m_sendQueue.empty();
 
         //Build up each packet
@@ -185,8 +184,8 @@ public:
 
             bytesLeft -= thisBuffer;
         }
+        xSemaphoreGive(sendMutex_);
 
-        //Check if this is the first packet in the queue
         if(willNeedToStartSend)
         {
             SendFrontPkt();
@@ -266,7 +265,8 @@ private:
         m_pktHandlerCallbacks((int)PktType::kNumPacketTypes, std::pair<PacketCallback, void*>(nullptr, nullptr)),
         m_maxRetries(5),
         m_curRetries(0),
-        recvMutex_(xSemaphoreCreateMutex())
+        recvMutex_(xSemaphoreCreateMutex()),
+        sendMutex_(xSemaphoreCreateMutex())
     {
 
         wifi_promiscuous_filter_t filter = {
@@ -478,17 +478,20 @@ private:
             }
         }
 
-        if(!manager->m_sendQueue.empty())
-        {
-            //TODO: Catch error and do reporting and push to next pkt
-            manager->SendFrontPkt();
-        }
+        //TODO: Catch error and do reporting and push to next pkt
+        manager->SendFrontPkt();
     }
 
     //Attempt to send the next packet in send queue
     int SendFrontPkt() {
+        xSemaphoreTake(sendMutex_, portMAX_DELAY);
+        if(m_sendQueue.empty()) {
+            xSemaphoreGive(sendMutex_);
+            return 0;
+        }
         auto buffer = m_sendQueue.front();
-        
+        xSemaphoreGive(sendMutex_);
+
         //If this is the first packet in cluster, make sure the peer is registered
         auto* hdr = reinterpret_cast<DataPktHdr*>(buffer.ptr);
         if(hdr->idxInCluster == 0 && (memcmp(buffer.dstMac, PEER_BROADCAST_ADDR, ESP_NOW_ETH_ALEN) != 0))
@@ -506,8 +509,7 @@ private:
                     LOG_E("ENC", "ESPNOW Failed after max retries. Err: %i\n", err);
                     //TODO: Pop all packets in the current cluster?
                     MoveToNextSendPkt();
-                    if(!m_sendQueue.empty())
-                        SendFrontPkt();
+                    SendFrontPkt();
                     //TODO: Return correct error code
                     return -1;
                 }
@@ -519,8 +521,10 @@ private:
 
     //Free front packet in send queue and pop it from queue
     void MoveToNextSendPkt() {
+        xSemaphoreTake(sendMutex_, portMAX_DELAY);
         free(m_sendQueue.front().ptr);
         m_sendQueue.pop();
+        xSemaphoreGive(sendMutex_);
         m_curRetries = 0;
     }
 
@@ -558,6 +562,8 @@ private:
 
     SemaphoreHandle_t recvMutex_;
     std::queue<DeferredPacket> recvQueue_;
+
+    SemaphoreHandle_t sendMutex_;
 
     //Storage for packet handler callbacks and their user args
     std::vector<std::pair<PacketCallback, void*>> m_pktHandlerCallbacks;

--- a/include/device/drivers/esp32-s3/esp-now-driver.hpp
+++ b/include/device/drivers/esp32-s3/esp-now-driver.hpp
@@ -45,7 +45,20 @@ public:
     // === PEER COMMS INTERFACE === //
 
     void exec() override {
-        // ESP-NOW uses interrupt-driven callbacks, no polling needed
+        std::queue<DeferredPacket> pending;
+        xSemaphoreTake(recvMutex_, portMAX_DELAY);
+        std::swap(pending, recvQueue_);
+        xSemaphoreGive(recvMutex_);
+
+        while (!pending.empty()) {
+            auto& pkt = pending.front();
+            PacketCallback cb = m_pktHandlerCallbacks[(int)pkt.type].first;
+            if (cb) {
+                cb(pkt.srcMac, pkt.data.data(), pkt.data.size(),
+                   m_pktHandlerCallbacks[(int)pkt.type].second);
+            }
+            pending.pop();
+        }
     }
 
     void connect() override {
@@ -228,6 +241,12 @@ private:
     static EspNowManager* instance;
 
     // Struct definitions must come before methods that use them
+    struct DeferredPacket {
+        PktType type;
+        uint8_t srcMac[6];
+        std::vector<uint8_t> data;
+    };
+
     struct DataSendBuffer
     {
         uint8_t dstMac[6];
@@ -246,7 +265,8 @@ private:
         PeerCommsDriverInterface(name),
         m_pktHandlerCallbacks((int)PktType::kNumPacketTypes, std::pair<PacketCallback, void*>(nullptr, nullptr)),
         m_maxRetries(5),
-        m_curRetries(0)
+        m_curRetries(0),
+        recvMutex_(xSemaphoreCreateMutex())
     {
 
         wifi_promiscuous_filter_t filter = {
@@ -536,10 +556,12 @@ private:
         return 0;
     }
 
+    SemaphoreHandle_t recvMutex_;
+    std::queue<DeferredPacket> recvQueue_;
+
     //Storage for packet handler callbacks and their user args
     std::vector<std::pair<PacketCallback, void*>> m_pktHandlerCallbacks;
 
-    //Handle received packet of a certain type
     void HandlePktCallback(const PktType packetType, const uint8_t* srcMacAddr, const uint8_t* pktData, const size_t pktLen) {
         if((int)packetType >= (int)PktType::kNumPacketTypes)
         {
@@ -547,11 +569,14 @@ private:
             return;
         }
 
-        PacketCallback callback = m_pktHandlerCallbacks[(int)packetType].first;
-        if(callback)
-        {
-            callback(srcMacAddr, pktData, pktLen, m_pktHandlerCallbacks[(int)packetType].second);
-        }
+        DeferredPacket pkt;
+        pkt.type = packetType;
+        memcpy(pkt.srcMac, srcMacAddr, 6);
+        pkt.data.assign(pktData, pktData + pktLen);
+
+        xSemaphoreTake(recvMutex_, portMAX_DELAY);
+        recvQueue_.push(std::move(pkt));
+        xSemaphoreGive(recvMutex_);
     }
 
     uint8_t* getMacAddress() override {

--- a/include/device/drivers/native/native-peer-comms-driver.hpp
+++ b/include/device/drivers/native/native-peer-comms-driver.hpp
@@ -4,6 +4,8 @@
 #include "device/drivers/native/native-peer-broker.hpp"
 #include <map>
 #include <deque>
+#include <mutex>
+#include <queue>
 #include <vector>
 #include <cstring>
 
@@ -34,7 +36,21 @@ public:
     }
 
     void exec() override {
-        // Packet delivery handled by broker calling receivePacket directly
+        std::queue<DeferredPacket> pending;
+        {
+            std::lock_guard<std::mutex> lock(recvMutex_);
+            std::swap(pending, recvQueue_);
+        }
+
+        while (!pending.empty()) {
+            auto& pkt = pending.front();
+            auto it = handlers_.find(pkt.type);
+            if (it != handlers_.end()) {
+                it->second.callback(pkt.srcMac, pkt.data.data(),
+                                    pkt.data.size(), it->second.context);
+            }
+            pending.pop();
+        }
     }
 
     void connect() override {
@@ -109,15 +125,14 @@ public:
 
     /**
      * Called by the broker to deliver a packet to this peer.
+     * Enqueues the packet for processing on the next exec() call.
      */
     void receivePacket(const uint8_t* srcMac, PktType packetType, 
                        const uint8_t* data, size_t length) {
-        // Only process packets when connected
         if (peerCommsState_ != PeerCommsState::CONNECTED) {
             return;
         }
-        
-        // Track received packet
+
         PacketHistoryEntry entry;
         entry.isSent = false;
         entry.srcMac = macToString(srcMac);
@@ -125,11 +140,14 @@ public:
         entry.packetType = packetType;
         entry.length = length;
         addToHistory(entry);
-        
-        auto it = handlers_.find(packetType);
-        if (it != handlers_.end()) {
-            it->second.callback(srcMac, data, length, it->second.context);
-        }
+
+        DeferredPacket pkt;
+        pkt.type = packetType;
+        memcpy(pkt.srcMac, srcMac, 6);
+        pkt.data.assign(data, data + length);
+
+        std::lock_guard<std::mutex> lock(recvMutex_);
+        recvQueue_.push(std::move(pkt));
     }
 
     /**
@@ -163,7 +181,15 @@ private:
         void* context;
     };
 
+    struct DeferredPacket {
+        PktType type;
+        uint8_t srcMac[6];
+        std::vector<uint8_t> data;
+    };
+
     std::map<PktType, HandlerEntry> handlers_;
+    std::mutex recvMutex_;
+    std::queue<DeferredPacket> recvQueue_;
     uint8_t macAddress_[6];
     PeerCommsState peerCommsState_ = PeerCommsState::DISCONNECTED;
     std::deque<PacketHistoryEntry> packetHistory_;

--- a/platformio.ini
+++ b/platformio.ini
@@ -104,6 +104,25 @@ lib_deps =
 build_unflags = -Werror
 
 ; ========================================
+; NATIVE TSAN ENVIRONMENT (Thread / race detection)
+; ========================================
+; Run in WSL: pio test -e native_tsan -f test_core --filter "*MatchManagerConcurrent*"
+; Enables ThreadSanitizer.
+; Any data races between the simulated WiFi task and the main loop are
+; reported inline. A clean run (no TSan output) confirms the queue fix works.
+
+[env:native_tsan]
+extends = env:native
+build_flags =
+    -std=c++17
+    -DNATIVE_BUILD
+    -fsanitize=thread
+    -fno-omit-frame-pointer
+    -g
+    -O1
+build_unflags = -Werror
+
+; ========================================
 ; NATIVE ASAN ENVIRONMENT (Memory / leak detection)
 ; ========================================
 ; Run in WSL: pio test -e native_asan

--- a/test/test_cli/cli-broker-tests.hpp
+++ b/test/test_cli/cli-broker-tests.hpp
@@ -131,9 +131,10 @@ void peerBrokerUnicastDelivery(NativePeerBrokerTestSuite* suite) {
     suite->peerA_->sendData(suite->peerB_->getMacAddress(), PktType::kQuickdrawCommand,
                            testData, sizeof(testData));
     
-    // Deliver pending packets (broker is asynchronous)
+    // Deliver pending packets, then drain the receiving driver's queue
     suite->broker_->deliverPackets();
-    
+    suite->peerB_->exec();
+
     ASSERT_EQ(suite->receivedPackets_, 1);
 }
 
@@ -150,9 +151,11 @@ void peerBrokerBroadcastExcludesSender(NativePeerBrokerTestSuite* suite) {
     uint8_t testData[] = {0x01};
     suite->peerA_->sendData(broadcastMac, PktType::kQuickdrawCommand, testData, 1);
     
-    // Deliver pending packets (broker is asynchronous)
+    // Deliver pending packets, then drain the receiving driver's queue
     suite->broker_->deliverPackets();
-    
+    suite->peerA_->exec();
+    suite->peerB_->exec();
+
     // B should receive, but A should not receive its own broadcast
     ASSERT_GE(suite->receivedPackets_, 1);
 }
@@ -169,9 +172,10 @@ void peerBrokerPeerRegistration(NativePeerBrokerTestSuite* suite) {
     suite->peerA_->sendData(suite->peerB_->getMacAddress(), PktType::kQuickdrawCommand,
                            testData, sizeof(testData));
     
-    // Deliver pending packets (broker is asynchronous)
+    // Deliver pending packets, then drain the receiving driver's queue
     suite->broker_->deliverPackets();
-    
+    suite->peerB_->exec();
+
     ASSERT_EQ(suite->receivedPackets_, 1);
 }
 

--- a/test/test_cli/native-driver-tests.hpp
+++ b/test/test_cli/native-driver-tests.hpp
@@ -202,13 +202,15 @@ void peerCommsHandlerRegistration(NativePeerCommsDriverTestSuite* suite) {
     uint8_t srcMac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
     uint8_t data[] = {0x01};
     suite->driver_->receivePacket(srcMac, PktType::kQuickdrawCommand, data, 1);
-    
+    suite->driver_->exec();  // Drain queue to invoke handler
+
     ASSERT_TRUE(handlerCalled);
     
     // Clear handler
     handlerCalled = false;
     suite->driver_->clearPacketHandler(PktType::kQuickdrawCommand);
     suite->driver_->receivePacket(srcMac, PktType::kQuickdrawCommand, data, 1);
+    suite->driver_->exec();  // Drain queue — cleared handler must not fire
     ASSERT_FALSE(handlerCalled);  // Should not be called after clear
 }
 

--- a/test/test_core/match-manager-concurrent.hpp
+++ b/test/test_core/match-manager-concurrent.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include "device/drivers/native/native-peer-comms-driver.hpp"
+#include "game/match-manager.hpp"
+#include "game/player.hpp"
+#include "wireless/quickdraw-wireless-manager.hpp"
+#include "utils/simple-timer.hpp"
+#include "device-mock.hpp"
+#include "utility-tests.hpp"
+
+// Verifies that the queue-based deferral in NativePeerCommsDriver eliminates the
+// race between the simulated WiFi task (receivePacket) and the main loop (exec +
+// MatchManager reads).
+//
+// Before the fix: receivePacket() called listenForMatchEvents() directly, racing
+// with the main loop reading isMatchReady() / getHunterDrawTime() etc.
+//
+// After the fix: receivePacket() only enqueues; exec() drains on the caller's
+// thread. MatchManager is therefore only ever touched from a single thread.
+//
+// Run under TSan to confirm zero race reports:
+//   pio test -e native_tsan -f test_core --filter "*MatchManagerConcurrent*"
+inline void matchManagerConcurrentDriverVsReader() {
+    FakePlatformClock clock;
+    clock.setTime(1000);
+    SimpleTimer::setPlatformClock(&clock);
+
+    // Declare dependencies before MatchManager so they outlive it.
+    // C++ destroys locals in reverse declaration order, so anything mm's
+    // destructor touches (storage->end(), etc.) must be declared earlier.
+    MockStorage storage;
+    Player player;
+    char playerId[] = "test";
+    player.setUserID(playerId);
+    player.setIsHunter(false);
+    FakeQuickdrawWirelessManager wireless;
+    FakeRemoteDeviceCoordinator rdc;
+    const uint8_t peerMac[6] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+    rdc.setPeerMac(SerialIdentifier::INPUT_JACK, peerMac);
+
+    NativePeerCommsDriver driver("tsan-test-driver");
+    driver.initialize();
+    driver.connect();
+
+    MatchManager mm;
+    mm.initialize(&player, &storage, &wireless);
+    mm.setRemoteDeviceCoordinator(&rdc);
+    mm.clearCurrentMatch();
+
+    // Handler is invoked by exec() on the main thread — never by the WiFi thread.
+    driver.setPacketHandler(
+        PktType::kQuickdrawCommand,
+        [](const uint8_t* src, const uint8_t* data, size_t len, void* ctx) {
+            if (len < sizeof(QuickdrawPacket)) return;
+            auto* matchMgr = static_cast<MatchManager*>(ctx);
+            const auto* pkt = reinterpret_cast<const QuickdrawPacket*>(data);
+            QuickdrawCommand cmd(src,
+                                 static_cast<QDCommand>(pkt->command),
+                                 pkt->matchId, pkt->playerId,
+                                 pkt->playerDrawTime, pkt->isHunter);
+            matchMgr->listenForMatchEvents(cmd);
+        },
+        &mm
+    );
+
+    std::atomic<bool> running{true};
+
+    // Simulates the WiFi task: only enqueues after the fix — never touches MatchManager.
+    std::thread wifiTask([&]() {
+        int iter = 0;
+        while (running.load(std::memory_order_relaxed)) {
+            char matchId[37] = {};
+            snprintf(matchId, sizeof(matchId), "match-%08d", iter++);
+
+            QuickdrawPacket pkt = {};
+            strncpy(pkt.matchId,  matchId, sizeof(pkt.matchId) - 1);
+            strncpy(pkt.playerId, "hunt",  sizeof(pkt.playerId) - 1);
+            pkt.command        = static_cast<int>(QDCommand::SEND_MATCH_ID);
+            pkt.isHunter       = true;
+            pkt.playerDrawTime = 0;
+
+            driver.receivePacket(peerMac, PktType::kQuickdrawCommand,
+                                 reinterpret_cast<const uint8_t*>(&pkt),
+                                 sizeof(pkt));
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    });
+
+    // Simulates the main loop: drains the queue (which calls listenForMatchEvents
+    // on this thread), then reads MatchManager state — all on one thread.
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+    volatile int sideEffect = 0;
+    while (std::chrono::steady_clock::now() < deadline) {
+        driver.exec();
+        sideEffect += static_cast<int>(mm.isMatchReady());
+        sideEffect += static_cast<int>(mm.getHasReceivedDrawResult());
+        sideEffect += static_cast<int>(mm.getHasPressedButton());
+        if (mm.getCurrentMatch().has_value()) {
+            sideEffect += static_cast<int>(mm.getCurrentMatch()->getHunterDrawTime());
+            sideEffect += static_cast<int>(mm.getCurrentMatch()->getBountyDrawTime());
+        }
+        std::this_thread::yield();
+    }
+    (void)sideEffect;
+
+    running.store(false);
+    wifiTask.join();
+    mm.clearCurrentMatch();
+    SimpleTimer::setPlatformClock(nullptr);
+
+    SUCCEED() << "No TSan races expected: MatchManager is only accessed from exec() on the main thread";
+}

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -19,6 +19,7 @@
 #include "chain-duel-manager-tests.hpp"
 #include "chain-duel-multi-device-fixture.hpp"
 #include "peer-comms-types-tests.hpp"
+#include "match-manager-concurrent.hpp"
 
 #if defined(ARDUINO)
 #include <Arduino.h>
@@ -775,6 +776,14 @@ TEST_F(MatchManagerTestSuite, clearMatchResetsMatchIsReadyFlag) {
 
 TEST_F(MatchManagerTestSuite, roleMismatchClearsInitiatorMatch) {
     matchManagerRoleMismatchClearsInitiatorMatch(matchManager, player);
+}
+
+// ============================================
+// MATCH MANAGER CONCURRENCY TESTS (TSan)
+// ============================================
+
+TEST(MatchManagerConcurrent, driverExecSerializesMatchManagerAccess) {
+    matchManagerConcurrentDriverVsReader();
 }
 
 // ============================================


### PR DESCRIPTION
Closes Issue #111 .

ESP-NOW explicitly runs on Core 0, while the core application runs on Core 1. This results in possible race conditions.

The updated implementation adds a receiveQueue to the esp-now-driver, which is guarded with the recvMutex semaphore.

This does add a single loop iteration delay between packet receive and consumption, which shouldn't negatively impact game experience.