### PR TITLE
Peer-graph wire library: crc16, graph, codec

### DIFF
--- a/include/device/mac-types.hpp
+++ b/include/device/mac-types.hpp
@@ -3,8 +3,10 @@
 #include <array>
 #include <cstdint>
 
-// Shared 6-byte MAC address type and peer-validity helpers, used by the
-// peer-graph protocol, the RDC, and their tests.
+// 6-byte MAC address type and peer-validity helpers for the peer-graph protocol
+// and its tests. The RDC and ESP-NOW layers still spell this type as a raw
+// std::array<uint8_t, 6> / uint8_t[6]; converging them onto net::Mac is left to
+// the peer-graph wire-up rather than done speculatively here.
 namespace net {
 using Mac = std::array<uint8_t, 6>;
 

--- a/include/device/mac-types.hpp
+++ b/include/device/mac-types.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+// Shared 6-byte MAC address type and peer-validity helpers, used by the
+// peer-graph protocol, the RDC, and their tests.
+namespace net {
+using Mac = std::array<uint8_t, 6>;
+
+inline bool isAllZeroMac(const Mac& m) {
+    for (uint8_t b : m) if (b != 0x00) return false;
+    return true;
+}
+
+inline bool isBroadcastMac(const Mac& m) {
+    for (uint8_t b : m) if (b != 0xFF) return false;
+    return true;
+}
+
+// Anti-poisoning: reject all-zero and broadcast MACs as direct peers.
+inline bool isValidPeerMac(const Mac& m) {
+    return !isAllZeroMac(m) && !isBroadcastMac(m);
+}
+}

--- a/include/device/peer-graph-codec.hpp
+++ b/include/device/peer-graph-codec.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "device/peer-graph.hpp"
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+// Wire codec for the peer-graph protocol. Two framed opcodes share a common
+// framing (preamble 0xAA 0x55, opcode, payload, CRC-16):
+//   HELLO  (0x00): 1-hop direct-peer announcement, payload = source mac[6] +
+//                  deviceType[1]. deviceType is a fixed hardware property
+//                  (PDN/FDN) the game layer reads to pick the interaction
+//                  (duel vs symbol); carried here because it is a device
+//                  concern exchanged at connect, like the MAC.
+//   BEACON (0x01): flooded topology frame, payload = source + inPeer + outPeer
+namespace peer_graph {
+
+constexpr uint8_t kOpHello = 0x00;
+constexpr uint8_t kOpBeacon = 0x01;
+
+struct HelloRecord {
+    net::Mac source{};
+    uint8_t deviceType = 0;
+};
+
+std::vector<uint8_t> encodeHello(const net::Mac& source, uint8_t deviceType);
+std::optional<HelloRecord> decodeHello(const std::vector<uint8_t>& frame);
+
+std::vector<uint8_t> encodeBeacon(const BeaconRecord& beacon);
+std::optional<BeaconRecord> decodeBeacon(const std::vector<uint8_t>& frame);
+
+}  // namespace peer_graph

--- a/include/device/peer-graph.hpp
+++ b/include/device/peer-graph.hpp
@@ -7,8 +7,9 @@
 #include <vector>
 
 // One device's direct-peer view, as carried in a BEACON frame. An all-zero
-// peer MAC means "no peer on that jack". Equality is by full content so the
-// flood layer can dedup re-received beacons without sequence numbers.
+// peer MAC means "no peer on that jack". Equality is by full content, so the
+// flood layer can dedup a re-received beacon against the cached one; freshness
+// after a transient is restored by the 1Hz BEACON backstop, not a seq number.
 struct BeaconRecord {
     net::Mac source{};
     net::Mac inPeer{};
@@ -31,7 +32,10 @@ public:
 
     // Cache a received beacon. Returns true if the cache changed (caller floods
     // the beacon onward when so). A beacon identical to the cached one for its
-    // source returns false — that is the flood-dedup signal.
+    // source returns false — that is the flood-dedup signal. A self-sourced
+    // beacon (source == selfMac_) is always dropped: self is the authority on its
+    // own peers via setSelfPeers, so re-accepting one flooded back around a ring
+    // would only cost an extra ring trip and reset the stability window.
     bool acceptBeacon(const BeaconRecord& beacon, unsigned long nowMs);
 
     std::optional<BeaconRecord> getBeacon(const net::Mac& source) const;
@@ -49,8 +53,9 @@ public:
     // back through self. In a linear chain, removing self splits it into two
     // sides; passing the peer on one jack counts only that side. firstHop
     // itself counts as 1 even before its beacon arrives (it is a confirmed
-    // direct peer); further hops require mutual edges. Returns 0 if firstHop
-    // is absent or is self.
+    // direct peer); further hops require mutual edges. Returns 0 if firstHop is
+    // absent, is self, or is not a MAC self currently claims on a jack — the
+    // count must not vouch for a node self has no live link to.
     size_t countReachableExcludingSelf(const net::Mac& firstHop) const;
 
     bool isTopologyStable(unsigned long nowMs) const;
@@ -63,7 +68,10 @@ private:
     net::Mac selfInPeer_{};
     net::Mac selfOutPeer_{};
     std::map<net::Mac, BeaconRecord> beaconsBySource_;
-    unsigned long lastGraphChangeMs_ = 0;
+    // Unset until the first change is recorded. A graph that has never changed
+    // has no settled topology to report, so it reads as unstable rather than
+    // stable-since-time-zero — the absence of a timestamp says so directly.
+    std::optional<unsigned long> lastGraphChangeMs_;
     GraphChangedCallback onGraphChanged_;
 
     static constexpr unsigned long kTopologyStabilityMs = 200;

--- a/include/device/peer-graph.hpp
+++ b/include/device/peer-graph.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "device/mac-types.hpp"  // net::Mac
+#include <functional>
+#include <map>
+#include <optional>
+#include <vector>
+
+// One device's direct-peer view, as carried in a BEACON frame. An all-zero
+// peer MAC means "no peer on that jack". Equality is by full content so the
+// flood layer can dedup re-received beacons without sequence numbers.
+struct BeaconRecord {
+    net::Mac source{};
+    net::Mac inPeer{};
+    net::Mac outPeer{};
+
+    bool operator==(const BeaconRecord& other) const {
+        return source == other.source && inPeer == other.inPeer && outPeer == other.outPeer;
+    }
+    bool operator!=(const BeaconRecord& other) const { return !(*this == other); }
+};
+
+// Derives ring topology from a cache of per-source beacons using the
+// mutual-consistency rule: an edge (A <-> B) exists only when both A's and B's
+// latest beacons claim each other. Loop detection and membership are computed
+// on demand from that cache; there is no separately-maintained roster.
+class PeerGraph {
+public:
+    void setSelfMac(const net::Mac& mac);
+    const net::Mac& getSelfMac() const { return selfMac_; }
+
+    // Cache a received beacon. Returns true if the cache changed (caller floods
+    // the beacon onward when so). A beacon identical to the cached one for its
+    // source returns false — that is the flood-dedup signal.
+    bool acceptBeacon(const BeaconRecord& beacon, unsigned long nowMs);
+
+    std::optional<BeaconRecord> getBeacon(const net::Mac& source) const;
+
+    // Update this device's own peer slots (from macPeer state). Triggers a
+    // graph-change notification when the slots actually change.
+    void setSelfPeers(const net::Mac& inPeer,
+                      const net::Mac& outPeer,
+                      unsigned long nowMs);
+
+    bool isInLoop() const;
+    std::vector<net::Mac> getChainMembers() const;
+
+    // Count of members reachable starting through `firstHop`, never crossing
+    // back through self. In a linear chain, removing self splits it into two
+    // sides; passing the peer on one jack counts only that side. firstHop
+    // itself counts as 1 even before its beacon arrives (it is a confirmed
+    // direct peer); further hops require mutual edges. Returns 0 if firstHop
+    // is absent or is self.
+    size_t countReachableExcludingSelf(const net::Mac& firstHop) const;
+
+    bool isTopologyStable(unsigned long nowMs) const;
+
+    using GraphChangedCallback = std::function<void()>;
+    void setOnGraphChanged(GraphChangedCallback cb) { onGraphChanged_ = std::move(cb); }
+
+private:
+    net::Mac selfMac_{};
+    net::Mac selfInPeer_{};
+    net::Mac selfOutPeer_{};
+    std::map<net::Mac, BeaconRecord> beaconsBySource_;
+    unsigned long lastGraphChangeMs_ = 0;
+    GraphChangedCallback onGraphChanged_;
+
+    static constexpr unsigned long kTopologyStabilityMs = 200;
+
+    bool hasMutualEdge(const net::Mac& a, const net::Mac& b) const;
+
+    // Nodes reachable from `start` by walking mutual edges, never crossing any
+    // node in `blocked` and never revisiting. `start` is always included in the
+    // result. The membership/count/loop queries differ only in their seed and
+    // what they tally, so they all express their walk through this.
+    std::vector<net::Mac> reachableFrom(
+        const net::Mac& start, std::initializer_list<net::Mac> blocked) const;
+};

--- a/include/wireless/crc16.hpp
+++ b/include/wireless/crc16.hpp
@@ -3,12 +3,11 @@
 #include <cstddef>
 
 // CRC-16/CCITT XMODEM: poly 0x1021, init 0x0000, no reflection, no xorout.
-// Generic byte-span checksum; today its only caller is serial UART framing
-// (the ESP-NOW path relies on the radio's hardware FCS instead).
-
-// Fold one more span into a running CRC. Lets a caller checksum several
-// non-contiguous spans (e.g. opcode then payload) without concatenating them.
-inline uint16_t crc16Update(uint16_t crc, const uint8_t* data, size_t len) {
+// Generic byte-span checksum; its only caller is the peer-graph wire codec,
+// which CRCs HELLO/BEACON serial frames (the ESP-NOW path relies on the radio's
+// hardware FCS instead).
+inline uint16_t crc16(const uint8_t* data, size_t len) {
+    uint16_t crc = 0x0000;
     for (size_t i = 0; i < len; ++i) {
         crc ^= static_cast<uint16_t>(data[i]) << 8;
         for (int j = 0; j < 8; ++j) {
@@ -16,8 +15,4 @@ inline uint16_t crc16Update(uint16_t crc, const uint8_t* data, size_t len) {
         }
     }
     return crc;
-}
-
-inline uint16_t crc16(const uint8_t* data, size_t len) {
-    return crc16Update(0x0000, data, len);
 }

--- a/include/wireless/crc16.hpp
+++ b/include/wireless/crc16.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <cstdint>
+#include <cstddef>
+
+// CRC-16/CCITT XMODEM: poly 0x1021, init 0x0000, no reflection, no xorout.
+// Generic byte-span checksum; today its only caller is serial UART framing
+// (the ESP-NOW path relies on the radio's hardware FCS instead).
+
+// Fold one more span into a running CRC. Lets a caller checksum several
+// non-contiguous spans (e.g. opcode then payload) without concatenating them.
+inline uint16_t crc16Update(uint16_t crc, const uint8_t* data, size_t len) {
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= static_cast<uint16_t>(data[i]) << 8;
+        for (int j = 0; j < 8; ++j) {
+            crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : (crc << 1);
+        }
+    }
+    return crc;
+}
+
+inline uint16_t crc16(const uint8_t* data, size_t len) {
+    return crc16Update(0x0000, data, len);
+}

--- a/src/device/peer-graph-codec.cpp
+++ b/src/device/peer-graph-codec.cpp
@@ -1,0 +1,86 @@
+#include "device/peer-graph-codec.hpp"
+
+#include "wireless/crc16.hpp"
+#include <algorithm>
+
+namespace peer_graph {
+
+namespace {
+
+constexpr size_t kPreambleBytes = 2;
+constexpr size_t kCrcBytes = 2;
+constexpr uint8_t kPreamble0 = 0xAA;
+constexpr uint8_t kPreamble1 = 0x55;
+
+std::vector<uint8_t> encodeFramed(uint8_t opcode, const std::vector<uint8_t>& payload) {
+    std::vector<uint8_t> body;
+    body.reserve(1 + payload.size());
+    body.push_back(opcode);
+    body.insert(body.end(), payload.begin(), payload.end());
+    const uint16_t crc = crc16(body.data(), body.size());
+
+    std::vector<uint8_t> frame;
+    frame.reserve(kPreambleBytes + body.size() + kCrcBytes);
+    frame.push_back(kPreamble0);
+    frame.push_back(kPreamble1);
+    frame.insert(frame.end(), body.begin(), body.end());
+    frame.push_back(static_cast<uint8_t>(crc >> 8));
+    frame.push_back(static_cast<uint8_t>(crc & 0xFF));
+    return frame;
+}
+
+// Validate framing + opcode + CRC. Returns a pointer to the payload start and
+// its length via out-params, or false on any mismatch.
+bool validateFrame(const std::vector<uint8_t>& frame, uint8_t expectedOpcode,
+                   size_t expectedPayloadLen, const uint8_t** payloadOut) {
+    const size_t expectedFrameLen =
+        kPreambleBytes + 1 /*opcode*/ + expectedPayloadLen + kCrcBytes;
+    if (frame.size() != expectedFrameLen) return false;
+    if (frame[0] != kPreamble0 || frame[1] != kPreamble1) return false;
+    if (frame[2] != expectedOpcode) return false;
+    const size_t bodyLen = 1 + expectedPayloadLen;
+    const uint16_t got =
+        (static_cast<uint16_t>(frame[2 + bodyLen]) << 8) | frame[2 + bodyLen + 1];
+    const uint16_t expected = crc16(&frame[2], bodyLen);
+    if (got != expected) return false;
+    *payloadOut = &frame[3];
+    return true;
+}
+
+}  // namespace
+
+std::vector<uint8_t> encodeHello(const net::Mac& source, uint8_t deviceType) {
+    std::vector<uint8_t> payload(source.begin(), source.end());
+    payload.push_back(deviceType);
+    return encodeFramed(kOpHello, payload);
+}
+
+std::optional<HelloRecord> decodeHello(const std::vector<uint8_t>& frame) {
+    const uint8_t* payload = nullptr;
+    if (!validateFrame(frame, kOpHello, 7, &payload)) return std::nullopt;
+    HelloRecord rec;
+    std::copy_n(payload, 6, rec.source.begin());
+    rec.deviceType = payload[6];
+    return rec;
+}
+
+std::vector<uint8_t> encodeBeacon(const BeaconRecord& beacon) {
+    std::vector<uint8_t> payload;
+    payload.reserve(18);
+    payload.insert(payload.end(), beacon.source.begin(), beacon.source.end());
+    payload.insert(payload.end(), beacon.inPeer.begin(), beacon.inPeer.end());
+    payload.insert(payload.end(), beacon.outPeer.begin(), beacon.outPeer.end());
+    return encodeFramed(kOpBeacon, payload);
+}
+
+std::optional<BeaconRecord> decodeBeacon(const std::vector<uint8_t>& frame) {
+    const uint8_t* payload = nullptr;
+    if (!validateFrame(frame, kOpBeacon, 18, &payload)) return std::nullopt;
+    BeaconRecord b;
+    std::copy_n(payload, 6, b.source.begin());
+    std::copy_n(payload + 6, 6, b.inPeer.begin());
+    std::copy_n(payload + 12, 6, b.outPeer.begin());
+    return b;
+}
+
+}  // namespace peer_graph

--- a/src/device/peer-graph-codec.cpp
+++ b/src/device/peer-graph-codec.cpp
@@ -2,6 +2,7 @@
 
 #include "wireless/crc16.hpp"
 #include <algorithm>
+#include <array>
 
 namespace peer_graph {
 
@@ -12,18 +13,17 @@ constexpr size_t kCrcBytes = 2;
 constexpr uint8_t kPreamble0 = 0xAA;
 constexpr uint8_t kPreamble1 = 0x55;
 
-std::vector<uint8_t> encodeFramed(uint8_t opcode, const std::vector<uint8_t>& payload) {
-    std::vector<uint8_t> body;
-    body.reserve(1 + payload.size());
-    body.push_back(opcode);
-    body.insert(body.end(), payload.begin(), payload.end());
-    const uint16_t crc = crc16(body.data(), body.size());
-
+// Assemble the whole frame in one buffer: preamble, opcode, payload, CRC. The
+// opcode+payload sit contiguously at frame[2..], so the CRC is taken over that
+// slice in place — no separate body buffer to keep byte-aligned with decode.
+std::vector<uint8_t> encodeFramed(uint8_t opcode, const uint8_t* payload, size_t payloadLen) {
     std::vector<uint8_t> frame;
-    frame.reserve(kPreambleBytes + body.size() + kCrcBytes);
+    frame.reserve(kPreambleBytes + 1 + payloadLen + kCrcBytes);
     frame.push_back(kPreamble0);
     frame.push_back(kPreamble1);
-    frame.insert(frame.end(), body.begin(), body.end());
+    frame.push_back(opcode);
+    frame.insert(frame.end(), payload, payload + payloadLen);
+    const uint16_t crc = crc16(&frame[2], 1 + payloadLen);
     frame.push_back(static_cast<uint8_t>(crc >> 8));
     frame.push_back(static_cast<uint8_t>(crc & 0xFF));
     return frame;
@@ -50,9 +50,10 @@ bool validateFrame(const std::vector<uint8_t>& frame, uint8_t expectedOpcode,
 }  // namespace
 
 std::vector<uint8_t> encodeHello(const net::Mac& source, uint8_t deviceType) {
-    std::vector<uint8_t> payload(source.begin(), source.end());
-    payload.push_back(deviceType);
-    return encodeFramed(kOpHello, payload);
+    std::array<uint8_t, 7> payload;
+    std::copy(source.begin(), source.end(), payload.begin());
+    payload[6] = deviceType;
+    return encodeFramed(kOpHello, payload.data(), payload.size());
 }
 
 std::optional<HelloRecord> decodeHello(const std::vector<uint8_t>& frame) {
@@ -65,12 +66,11 @@ std::optional<HelloRecord> decodeHello(const std::vector<uint8_t>& frame) {
 }
 
 std::vector<uint8_t> encodeBeacon(const BeaconRecord& beacon) {
-    std::vector<uint8_t> payload;
-    payload.reserve(18);
-    payload.insert(payload.end(), beacon.source.begin(), beacon.source.end());
-    payload.insert(payload.end(), beacon.inPeer.begin(), beacon.inPeer.end());
-    payload.insert(payload.end(), beacon.outPeer.begin(), beacon.outPeer.end());
-    return encodeFramed(kOpBeacon, payload);
+    std::array<uint8_t, 18> payload;
+    std::copy(beacon.source.begin(), beacon.source.end(), payload.begin());
+    std::copy(beacon.inPeer.begin(), beacon.inPeer.end(), payload.begin() + 6);
+    std::copy(beacon.outPeer.begin(), beacon.outPeer.end(), payload.begin() + 12);
+    return encodeFramed(kOpBeacon, payload.data(), payload.size());
 }
 
 std::optional<BeaconRecord> decodeBeacon(const std::vector<uint8_t>& frame) {

--- a/src/device/peer-graph.cpp
+++ b/src/device/peer-graph.cpp
@@ -13,10 +13,13 @@ bool PeerGraph::acceptBeacon(const BeaconRecord& beacon, unsigned long nowMs) {
     // jack, fabricating a false loop and inflating the chain count. inPeer/outPeer
     // may legitimately be all-zero (an open jack), so only source is validated.
     if (!net::isValidPeerMac(beacon.source)) return false;
+    // Self is the authority on its own peers (setSelfPeers); a self-beacon that
+    // floods back around a ring carries no new information and would otherwise
+    // cost an extra ring trip and reset the stability window.
+    if (beacon.source == selfMac_) return false;
+
     auto it = beaconsBySource_.find(beacon.source);
-    if (it != beaconsBySource_.end() && it->second == beacon) {
-        return false;
-    }
+    if (it != beaconsBySource_.end() && it->second == beacon) return false;
     beaconsBySource_[beacon.source] = beacon;
     lastGraphChangeMs_ = nowMs;
     if (onGraphChanged_) onGraphChanged_();
@@ -85,9 +88,13 @@ std::vector<net::Mac> PeerGraph::getChainMembers() const {
 
 size_t PeerGraph::countReachableExcludingSelf(const net::Mac& firstHop) const {
     if (firstHop == net::Mac{} || firstHop == selfMac_) return 0;
-    // Block self so traversal never crosses to the far side of the chain.
-    // firstHop counts directly (a confirmed direct peer, included as the start
-    // even before its beacon arrives); expansion past it follows mutual edges.
+    // firstHop must be a peer self actually claims on a jack. Counting it as a
+    // confirmed direct peer before its beacon arrives is only sound because self
+    // vouches for the physical link; a MAC self does not claim (e.g. a stale
+    // value held after a yank) is not a member and must contribute nothing.
+    if (selfInPeer_ != firstHop && selfOutPeer_ != firstHop) return 0;
+    // Block self so traversal never crosses to the far side of the chain;
+    // expansion past firstHop follows mutual edges.
     return reachableFrom(firstHop, {selfMac_}).size();
 }
 
@@ -112,11 +119,14 @@ bool PeerGraph::isInLoop() const {
 }
 
 bool PeerGraph::isTopologyStable(unsigned long nowMs) const {
+    // No recorded change yet means no settled topology to report; a just-booted
+    // device must read as unstable, not stable-since-time-zero, so a premature
+    // coordinator can't claim through.
+    if (!lastGraphChangeMs_) return false;
     // Clamp the gap to 0 on a backwards/zero clock so unsigned subtraction can't
-    // underflow to ~UINT32_MAX and falsely report stability (which would let a
-    // premature coordinator claim through). Mirrors the silent-link gap guard in
-    // RemoteDeviceCoordinator.
-    const unsigned long gap = nowMs >= lastGraphChangeMs_ ? nowMs - lastGraphChangeMs_ : 0;
+    // underflow to ~UINT32_MAX and falsely report stability.
+    const unsigned long last = *lastGraphChangeMs_;
+    const unsigned long gap = nowMs >= last ? nowMs - last : 0;
     return gap >= kTopologyStabilityMs;
 }
 

--- a/src/device/peer-graph.cpp
+++ b/src/device/peer-graph.cpp
@@ -1,0 +1,122 @@
+#include "device/peer-graph.hpp"
+
+#include <algorithm>
+
+void PeerGraph::setSelfMac(const net::Mac& mac) {
+    selfMac_ = mac;
+}
+
+bool PeerGraph::acceptBeacon(const BeaconRecord& beacon, unsigned long nowMs) {
+    // Reject poison at the layer that owns the cache. An all-zero/broadcast
+    // source cached as a node corrupts loop detection: an open jack is itself an
+    // all-zero peer, so hasMutualEdge(real, {0}) holds for any node with a free
+    // jack, fabricating a false loop and inflating the chain count. inPeer/outPeer
+    // may legitimately be all-zero (an open jack), so only source is validated.
+    if (!net::isValidPeerMac(beacon.source)) return false;
+    auto it = beaconsBySource_.find(beacon.source);
+    if (it != beaconsBySource_.end() && it->second == beacon) {
+        return false;
+    }
+    beaconsBySource_[beacon.source] = beacon;
+    lastGraphChangeMs_ = nowMs;
+    if (onGraphChanged_) onGraphChanged_();
+    return true;
+}
+
+std::optional<BeaconRecord> PeerGraph::getBeacon(const net::Mac& source) const {
+    auto it = beaconsBySource_.find(source);
+    if (it == beaconsBySource_.end()) return std::nullopt;
+    return it->second;
+}
+
+void PeerGraph::setSelfPeers(const net::Mac& inPeer,
+                             const net::Mac& outPeer,
+                             unsigned long nowMs) {
+    if (selfInPeer_ == inPeer && selfOutPeer_ == outPeer) return;
+    selfInPeer_ = inPeer;
+    selfOutPeer_ = outPeer;
+    lastGraphChangeMs_ = nowMs;
+    if (onGraphChanged_) onGraphChanged_();
+}
+
+bool PeerGraph::hasMutualEdge(const net::Mac& a, const net::Mac& b) const {
+    auto claims = [this](const net::Mac& from, const net::Mac& to) -> bool {
+        if (from == selfMac_) {
+            return selfInPeer_ == to || selfOutPeer_ == to;
+        }
+        auto it = beaconsBySource_.find(from);
+        if (it == beaconsBySource_.end()) return false;
+        return it->second.inPeer == to || it->second.outPeer == to;
+    };
+    return claims(a, b) && claims(b, a);
+}
+
+std::vector<net::Mac> PeerGraph::reachableFrom(
+    const net::Mac& start, std::initializer_list<net::Mac> blocked) const {
+    std::vector<net::Mac> visited(blocked);
+    std::vector<net::Mac> result;
+    std::vector<net::Mac> frontier;
+    // start is reachable from itself, unless it is itself blocked.
+    if (std::find(visited.begin(), visited.end(), start) == visited.end()) {
+        visited.push_back(start);
+        result.push_back(start);
+        frontier.push_back(start);
+    }
+    while (!frontier.empty()) {
+        net::Mac current = frontier.back();
+        frontier.pop_back();
+        for (const auto& entry : beaconsBySource_) {
+            const net::Mac& source = entry.first;
+            if (std::find(visited.begin(), visited.end(), source) != visited.end()) continue;
+            if (hasMutualEdge(current, source)) {
+                visited.push_back(source);
+                result.push_back(source);
+                frontier.push_back(source);
+            }
+        }
+    }
+    return result;
+}
+
+std::vector<net::Mac> PeerGraph::getChainMembers() const {
+    // Everything reachable from self over mutual edges (self included).
+    return reachableFrom(selfMac_, {});
+}
+
+size_t PeerGraph::countReachableExcludingSelf(const net::Mac& firstHop) const {
+    if (firstHop == net::Mac{} || firstHop == selfMac_) return 0;
+    // Block self so traversal never crosses to the far side of the chain.
+    // firstHop counts directly (a confirmed direct peer, included as the start
+    // even before its beacon arrives); expansion past it follows mutual edges.
+    return reachableFrom(firstHop, {selfMac_}).size();
+}
+
+bool PeerGraph::isInLoop() const {
+    // Self is in a cycle iff two distinct mutual neighbors of self are
+    // connected to each other by a path that does not pass back through self.
+    std::vector<net::Mac> neighbors;
+    for (const auto& entry : beaconsBySource_) {
+        if (hasMutualEdge(selfMac_, entry.first)) neighbors.push_back(entry.first);
+    }
+    if (neighbors.size() < 2) return false;
+
+    for (size_t i = 0; i < neighbors.size(); ++i) {
+        // Reachability from neighbors[i] avoiding self is the same set for every
+        // partner j, so compute it once per i.
+        std::vector<net::Mac> reach = reachableFrom(neighbors[i], {selfMac_});
+        for (size_t j = i + 1; j < neighbors.size(); ++j) {
+            if (std::find(reach.begin(), reach.end(), neighbors[j]) != reach.end()) return true;
+        }
+    }
+    return false;
+}
+
+bool PeerGraph::isTopologyStable(unsigned long nowMs) const {
+    // Clamp the gap to 0 on a backwards/zero clock so unsigned subtraction can't
+    // underflow to ~UINT32_MAX and falsely report stability (which would let a
+    // premature coordinator claim through). Mirrors the silent-link gap guard in
+    // RemoteDeviceCoordinator.
+    const unsigned long gap = nowMs >= lastGraphChangeMs_ ? nowMs - lastGraphChangeMs_ : 0;
+    return gap >= kTopologyStabilityMs;
+}
+

--- a/test/test_core/crc16-tests.hpp
+++ b/test/test_core/crc16-tests.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+
+#include "wireless/crc16.hpp"
+
+// CRC-16/CCITT XMODEM canonical check string. Locks the wire format against
+// any future port (Python, Go, etc.) that needs to interoperate with serial
+// frames produced by this code.
+TEST(Crc16, canonicalCheckString) {
+    const char* s = "123456789";
+    uint16_t result = crc16(reinterpret_cast<const uint8_t*>(s), 9);
+    EXPECT_EQ(result, 0x31C3);
+}
+
+// ADD frame body: opcode 0x01 + seqId 0x10 + MAC AA:BB:CC:DD:EE:FF.
+// Locked against Python reference (poly 0x1021, init 0x0000, no reflection).
+TEST(Crc16, frameVectorOpcodeAddPlusMac) {
+    uint8_t input[] = {0x01, 0x10, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    uint16_t result = crc16(input, sizeof(input));
+    EXPECT_EQ(result, 0x235D);
+}
+
+// Two MACs sorted by memcmp byte-order — locks the PROBE fingerprint
+// computation against any peer port that needs to compute matching
+// fingerprints from the same set.
+TEST(Crc16, sortedProbeVectorTwoMacs) {
+    uint8_t input[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
+                       0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    uint16_t result = crc16(input, sizeof(input));
+    EXPECT_EQ(result, 0x239E);
+}
+
+// Empty input must produce the init value (0x0000) — guards against a
+// future change that switches init to a non-zero value (XMODEM = 0x0000;
+// CCITT-FALSE = 0xFFFF; KERMIT reflected = 0x0000 different algorithm).
+TEST(Crc16, emptyInputReturnsInitValue) {
+    uint16_t result = crc16(nullptr, 0);
+    EXPECT_EQ(result, 0x0000);
+}

--- a/test/test_core/crc16-tests.hpp
+++ b/test/test_core/crc16-tests.hpp
@@ -7,27 +7,27 @@
 
 #include "wireless/crc16.hpp"
 
-// CRC-16/CCITT XMODEM canonical check string. Locks the wire format against
-// any future port (Python, Go, etc.) that needs to interoperate with serial
-// frames produced by this code.
+// CRC-16/CCITT XMODEM canonical check string ("123456789" -> 0x31C3). This is
+// the standard identity vector for the variant; it pins poly/init/reflection so
+// a refactor can't silently swap in a different CRC-16.
 TEST(Crc16, canonicalCheckString) {
     const char* s = "123456789";
     uint16_t result = crc16(reinterpret_cast<const uint8_t*>(s), 9);
     EXPECT_EQ(result, 0x31C3);
 }
 
-// ADD frame body: opcode 0x01 + seqId 0x10 + MAC AA:BB:CC:DD:EE:FF.
-// Locked against Python reference (poly 0x1021, init 0x0000, no reflection).
-TEST(Crc16, frameVectorOpcodeAddPlusMac) {
+// Regression vector over an 8-byte span (an opcode byte followed by a MAC), the
+// shape of a short framed body. Value computed from the same algorithm; locks it
+// against drift.
+TEST(Crc16, eightByteSpanVector) {
     uint8_t input[] = {0x01, 0x10, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
     uint16_t result = crc16(input, sizeof(input));
     EXPECT_EQ(result, 0x235D);
 }
 
-// Two MACs sorted by memcmp byte-order — locks the PROBE fingerprint
-// computation against any peer port that needs to compute matching
-// fingerprints from the same set.
-TEST(Crc16, sortedProbeVectorTwoMacs) {
+// Regression vector over a 12-byte span (two MACs), the shape of a longer body.
+// Locks the algorithm against drift.
+TEST(Crc16, twelveByteSpanVector) {
     uint8_t input[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
                        0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
     uint16_t result = crc16(input, sizeof(input));

--- a/test/test_core/peer-graph-codec-tests.hpp
+++ b/test/test_core/peer-graph-codec-tests.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <vector>
+#include "device/peer-graph-codec.hpp"
+#include "wireless/crc16.hpp"
+
+inline void codecHelloRoundTrip() {
+    net::Mac src = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    auto frame = peer_graph::encodeHello(src, 2);  // deviceType FDN=2
+    EXPECT_EQ(frame.size(), 12u);  // preamble 2 + opcode 1 + payload 7 + CRC 2
+    auto decoded = peer_graph::decodeHello(frame);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->source, src);
+    EXPECT_EQ(decoded->deviceType, 2);
+}
+
+inline void codecBeaconRoundTrip() {
+    BeaconRecord b{{0x01, 0, 0, 0, 0, 0}, {0x02, 0, 0, 0, 0, 0}, {0x03, 0, 0, 0, 0, 0}};
+    auto frame = peer_graph::encodeBeacon(b);
+    EXPECT_EQ(frame.size(), 23u);  // preamble 2 + opcode 1 + payload 18 + CRC 2
+    auto decoded = peer_graph::decodeBeacon(frame);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(*decoded, b);
+}
+
+inline void codecBeaconEmptyPeersRoundTrip() {
+    BeaconRecord b{{0x01, 0, 0, 0, 0, 0}, {}, {}};
+    auto frame = peer_graph::encodeBeacon(b);
+    auto decoded = peer_graph::decodeBeacon(frame);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(*decoded, b);
+}
+
+inline void codecRejectsCorruptedCrc() {
+    net::Mac src = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    auto frame = peer_graph::encodeHello(src, 1);
+    frame[5] ^= 0xFF;  // flip a payload byte; CRC no longer matches
+    EXPECT_FALSE(peer_graph::decodeHello(frame).has_value());
+}
+
+// Builds a well-framed, valid-CRC frame carrying an arbitrary opcode over a
+// payload of the given length, so length and CRC both pass validation and only
+// the opcode check can reject it.
+inline std::vector<uint8_t> codecFrameWithOpcode(uint8_t opcode, size_t payloadLen) {
+    std::vector<uint8_t> body;
+    body.push_back(opcode);
+    for (size_t i = 0; i < payloadLen; ++i) body.push_back(static_cast<uint8_t>(i));
+    const uint16_t crc = crc16(body.data(), body.size());
+    std::vector<uint8_t> frame{0xAA, 0x55};
+    frame.insert(frame.end(), body.begin(), body.end());
+    frame.push_back(static_cast<uint8_t>(crc >> 8));
+    frame.push_back(static_cast<uint8_t>(crc & 0xFF));
+    return frame;
+}
+
+inline void codecRejectsWrongOpcode() {
+    // Cross-decoding a whole BEACON/HELLO frame is rejected on the length check
+    // (payloads differ: 18 vs 7), so it never reaches the opcode comparison.
+    BeaconRecord b{{0x01, 0, 0, 0, 0, 0}, {}, {}};
+    EXPECT_FALSE(peer_graph::decodeHello(peer_graph::encodeBeacon(b)).has_value());
+    net::Mac src = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    EXPECT_FALSE(peer_graph::decodeBeacon(peer_graph::encodeHello(src, 1)).has_value());
+
+    // Isolate the opcode guard: a frame with HELLO's payload length (7) but the
+    // BEACON opcode, with a valid CRC, passes length+CRC and can only be rejected
+    // by the opcode check. Same for a BEACON-length frame carrying the HELLO opcode.
+    EXPECT_FALSE(peer_graph::decodeHello(
+        codecFrameWithOpcode(peer_graph::kOpBeacon, 7)).has_value());
+    EXPECT_FALSE(peer_graph::decodeBeacon(
+        codecFrameWithOpcode(peer_graph::kOpHello, 18)).has_value());
+
+    // Sanity: the same builder with the CORRECT opcode decodes, proving the
+    // rejections above are due to the opcode and not the hand-built framing.
+    EXPECT_TRUE(peer_graph::decodeHello(
+        codecFrameWithOpcode(peer_graph::kOpHello, 7)).has_value());
+}

--- a/test/test_core/peer-graph-tests.hpp
+++ b/test/test_core/peer-graph-tests.hpp
@@ -228,3 +228,43 @@ inline void peerGraphPeerDropsOutWhenSelfStopsClaiming(PeerGraphTests* suite) {
     EXPECT_EQ(g.getChainMembers().size(), 1u);
     EXPECT_FALSE(g.isInLoop());
 }
+
+// A freshly constructed graph has recorded no change, so it must not claim its
+// (nonexistent) topology has settled — otherwise a just-booted device reads as
+// stable from time zero and a premature coordinator can claim through.
+inline void peerGraphNeverChangedIsNotStable(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    EXPECT_FALSE(g.isTopologyStable(0));
+    EXPECT_FALSE(g.isTopologyStable(10000));  // long uptime, but nothing ever changed
+    // A real change establishes the baseline; stability then follows the window.
+    g.setSelfPeers(suite->mac(0x02), {}, 1000);
+    EXPECT_FALSE(g.isTopologyStable(1100));   // inside the 200ms window
+    EXPECT_TRUE(g.isTopologyStable(1300));
+}
+
+// countReachableExcludingSelf must vouch only for peers self actually claims on
+// a jack. A MAC self has no live link to (e.g. a stale value after a yank)
+// contributes nothing, even though it is non-zero and not self.
+inline void peerGraphCountReachableZeroForUnclaimedPeer(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.setSelfPeers(suite->mac(0x02), {}, 0);
+    // 0x03 is a real, non-self MAC that self does not claim on either jack.
+    EXPECT_EQ(g.countReachableExcludingSelf(suite->mac(0x03)), 0u);
+    // Even with a beacon on file for 0x03, self still has no link to it.
+    g.acceptBeacon({suite->mac(0x03), {}, {}}, 0);
+    EXPECT_EQ(g.countReachableExcludingSelf(suite->mac(0x03)), 0u);
+    // The actually-claimed peer still counts.
+    EXPECT_EQ(g.countReachableExcludingSelf(suite->mac(0x02)), 1u);
+}
+
+// A self-sourced beacon (our own, flooded back around a ring) carries nothing
+// setSelfPeers doesn't already own; it must be dropped, not cached.
+inline void peerGraphSelfSourcedBeaconDropped(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.setSelfPeers(suite->mac(0x02), suite->mac(0x03), 0);
+    EXPECT_FALSE(g.acceptBeacon({suite->mac(0x01), suite->mac(0x02), suite->mac(0x03)}, 100));
+    EXPECT_FALSE(g.getBeacon(suite->mac(0x01)).has_value());
+}

--- a/test/test_core/peer-graph-tests.hpp
+++ b/test/test_core/peer-graph-tests.hpp
@@ -1,0 +1,230 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include "device/peer-graph.hpp"
+
+class PeerGraphTests : public testing::Test {
+public:
+    net::Mac mac(uint8_t last) {
+        return {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, last};
+    }
+};
+
+inline void peerGraphStoresBeaconBySource(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    BeaconRecord b{suite->mac(0x02), suite->mac(0x01), {}};
+    g.acceptBeacon(b, 0);
+    auto cached = g.getBeacon(suite->mac(0x02));
+    ASSERT_TRUE(cached.has_value());
+    EXPECT_EQ((*cached).source, suite->mac(0x02));
+}
+
+inline void peerGraphMutualEdgeRequiresBothClaims(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.setSelfPeers(suite->mac(0x02), {}, 0);  // self claims 0x02 on IN
+    // Without 0x02's beacon there is no mutual edge yet.
+    EXPECT_EQ(g.getChainMembers().size(), 1u);
+    // 0x02 claims self on its OUT. Now the edge is mutual.
+    g.acceptBeacon({suite->mac(0x02), {}, suite->mac(0x01)}, 0);
+    // Two devices mutually claiming each other is a single edge, not a cycle
+    // of length >= 3 through self, so isInLoop stays false but both are members.
+    EXPECT_FALSE(g.isInLoop());
+    EXPECT_EQ(g.getChainMembers().size(), 2u);
+}
+
+inline void peerGraphIsInLoopThreeNodeRing(PeerGraphTests* suite) {
+    // Ring: self(0x01) IN<-0x02, OUT->0x03; 0x02 IN<-0x03, OUT->0x01;
+    //       0x03 IN<-0x01, OUT->0x02.
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.setSelfPeers(suite->mac(0x02), suite->mac(0x03), 0);
+    g.acceptBeacon({suite->mac(0x02), suite->mac(0x03), suite->mac(0x01)}, 0);
+    g.acceptBeacon({suite->mac(0x03), suite->mac(0x01), suite->mac(0x02)}, 0);
+    EXPECT_TRUE(g.isInLoop());
+    EXPECT_EQ(g.getChainMembers().size(), 3u);
+}
+
+inline void peerGraphThreeNodeChainNotInLoop(PeerGraphTests* suite) {
+    // Chain: 0x02 <- self(0x01) -> 0x03. self is the middle; ends are open.
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.setSelfPeers(suite->mac(0x02), suite->mac(0x03), 0);
+    g.acceptBeacon({suite->mac(0x02), {}, suite->mac(0x01)}, 0);
+    g.acceptBeacon({suite->mac(0x03), suite->mac(0x01), {}}, 0);
+    EXPECT_FALSE(g.isInLoop());
+    EXPECT_EQ(g.getChainMembers().size(), 3u);
+}
+
+inline void peerGraphFourNodeRingInLoop(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.setSelfPeers(suite->mac(0x02), suite->mac(0x04), 0);
+    g.acceptBeacon({suite->mac(0x02), suite->mac(0x03), suite->mac(0x01)}, 0);
+    g.acceptBeacon({suite->mac(0x03), suite->mac(0x04), suite->mac(0x02)}, 0);
+    g.acceptBeacon({suite->mac(0x04), suite->mac(0x01), suite->mac(0x03)}, 0);
+    EXPECT_TRUE(g.isInLoop());
+    EXPECT_EQ(g.getChainMembers().size(), 4u);
+}
+
+// An open jack reads as an all-zero peer. If acceptBeacon cached an all-zero
+// (or broadcast) source as a node, hasMutualEdge(realNode, {0}) would hold for
+// any device with a free jack, fabricating a false loop and inflating the
+// chain. The poison gate must reject the beacon at the cache owner, before it
+// ever enters beaconsBySource_.
+inline void peerGraphRejectsPoisonBeaconSource(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.setSelfPeers({}, {}, 0);  // both jacks open -> self peers are all-zero
+
+    // All-zero source: rejected, not cached, no graph-change side effect.
+    EXPECT_FALSE(g.acceptBeacon({net::Mac{}, suite->mac(0x01), {}}, 100));
+    EXPECT_FALSE(g.getBeacon(net::Mac{}).has_value());
+
+    // Broadcast source: also rejected.
+    net::Mac broadcast{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    EXPECT_FALSE(g.acceptBeacon({broadcast, suite->mac(0x01), {}}, 100));
+    EXPECT_FALSE(g.getBeacon(broadcast).has_value());
+
+    // No poison node leaked in: self with two open jacks is an island, never a loop.
+    EXPECT_FALSE(g.isInLoop());
+    EXPECT_EQ(g.getChainMembers().size(), 1u);
+
+    // inPeer/outPeer may legitimately be all-zero (open jacks) — only source is
+    // validated, so a real source with open peers is still accepted.
+    EXPECT_TRUE(g.acceptBeacon({suite->mac(0x02), {}, {}}, 200));
+    EXPECT_TRUE(g.getBeacon(suite->mac(0x02)).has_value());
+}
+
+inline void peerGraphSelfIslandNotInLoop(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    EXPECT_FALSE(g.isInLoop());
+    EXPECT_EQ(g.getChainMembers().size(), 1u);
+}
+
+inline void peerGraphTopologyStableAfterDebounceWindow(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.acceptBeacon({suite->mac(0x02), {}, suite->mac(0x01)}, 0);
+    // 100ms after the change: still inside the 200ms window.
+    EXPECT_FALSE(g.isTopologyStable(100));
+    // 250ms after the change: past the window.
+    EXPECT_TRUE(g.isTopologyStable(250));
+    // A new change resets the window.
+    g.acceptBeacon({suite->mac(0x03), {}, suite->mac(0x01)}, 300);
+    EXPECT_FALSE(g.isTopologyStable(400));
+    EXPECT_TRUE(g.isTopologyStable(550));
+}
+
+// A backwards/zero clock must report unstable, not underflow unsigned
+// subtraction into a near-UINT32_MAX gap that reads as falsely stable.
+inline void peerGraphBackwardsClockNotStable(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.acceptBeacon({suite->mac(0x02), {}, suite->mac(0x01)}, 500);  // last change at 500
+    EXPECT_FALSE(g.isTopologyStable(0));
+    EXPECT_FALSE(g.isTopologyStable(499));
+    // Forward progress past the window still reads stable.
+    EXPECT_TRUE(g.isTopologyStable(800));
+}
+
+inline void peerGraphUnchangedBeaconDoesNotResetStability(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.acceptBeacon({suite->mac(0x02), {}, suite->mac(0x01)}, 0);
+    EXPECT_TRUE(g.isTopologyStable(250));
+    // Re-receiving the identical beacon must NOT reset the stability window.
+    bool changed = g.acceptBeacon({suite->mac(0x02), {}, suite->mac(0x01)}, 300);
+    EXPECT_FALSE(changed);
+    EXPECT_TRUE(g.isTopologyStable(310));
+}
+
+inline void peerGraphNonMutualNodeExcludedFromMembers(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.setSelfPeers(suite->mac(0x02), {}, 0);
+    g.acceptBeacon({suite->mac(0x02), {}, suite->mac(0x01)}, 0);  // mutual with self
+    // 0x03 claims 0x02 but no one claims 0x03 back: zero mutual edges. It is
+    // retained in the cache (harmless) but excluded from the membership set.
+    g.acceptBeacon({suite->mac(0x03), suite->mac(0x02), {}}, 0);
+    auto members = g.getChainMembers();
+    EXPECT_EQ(members.size(), 2u);
+    EXPECT_EQ(std::find(members.begin(), members.end(), suite->mac(0x03)), members.end());
+}
+
+inline void peerGraphCountReachableSplitsChainAtSelf(PeerGraphTests* suite) {
+    // Linear chain: 0x04 - 0x02 - self(0x01) - 0x03 - 0x05.
+    // self IN<-0x02, OUT->0x03. Counting through the IN side (0x02) reaches
+    // 0x02 and 0x04 (2); through the OUT side (0x03) reaches 0x03 and 0x05 (2).
+    // self is never crossed, so the two sides never bleed into each other.
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.setSelfPeers(suite->mac(0x02), suite->mac(0x03), 0);
+    g.acceptBeacon({suite->mac(0x02), suite->mac(0x04), suite->mac(0x01)}, 0);
+    g.acceptBeacon({suite->mac(0x03), suite->mac(0x01), suite->mac(0x05)}, 0);
+    g.acceptBeacon({suite->mac(0x04), {}, suite->mac(0x02)}, 0);
+    g.acceptBeacon({suite->mac(0x05), suite->mac(0x03), {}}, 0);
+    EXPECT_EQ(g.countReachableExcludingSelf(suite->mac(0x02)), 2u);
+    EXPECT_EQ(g.countReachableExcludingSelf(suite->mac(0x03)), 2u);
+}
+
+inline void peerGraphCountReachableDirectPeerBeforeBeacon(PeerGraphTests* suite) {
+    // A freshly connected direct peer counts as 1 even before its beacon
+    // arrives — it is a confirmed physical neighbor. Once its beacon lands
+    // showing another hop behind it, the count grows.
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.setSelfPeers(suite->mac(0x02), {}, 0);
+    EXPECT_EQ(g.countReachableExcludingSelf(suite->mac(0x02)), 1u);
+    g.acceptBeacon({suite->mac(0x02), suite->mac(0x04), suite->mac(0x01)}, 0);
+    g.acceptBeacon({suite->mac(0x04), {}, suite->mac(0x02)}, 0);
+    EXPECT_EQ(g.countReachableExcludingSelf(suite->mac(0x02)), 2u);
+}
+
+inline void peerGraphCountReachableZeroForAbsentPeer(PeerGraphTests* suite) {
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    EXPECT_EQ(g.countReachableExcludingSelf({}), 0u);
+    EXPECT_EQ(g.countReachableExcludingSelf(suite->mac(0x01)), 0u);  // self
+}
+
+inline void peerGraphTwoDeviceBothJacksNotLoopButRetainsPeer(PeerGraphTests* suite) {
+    // Two devices wired with BOTH cables: self has the same peer on IN and OUT.
+    // Only two distinct nodes exist, so this is not a >=3-node cycle (isInLoop
+    // stays false), but the peer is a member and stays one when a single jack is
+    // yanked, because the other jack still claims it. declareJackDead relies on
+    // exactly this to keep the ESP-NOW peer slot while either cable is live.
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.setSelfPeers(suite->mac(0x02), suite->mac(0x02), 0);  // same peer both jacks
+    g.acceptBeacon({suite->mac(0x02), suite->mac(0x01), suite->mac(0x01)}, 0);
+    EXPECT_FALSE(g.isInLoop());
+    EXPECT_EQ(g.getChainMembers().size(), 2u);
+    EXPECT_EQ(g.countReachableExcludingSelf(suite->mac(0x02)), 1u);
+
+    // Yank the OUT jack: self still claims 0x02 on IN, edge stays mutual.
+    g.setSelfPeers(suite->mac(0x02), {}, 100);
+    EXPECT_EQ(g.getChainMembers().size(), 2u);
+
+    // Yank the IN jack too: no claim remains, peer drops out.
+    g.setSelfPeers({}, {}, 200);
+    EXPECT_EQ(g.getChainMembers().size(), 1u);
+    EXPECT_FALSE(g.isInLoop());
+}
+
+inline void peerGraphPeerDropsOutWhenSelfStopsClaiming(PeerGraphTests* suite) {
+    // A device leaves the ring: self's macPeer clears, self stops claiming it,
+    // so the edge is no longer mutual and the peer leaves the membership set.
+    PeerGraph g;
+    g.setSelfMac(suite->mac(0x01));
+    g.setSelfPeers(suite->mac(0x02), {}, 0);
+    g.acceptBeacon({suite->mac(0x02), {}, suite->mac(0x01)}, 0);
+    EXPECT_EQ(g.getChainMembers().size(), 2u);
+    // Self drops the peer (cable yank). The 0x02 edge is no longer mutual.
+    g.setSelfPeers({}, {}, 100);
+    EXPECT_EQ(g.getChainMembers().size(), 1u);
+    EXPECT_FALSE(g.isInLoop());
+}

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -20,6 +20,9 @@
 #include "chain-duel-multi-device-fixture.hpp"
 #include "shootout-manager-tests.hpp"
 #include "match-manager-concurrent.hpp"
+#include "crc16-tests.hpp"
+#include "peer-graph-tests.hpp"
+#include "peer-graph-codec-tests.hpp"
 
 #if defined(ARDUINO)
 #include <Arduino.h>
@@ -1468,6 +1471,79 @@ TEST_F(ShootoutManagerTests, localRDCDisconnectIsIdempotent) { localRDCDisconnec
 TEST_F(ShootoutManagerTests, shootoutProposalDebouncesTransientLoopBreak) { shootoutProposalDebouncesTransientLoopBreak(this); }
 TEST_F(ShootoutManagerTests, shootoutBracketRevealDebouncesTransientLoopBreak) { shootoutBracketRevealDebouncesTransientLoopBreak(this); }
 
+
+// ============================================
+// PEER-GRAPH WIRE LIBRARY TESTS
+// ============================================
+
+TEST_F(PeerGraphTests, storesBeaconBySource) {
+    peerGraphStoresBeaconBySource(this);
+}
+
+TEST_F(PeerGraphTests, mutualEdgeRequiresBothClaims) {
+    peerGraphMutualEdgeRequiresBothClaims(this);
+}
+
+TEST_F(PeerGraphTests, isInLoopThreeNodeRing) {
+    peerGraphIsInLoopThreeNodeRing(this);
+}
+
+TEST_F(PeerGraphTests, threeNodeChainNotInLoop) {
+    peerGraphThreeNodeChainNotInLoop(this);
+}
+
+TEST_F(PeerGraphTests, fourNodeRingInLoop) {
+    peerGraphFourNodeRingInLoop(this);
+}
+
+TEST_F(PeerGraphTests, selfIslandNotInLoop) {
+    peerGraphSelfIslandNotInLoop(this);
+}
+
+TEST_F(PeerGraphTests, rejectsPoisonBeaconSource) {
+    peerGraphRejectsPoisonBeaconSource(this);
+}
+
+TEST_F(PeerGraphTests, topologyStableAfterDebounceWindow) {
+    peerGraphTopologyStableAfterDebounceWindow(this);
+}
+TEST_F(PeerGraphTests, backwardsClockNotStable) {
+    peerGraphBackwardsClockNotStable(this);
+}
+
+TEST_F(PeerGraphTests, unchangedBeaconDoesNotResetStability) {
+    peerGraphUnchangedBeaconDoesNotResetStability(this);
+}
+
+TEST_F(PeerGraphTests, nonMutualNodeExcludedFromMembers) {
+    peerGraphNonMutualNodeExcludedFromMembers(this);
+}
+
+TEST_F(PeerGraphTests, peerDropsOutWhenSelfStopsClaiming) {
+    peerGraphPeerDropsOutWhenSelfStopsClaiming(this);
+}
+
+TEST_F(PeerGraphTests, twoDeviceBothJacksNotLoopButRetainsPeer) {
+    peerGraphTwoDeviceBothJacksNotLoopButRetainsPeer(this);
+}
+
+TEST_F(PeerGraphTests, countReachableSplitsChainAtSelf) {
+    peerGraphCountReachableSplitsChainAtSelf(this);
+}
+
+TEST_F(PeerGraphTests, countReachableDirectPeerBeforeBeacon) {
+    peerGraphCountReachableDirectPeerBeforeBeacon(this);
+}
+
+TEST_F(PeerGraphTests, countReachableZeroForAbsentPeer) {
+    peerGraphCountReachableZeroForAbsentPeer(this);
+}
+
+TEST(PeerGraphCodecTests, helloRoundTrip) { codecHelloRoundTrip(); }
+TEST(PeerGraphCodecTests, beaconRoundTrip) { codecBeaconRoundTrip(); }
+TEST(PeerGraphCodecTests, beaconEmptyPeersRoundTrip) { codecBeaconEmptyPeersRoundTrip(); }
+TEST(PeerGraphCodecTests, rejectsCorruptedCrc) { codecRejectsCorruptedCrc(); }
+TEST(PeerGraphCodecTests, rejectsWrongOpcode) { codecRejectsWrongOpcode(); }
 // ============================================
 // MAIN
 // ============================================

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1539,6 +1539,18 @@ TEST_F(PeerGraphTests, countReachableZeroForAbsentPeer) {
     peerGraphCountReachableZeroForAbsentPeer(this);
 }
 
+TEST_F(PeerGraphTests, neverChangedIsNotStable) {
+    peerGraphNeverChangedIsNotStable(this);
+}
+
+TEST_F(PeerGraphTests, countReachableZeroForUnclaimedPeer) {
+    peerGraphCountReachableZeroForUnclaimedPeer(this);
+}
+
+TEST_F(PeerGraphTests, selfSourcedBeaconDropped) {
+    peerGraphSelfSourcedBeaconDropped(this);
+}
+
 TEST(PeerGraphCodecTests, helloRoundTrip) { codecHelloRoundTrip(); }
 TEST(PeerGraphCodecTests, beaconRoundTrip) { codecBeaconRoundTrip(); }
 TEST(PeerGraphCodecTests, beaconEmptyPeersRoundTrip) { codecBeaconEmptyPeersRoundTrip(); }


### PR DESCRIPTION
Wire library for the peer-graph loop-detection protocol. Nothing calls it yet; this is the contract the RDC will be built on, so the review is about getting the interface and the topology rules right before integration code depends on them.

Each device caches the latest BEACON from every source and derives ring topology on demand: an edge A↔B counts only when both ends' latest beacons claim each other. `PeerGraph` answers `isInLoop`, `getChainMembers`, `countReachableExcludingSelf`, and `isTopologyStable` from that cache. The codec frames HELLO and BEACON (preamble, opcode, payload, CRC-16).

Where the risk is:

- Self is not in the beacon cache. It lives in `selfInPeer_`/`selfOutPeer_` and is special-cased in `hasMutualEdge` and every query. A future query that reads the cache for self will be silently wrong. This is the most fragile part of the design.
- `acceptBeacon` returning true is the signal for the (not-yet-written) flood layer to forward the beacon. The self-sourced-beacon drop exists to handle that layer echoing our own beacon back around a ring.
- `net::Mac` is a new alias for the `std::array<uint8_t,6>` the rest of the codebase spells raw, so merging it commits to a later migration.

The tests are the behavioral spec for the rules worth scrutinizing: chain vs ring, the 2-device-both-jacks case, and count-splits-at-self.