### PR TITLE
Add Player role-changed callback hook

### DIFF
--- a/include/game/player.hpp
+++ b/include/game/player.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <functional>
 #include <string>
 #include <iostream>
 #include <cstdint>
@@ -27,6 +28,13 @@ public:
     bool isHunter() const;
 
     void setIsHunter(bool isHunter);
+
+    // Fires AFTER setIsHunter / toggleHunter mutates the role. Lets ChainManager
+    // invalidate peerRoleByPort_ caches and re-broadcast RoleAnnounce so peers
+    // see the freshly-chosen role rather than the pre-registration default.
+    // Set once at wire-up; not reentrant-safe.
+    using RoleChangedCallback = std::function<void()>;
+    void setOnRoleChanged(RoleChangedCallback cb);
 
     void toggleHunter();
 
@@ -105,6 +113,8 @@ private:
     Allegiance allegiance = Allegiance::RESISTANCE;
 
     Symbol symbol;
-    
+
     bool hunter = true;
+
+    RoleChangedCallback onRoleChanged_;
 };

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -53,12 +53,21 @@ void Player::fromJson(const std::string &json) {
 
 void Player::toggleHunter()
 {
+  bool prev = hunter;
   hunter = !hunter;
+  if (prev != hunter && onRoleChanged_) onRoleChanged_();
 }
 
-void Player::setIsHunter(bool isHunter) 
+void Player::setIsHunter(bool isHunter)
 {
+  bool prev = hunter;
   hunter = isHunter;
+  if (prev != hunter && onRoleChanged_) onRoleChanged_();
+}
+
+void Player::setOnRoleChanged(RoleChangedCallback cb)
+{
+  onRoleChanged_ = std::move(cb);
 }
 
 void Player::clearUserID()

--- a/test/test_core/player-tests.hpp
+++ b/test/test_core/player-tests.hpp
@@ -165,3 +165,25 @@ inline void playerReactionTimeAverageCalculatesCorrectly(Player* player) {
     EXPECT_EQ(player->getLastReactionTime(), 400);
     EXPECT_EQ(player->getAverageReactionTime(), 300); // (200+300+400)/3
 }
+
+// ============================================
+// Role-changed Callback Tests
+// ============================================
+
+inline void playerOnRoleChangedFiresOnlyOnActualChange(Player* player) {
+    int calls = 0;
+    player->setOnRoleChanged([&calls]() { ++calls; });
+
+    // toggleHunter always flips the role, so it fires on every call.
+    player->toggleHunter();
+    player->toggleHunter();
+    EXPECT_EQ(calls, 2);
+
+    // setIsHunter to the role already held is a no-op and must not fire.
+    player->setIsHunter(player->isHunter());
+    EXPECT_EQ(calls, 2);
+
+    // setIsHunter to the opposite role fires once.
+    player->setIsHunter(!player->isHunter());
+    EXPECT_EQ(calls, 3);
+}

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -518,6 +518,10 @@ TEST_F(PlayerTestSuite, reactionTimeAverageCalculatesCorrectly) {
     playerReactionTimeAverageCalculatesCorrectly(player);
 }
 
+TEST_F(PlayerTestSuite, onRoleChangedFiresOnlyOnActualChange) {
+    playerOnRoleChangedFiresOnlyOnActualChange(player);
+}
+
 // ============================================
 // MATCH TESTS
 // ============================================


### PR DESCRIPTION
Adds `Player::setOnRoleChanged`, a callback that fires after `setIsHunter`/`toggleHunter`, but only when the role actually changes.

Extracted ahead of the connectivity-core work, which uses it so ChainManager can invalidate its cached peer roles and re-broadcast RoleAnnounce when the local role flips. Nothing calls it on this branch; it stands alone so it can be reviewed without the larger rewrite.

The only logic is the fire-only-on-change guard (`prev != hunter`); the added test covers it.