### PR TITLE
Merging FDN code into monorepo

### DIFF
--- a/lib/core/include/apps/handshake/handshake-states.hpp
+++ b/lib/core/include/apps/handshake/handshake-states.hpp
@@ -77,7 +77,7 @@ private:
 
 class InputIdleState : public State {
 public:
-    explicit InputIdleState(HandshakeWirelessManager* handshakeWirelessManager);
+    InputIdleState(HandshakeWirelessManager* handshakeWirelessManager, SerialIdentifier jack);
     ~InputIdleState();
 
     void onStateMounted(Device *PDN) override;
@@ -89,6 +89,7 @@ public:
 
 private:
     HandshakeWirelessManager* handshakeWirelessManager;
+    SerialIdentifier jack;
     SimpleTimer emitMacTimer;
     const int emitMacInterval = 250;
     bool transitionToSendIdState = false;
@@ -96,7 +97,7 @@ private:
 
 class InputSendIdState : public State {
 public:
-    explicit InputSendIdState(HandshakeWirelessManager* handshakeWirelessManager);
+    InputSendIdState(HandshakeWirelessManager* handshakeWirelessManager, SerialIdentifier jack);
     ~InputSendIdState();
 
     void onStateMounted(Device *PDN) override;
@@ -108,5 +109,6 @@ public:
 
 private:
     HandshakeWirelessManager* handshakeWirelessManager;
+    SerialIdentifier jack;
     bool transitionToConnectedState = false;
 };

--- a/lib/core/include/device/driver-names.hpp
+++ b/lib/core/include/device/driver-names.hpp
@@ -2,15 +2,17 @@
 
 #include <string>
 
-inline const std::string DISPLAY_DRIVER_NAME         = "display";
-inline const std::string PRIMARY_BUTTON_DRIVER_NAME  = "primary_button";
-inline const std::string SECONDARY_BUTTON_DRIVER_NAME = "secondary_button";
-inline const std::string LIGHT_DRIVER_NAME           = "light";
-inline const std::string HAPTICS_DRIVER_NAME         = "haptics";
-inline const std::string SERIAL_OUT_DRIVER_NAME      = "serial_out";
-inline const std::string SERIAL_IN_DRIVER_NAME       = "serial_in";
-inline const std::string HTTP_CLIENT_DRIVER_NAME     = "http_client";
-inline const std::string PEER_COMMS_DRIVER_NAME      = "peer_comms";
-inline const std::string PLATFORM_CLOCK_DRIVER_NAME  = "platform_clock";
-inline const std::string LOGGER_DRIVER_NAME          = "logger";
-inline const std::string STORAGE_DRIVER_NAME         = "storage";
+inline const std::string DISPLAY_DRIVER_NAME              = "display";
+inline const std::string PRIMARY_BUTTON_DRIVER_NAME       = "primary_button";
+inline const std::string SECONDARY_BUTTON_DRIVER_NAME     = "secondary_button";
+inline const std::string TERTIARY_BUTTON_DRIVER_NAME      = "tertiary_button";
+inline const std::string LIGHT_DRIVER_NAME                = "light";
+inline const std::string HAPTICS_DRIVER_NAME              = "haptics";
+inline const std::string SERIAL_OUT_DRIVER_NAME           = "serial_out";
+inline const std::string SERIAL_IN_DRIVER_NAME            = "serial_in";
+inline const std::string SERIAL_IN_SECONDARY_DRIVER_NAME  = "serial_in_secondary";
+inline const std::string HTTP_CLIENT_DRIVER_NAME          = "http_client";
+inline const std::string PEER_COMMS_DRIVER_NAME           = "peer_comms";
+inline const std::string PLATFORM_CLOCK_DRIVER_NAME       = "platform_clock";
+inline const std::string LOGGER_DRIVER_NAME               = "logger";
+inline const std::string STORAGE_DRIVER_NAME              = "storage";

--- a/lib/core/include/device/drivers/peer-comms-interface.hpp
+++ b/lib/core/include/device/drivers/peer-comms-interface.hpp
@@ -27,6 +27,9 @@ public:
     virtual void connect() = 0;
     virtual void disconnect() = 0;
 
+    // Returns the last observed RSSI for a peer, or -1 if unknown/unavailable.
+    virtual int getRssiForPeer(const uint8_t* macAddr) { (void)macAddr; return -1; }
+
 protected:
 
 };

--- a/lib/core/include/device/drivers/serial-wrapper.hpp
+++ b/lib/core/include/device/drivers/serial-wrapper.hpp
@@ -11,7 +11,8 @@ using SerialStringCallback = std::function<void(std::string)>;
 
 enum class SerialIdentifier {
     OUTPUT_JACK = 0,
-    INPUT_JACK = 1
+    INPUT_JACK = 1,
+    INPUT_JACK_SECONDARY = 2,
 };
 
 class HWSerialWrapper {

--- a/lib/core/include/device/light-manager.hpp
+++ b/lib/core/include/device/light-manager.hpp
@@ -22,7 +22,7 @@
 class LightManager {
 public:
     LightManager(LightStrip& pdnLights);
-    ~LightManager();
+    virtual ~LightManager();
 
     // Core functionality
     void loop();
@@ -42,52 +42,28 @@ public:
     bool isPaused() const;
     bool isAnimationComplete() const;
 
+protected:
+    // Override in subclasses to provide a device-specific LED mapping.
+    // The default implementation uses PDN layout (6 grip + 13 display).
+    virtual void applyLEDState(const LEDState& state);
+
+    LightStrip& pdnLights;
+
 private:
     /*
-        These methods are used to extract the CRGB arrays from the LEDState.
-        This is useful for sending the LEDState to the FastLED library.
-        Extract grip lights will create a CRGB array from the LEDState like this:
-
-        gripLight[0] = state.leftLights[0];
-        gripLight[1] = state.leftLights[1];
-        gripLight[2] = state.leftLights[2];
-        gripLight[3] = state.rightLights[2];
-        gripLight[4] = state.rightLights[1];
-        gripLight[5] = state.rightLights[0];
-        
-        And extract display lights will create a CRGB array from the LEDState like this:
-
-        displayLight[0] = state.leftLights[3];
-        displayLight[1] = state.leftLights[4];
-        displayLight[2] = state.leftLights[5];
-        displayLight[3] = state.leftLights[6];
-        displayLight[4] = state.leftLights[7];
-        displayLight[5] = state.leftLights[8];
-        displayLight[6] = state.rightLights[8];
-        displayLight[7] = state.rightLights[7];
-        displayLight[8] = state.rightLights[6];
-        displayLight[9] = state.rightLights[5];
-        displayLight[10] = state.rightLights[4];
-        displayLight[11] = state.rightLights[3];
-        displayLight[12] = state.transmitLight;
-        
+        PDN LED mapping:
+        gripLight[0-2]   = leftLights[0-2]
+        gripLight[3-5]   = rightLights[0-2]
+        displayLight[0-5]  = leftLights[3-8]
+        displayLight[6-11] = rightLights[3-8] (reversed)
+        displayLight[12]   = transmitLight
     */
     void mapStateToGripLights(const LEDState& state);
     void mapStateToDisplayLights(const LEDState& state);
-    
-    /*
-        This method will apply the LEDState to the physical LEDs.
-        It will use the arrays extracted from the LEDState to set the color and brightness of the LEDs.
-        This should be a pair of simple for loops, one that iterates over the grip lights
-        and one that iterates over the display lights. For each LED, we will set the color and brightness.
-    */ 
-    void applyLEDState(const LEDState& state);
-    
-    // Member variables
-    LightStrip& pdnLights;
+
     IAnimation* currentAnimation;
-    
-    // Member arrays for extracted lights
+
+    // Member arrays for extracted lights (PDN layout: 6 grip + 13 display)
     LEDState::SingleLEDState gripLightArray[6];
     LEDState::SingleLEDState displayLightArray[13];
 };

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -102,8 +102,9 @@ public:
 
 private:
     RetryStats retryStats_;
-    std::array<std::vector<std::array<uint8_t, 6>>, 2> daisyChainedByPort_;
-    std::array<std::optional<std::array<uint8_t, 6>>, 2> previousDirectPeer_;
+    static constexpr size_t kNumPorts = 3;
+    std::array<std::vector<std::array<uint8_t, 6>>, kNumPorts> daisyChainedByPort_;
+    std::array<std::optional<std::array<uint8_t, 6>>, kNumPorts> previousDirectPeer_;
     uint8_t nextAnnouncementId_ = 1;
 
     struct PendingAnnouncement {
@@ -113,7 +114,7 @@ private:
         std::vector<std::array<uint8_t, 6>> peers;
         SimpleTimer timer;
     };
-    std::array<PendingAnnouncement, 2> pendingByPort_;
+    std::array<PendingAnnouncement, kNumPorts> pendingByPort_;
     static constexpr unsigned long ackTimeoutMs_ = 100;
     static constexpr uint8_t maxRetries_ = 3;
     // ESP-NOW peer-table capacity is 20 on ESP32-S3. Reserve margin for the
@@ -150,4 +151,9 @@ private:
 
     HandshakeApp* inputPortHandshake = nullptr;
     HandshakeApp* outputPortHandshake = nullptr;
+    HandshakeApp* secondaryInputPortHandshake = nullptr;
+
+    // Returns the list of ports that have active handshake apps.
+    std::vector<SerialIdentifier> activePorts() const;
+    HandshakeApp* handshakeAppForPort(SerialIdentifier port) const;
 };

--- a/lib/core/include/device/serial-manager.hpp
+++ b/lib/core/include/device/serial-manager.hpp
@@ -12,7 +12,7 @@
 class SerialManager {
 public:
     SerialManager(HWSerialWrapper* outputJack, HWSerialWrapper* inputJack)
-        : outputJack(outputJack), inputJack(inputJack) {}
+        : outputJack(outputJack), inputJack(inputJack), inputJackSecondary(nullptr) {}
 
     ~SerialManager() = default;
 
@@ -22,8 +22,12 @@ public:
     HWSerialWrapper* getInputJack() { return inputJack; }
     void setInputJack(HWSerialWrapper* jack) { inputJack = jack; }
 
+    HWSerialWrapper* getSecondaryInputJack() { return inputJackSecondary; }
+    void setSecondaryInputJack(HWSerialWrapper* jack) { inputJackSecondary = jack; }
+
     void writeString(const std::string& msg, SerialIdentifier jack = SerialIdentifier::OUTPUT_JACK) {
         HWSerialWrapper* hw = getJack(jack);
+        if (!hw) return;
         hw->print(STRING_START);
         hw->println(msg);
     }
@@ -34,6 +38,7 @@ public:
         head = "";
 
         HWSerialWrapper* hw = getJack(jack);
+        if (!hw) return "null";
 
         if (return_me.empty()) {
             while (hw->available() && hw->peek() != STRING_START) {
@@ -58,45 +63,62 @@ public:
     }
 
     bool commsAvailable(SerialIdentifier jack = SerialIdentifier::OUTPUT_JACK) {
-        return getJack(jack)->available() > 0;
+        HWSerialWrapper* hw = getJack(jack);
+        return hw ? hw->available() > 0 : false;
     }
 
     int getSerialWriteQueueSize(SerialIdentifier jack = SerialIdentifier::OUTPUT_JACK) {
-        return TRANSMIT_QUEUE_MAX_SIZE - getJack(jack)->availableForWrite();
+        HWSerialWrapper* hw = getJack(jack);
+        return hw ? TRANSMIT_QUEUE_MAX_SIZE - hw->availableForWrite() : 0;
     }
 
     void setOnStringReceivedCallback(const std::function<void(std::string)>& callback, SerialIdentifier jack = SerialIdentifier::OUTPUT_JACK) {
-        getJack(jack)->setStringCallback(callback);
+        HWSerialWrapper* hw = getJack(jack);
+        if (hw) hw->setStringCallback(callback);
     }
 
     void clearCallback(SerialIdentifier jack = SerialIdentifier::OUTPUT_JACK) {
-        getJack(jack)->setStringCallback(nullptr);
+        HWSerialWrapper* hw = getJack(jack);
+        if (hw) hw->setStringCallback(nullptr);
     }
 
     void clearCallbacks() {
-        outputJack->setStringCallback(nullptr);
-        inputJack->setStringCallback(nullptr);
+        if (outputJack) outputJack->setStringCallback(nullptr);
+        if (inputJack) inputJack->setStringCallback(nullptr);
+        if (inputJackSecondary) inputJackSecondary->setStringCallback(nullptr);
     }
 
     void flushSerial() {
-        outputJack->flush();
-        inputJack->flush();
+        if (outputJack) outputJack->flush();
+        if (inputJack) inputJack->flush();
+        if (inputJackSecondary) inputJackSecondary->flush();
     }
 
     std::string getOutputHead() const { return outputHead; }
 
 private:
     HWSerialWrapper* getJack(SerialIdentifier jack) {
-        return jack == SerialIdentifier::OUTPUT_JACK ? outputJack : inputJack;
+        switch (jack) {
+            case SerialIdentifier::OUTPUT_JACK:          return outputJack;
+            case SerialIdentifier::INPUT_JACK:           return inputJack;
+            case SerialIdentifier::INPUT_JACK_SECONDARY: return inputJackSecondary;
+            default:                                     return nullptr;
+        }
     }
 
     std::string& getHead(SerialIdentifier jack) {
-        return jack == SerialIdentifier::OUTPUT_JACK ? outputHead : inputHead;
+        switch (jack) {
+            case SerialIdentifier::OUTPUT_JACK:          return outputHead;
+            case SerialIdentifier::INPUT_JACK_SECONDARY: return secondaryInputHead;
+            default:                                     return inputHead;
+        }
     }
 
     HWSerialWrapper* outputJack;
     HWSerialWrapper* inputJack;
+    HWSerialWrapper* inputJackSecondary;
 
     std::string outputHead = "";
     std::string inputHead = "";
+    std::string secondaryInputHead = "";
 };

--- a/lib/core/include/state/connect-state.hpp
+++ b/lib/core/include/state/connect-state.hpp
@@ -23,8 +23,9 @@ public:
             PortStatus s = remoteDeviceCoordinator->getPortStatus(jack);
             return s == PortStatus::CONNECTED || s == PortStatus::DAISY_CHAINED;
         };
-        return (isPrimaryRequired() && connectedOrChain(SerialIdentifier::OUTPUT_JACK)) ||
-               (isAuxRequired() && connectedOrChain(SerialIdentifier::INPUT_JACK));
+        return (isPrimaryRequired()   && connectedOrChain(SerialIdentifier::OUTPUT_JACK)) ||
+               (isAuxRequired()       && connectedOrChain(SerialIdentifier::INPUT_JACK)) ||
+               (isSecondaryRequired() && connectedOrChain(SerialIdentifier::INPUT_JACK_SECONDARY));
     }
 
     bool isPersistentlyDisconnected() {
@@ -36,6 +37,9 @@ protected:
 
     virtual bool isPrimaryRequired() = 0;
     virtual bool isAuxRequired() = 0;
+    // Override and return true to also consider INPUT_JACK_SECONDARY when
+    // evaluating isConnected(). Devices with a single input jack leave this false.
+    virtual bool isSecondaryRequired() { return false; }
 
 private:
     static constexpr unsigned long kDisconnectDebounceMs = 500;

--- a/lib/core/include/state/state-machine.hpp
+++ b/lib/core/include/state/state-machine.hpp
@@ -122,6 +122,12 @@ public:
         checkStateTransitions();
         if (stateChangeReady) {
             commitState(PDN);
+            return;
+        }
+
+        StateId nextApp = currentState->checkAppTransitions();
+        if (nextApp.id >= 0) {
+            PDN->setActiveApp(nextApp);
         }
     }
 

--- a/lib/core/include/state/state.hpp
+++ b/lib/core/include/state/state.hpp
@@ -86,6 +86,17 @@ public:
         transitions.push_back(transition);
     }
 
+    void addAppTransition(std::function<bool()> condition, StateId targetAppId) {
+        appTransitions.push_back({std::move(condition), targetAppId});
+    }
+
+    StateId checkAppTransitions() const {
+        for (const auto& t : appTransitions) {
+            if (t.condition()) return t.targetAppId;
+        }
+        return StateId(-1);
+    }
+
     State* checkTransitions() {
         for (StateTransition* transition : transitions) {
             if (transition->isConditionMet()) {
@@ -114,6 +125,12 @@ protected:
     std::vector<StateTransition*> transitions;
 
 private:
+    struct AppTransitionEntry {
+        std::function<bool()> condition;
+        StateId targetAppId;
+    };
+    std::vector<AppTransitionEntry> appTransitions;
+
     // StateLifecycle bridge — private so state subclasses cannot call or override
     // these entry points. StateMachine dispatches through StateLifecycle* to reach them.
     void mount(Device* device) override    { onStateMounted(device); }

--- a/lib/core/include/wireless/remote-player-manager.hpp
+++ b/lib/core/include/wireless/remote-player-manager.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <vector>
 #include <cstring>  // For memcpy
 #include <string>
@@ -20,6 +22,10 @@ public:
 
     int ProcessPlayerInfoPkt(const uint8_t* srcMacAddr, const uint8_t* data, const size_t dataLen);
 
+    int getLastRssi() const;
+    int getRemotePlayerCount() const;
+    bool consumePacketReceived();
+
 protected:
     int BroadcastPlayerInfo();
     PeerCommsInterface* peerComms;
@@ -28,5 +34,7 @@ protected:
     unsigned long remotePlayerTTL;
     unsigned long broadcastInterval;
     unsigned long lastBroadcastTime;
+    int lastRssi = 0;
+    bool packetReceived = false;
 
 };

--- a/lib/core/src/apps/handshake/handshake.cpp
+++ b/lib/core/src/apps/handshake/handshake.cpp
@@ -83,9 +83,9 @@ void HandshakeApp::createOutputJackStateMap() {
 }
 
 void HandshakeApp::createInputJackStateMap() {
-    InputIdleState* inputIdleState = new InputIdleState(handshakeWirelessManager);
-    InputSendIdState* inputSendIdState = new InputSendIdState(handshakeWirelessManager);
-    HandshakeConnectedState* connectedState = new HandshakeConnectedState(handshakeWirelessManager, SerialIdentifier::INPUT_JACK, HandshakeStateId::INPUT_CONNECTED_STATE);
+    InputIdleState* inputIdleState = new InputIdleState(handshakeWirelessManager, jack);
+    InputSendIdState* inputSendIdState = new InputSendIdState(handshakeWirelessManager, jack);
+    HandshakeConnectedState* connectedState = new HandshakeConnectedState(handshakeWirelessManager, jack, HandshakeStateId::INPUT_CONNECTED_STATE);
 
     inputIdleState->addTransition(
         new StateTransition(

--- a/lib/core/src/apps/handshake/input-idle-state.cpp
+++ b/lib/core/src/apps/handshake/input-idle-state.cpp
@@ -6,7 +6,8 @@
 
 #define TAG "INPUT_IDLE_STATE"
 
-InputIdleState::InputIdleState(HandshakeWirelessManager* handshakeWirelessManager) : State(HandshakeStateId::INPUT_IDLE_STATE) {
+InputIdleState::InputIdleState(HandshakeWirelessManager* handshakeWirelessManager, SerialIdentifier jack)
+    : State(HandshakeStateId::INPUT_IDLE_STATE), jack(jack) {
     this->handshakeWirelessManager = handshakeWirelessManager;
 }
 
@@ -15,7 +16,8 @@ InputIdleState::~InputIdleState() {
 }
 
 void InputIdleState::onStateMounted(Device *PDN) {
-    handshakeWirelessManager->setPacketReceivedCallback(std::bind(&InputIdleState::onHandshakeCommandReceived, this, std::placeholders::_1), SerialIdentifier::INPUT_JACK);
+    handshakeWirelessManager->setPacketReceivedCallback(
+        std::bind(&InputIdleState::onHandshakeCommandReceived, this, std::placeholders::_1), jack);
 
     emitMacTimer.setTimer(emitMacInterval);
 }
@@ -24,9 +26,9 @@ void InputIdleState::onStateLoop(Device *PDN) {
     if (emitMacTimer.expired()) {
         PDN->getSerialManager()->writeString(
             SEND_MAC_ADDRESS + MacToString(PDN->getWirelessManager()->getMacAddress()) +
-            PORT_SEPARATOR + std::to_string((int)SerialIdentifier::INPUT_JACK) +
+            PORT_SEPARATOR + std::to_string((int)jack) +
             DEVICE_TYPE_SEPARATOR + std::to_string((int)PDN->getDeviceType()),
-            SerialIdentifier::INPUT_JACK);
+            jack);
         emitMacTimer.setTimer(emitMacInterval);
     }
 }
@@ -34,7 +36,7 @@ void InputIdleState::onStateLoop(Device *PDN) {
 void InputIdleState::onStateDismounted(Device *PDN) {
     emitMacTimer.invalidate();
     transitionToSendIdState = false;
-    handshakeWirelessManager->clearCallback(SerialIdentifier::INPUT_JACK);
+    handshakeWirelessManager->clearCallback(jack);
 }
 
 void InputIdleState::onHandshakeCommandReceived(HandshakeCommand command) {
@@ -43,7 +45,7 @@ void InputIdleState::onHandshakeCommandReceived(HandshakeCommand command) {
         memcpy(peer.macAddr.data(), command.wifiMacAddr, 6);
         peer.sid = command.sendingJack;
         peer.deviceType = static_cast<DeviceType>(command.deviceType);
-        if (!handshakeWirelessManager->setMacPeer(SerialIdentifier::INPUT_JACK, peer)) {
+        if (!handshakeWirelessManager->setMacPeer(jack, peer)) {
             LOG_W(TAG, "Rejecting EXCHANGE_ID from self-MAC (loopback or spoof)");
             return;
         }

--- a/lib/core/src/apps/handshake/input-send-id-state.cpp
+++ b/lib/core/src/apps/handshake/input-send-id-state.cpp
@@ -3,7 +3,8 @@
 
 #define TAG "INPUT_SEND_ID_STATE"
 
-InputSendIdState::InputSendIdState(HandshakeWirelessManager* handshakeWirelessManager) : State(HandshakeStateId::INPUT_SEND_ID_STATE) {
+InputSendIdState::InputSendIdState(HandshakeWirelessManager* handshakeWirelessManager, SerialIdentifier jack)
+    : State(HandshakeStateId::INPUT_SEND_ID_STATE), jack(jack) {
     this->handshakeWirelessManager = handshakeWirelessManager;
 }
 
@@ -11,14 +12,12 @@ InputSendIdState::~InputSendIdState() {
     handshakeWirelessManager = nullptr;
 }
 
-
-
 void InputSendIdState::onStateMounted(Device *PDN) {
     handshakeWirelessManager->setPacketReceivedCallback(
         std::bind(&InputSendIdState::onHandshakeCommandReceived, this, std::placeholders::_1),
-        SerialIdentifier::INPUT_JACK);
+        jack);
 
-    handshakeWirelessManager->sendPacket(HSCommand::EXCHANGE_ID, SerialIdentifier::INPUT_JACK);
+    handshakeWirelessManager->sendPacket(HSCommand::EXCHANGE_ID, jack);
 }
 
 void InputSendIdState::onHandshakeCommandReceived(HandshakeCommand command) {
@@ -31,9 +30,8 @@ void InputSendIdState::onStateLoop(Device *PDN) {}
 
 void InputSendIdState::onStateDismounted(Device *PDN) {
     transitionToConnectedState = false;
-    handshakeWirelessManager->clearCallback(SerialIdentifier::INPUT_JACK);
+    handshakeWirelessManager->clearCallback(jack);
 }
-
 
 bool InputSendIdState::transitionToConnected() {
     return transitionToConnectedState;

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -15,6 +15,7 @@ RemoteDeviceCoordinator::RemoteDeviceCoordinator() : handshakeWirelessManager(Ha
 RemoteDeviceCoordinator::~RemoteDeviceCoordinator() {
     delete inputPortHandshake;
     delete outputPortHandshake;
+    delete secondaryInputPortHandshake;
 }
 
 
@@ -25,10 +26,20 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
     handshakeWirelessManager.initialize(wirelessManager);
 
     inputPortHandshake = new HandshakeApp(&handshakeWirelessManager, SerialIdentifier::INPUT_JACK);
-    outputPortHandshake = new HandshakeApp(&handshakeWirelessManager, SerialIdentifier::OUTPUT_JACK);
-
     inputPortHandshake->initialize(PDN);
-    outputPortHandshake->initialize(PDN);
+
+    // Only create the output port handshake when an output serial jack is present.
+    // Devices like the FDN that have only input jacks will pass nullptr for outputJack.
+    if (serialManager->getOutputJack() != nullptr) {
+        outputPortHandshake = new HandshakeApp(&handshakeWirelessManager, SerialIdentifier::OUTPUT_JACK);
+        outputPortHandshake->initialize(PDN);
+    }
+
+    // Optionally initialize secondary input port (used by FDN which has two input jacks).
+    if (serialManager->getSecondaryInputJack() != nullptr) {
+        secondaryInputPortHandshake = new HandshakeApp(&handshakeWirelessManager, SerialIdentifier::INPUT_JACK_SECONDARY);
+        secondaryInputPortHandshake->initialize(PDN);
+    }
 
     wirelessManager->setEspNowPacketHandler(
         PktType::kHandshakeCommand,
@@ -65,11 +76,28 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
     );
 }
 
+std::vector<SerialIdentifier> RemoteDeviceCoordinator::activePorts() const {
+    std::vector<SerialIdentifier> ports;
+    if (inputPortHandshake)          ports.push_back(SerialIdentifier::INPUT_JACK);
+    if (outputPortHandshake)         ports.push_back(SerialIdentifier::OUTPUT_JACK);
+    if (secondaryInputPortHandshake) ports.push_back(SerialIdentifier::INPUT_JACK_SECONDARY);
+    return ports;
+}
+
+HandshakeApp* RemoteDeviceCoordinator::handshakeAppForPort(SerialIdentifier port) const {
+    switch (port) {
+        case SerialIdentifier::INPUT_JACK:           return inputPortHandshake;
+        case SerialIdentifier::OUTPUT_JACK:          return outputPortHandshake;
+        case SerialIdentifier::INPUT_JACK_SECONDARY: return secondaryInputPortHandshake;
+        default:                                     return nullptr;
+    }
+}
+
 void RemoteDeviceCoordinator::processChainAnnouncementAckPacket(const uint8_t* fromMac, const uint8_t* data, size_t dataLen) {
     if (dataLen < 1) return;
     uint8_t ackedId = data[0];
 
-    for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK}) {
+    for (SerialIdentifier port : activePorts()) {
         const Peer* directPeer = handshakeWirelessManager.getMacPeer(port);
         if (directPeer == nullptr || memcmp(directPeer->macAddr.data(), fromMac, 6) != 0) continue;
 
@@ -97,7 +125,7 @@ void RemoteDeviceCoordinator::processChainAnnouncementPacket(const uint8_t* from
     // transitioning, violating the StatusMatchesPeerList invariant.
     SerialIdentifier port;
     bool found = false;
-    for (SerialIdentifier candidate : {SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK}) {
+    for (SerialIdentifier candidate : activePorts()) {
         const Peer* directPeer = handshakeWirelessManager.getMacPeer(candidate);
         if (directPeer == nullptr) continue;
         if (memcmp(directPeer->macAddr.data(), fromMac, 6) != 0) continue;
@@ -121,32 +149,32 @@ void RemoteDeviceCoordinator::processChainAnnouncementPacket(const uint8_t* from
 }
 
 void RemoteDeviceCoordinator::sync(Device* PDN) {
-    inputPortHandshake->onStateLoop(PDN);
-    outputPortHandshake->onStateLoop(PDN);
+    if (inputPortHandshake)          inputPortHandshake->onStateLoop(PDN);
+    if (outputPortHandshake)         outputPortHandshake->onStateLoop(PDN);
+    if (secondaryInputPortHandshake) secondaryInputPortHandshake->onStateLoop(PDN);
 
     // Wipe daisy-chained peers for any port whose direct peer has dropped.
-    // The daisy-chained list represents peers reachable through the direct peer,
-    // so without a direct peer they are no longer reachable.
-    for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK}) {
+    for (SerialIdentifier port : activePorts()) {
         if (handshakeWirelessManager.getMacPeer(port) == nullptr) {
             daisyChainedByPort_[portIndex(port)].clear();
         }
     }
 
     // Detect direct peer registration transitions and emit chain announcements.
-    for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK}) {
+    for (SerialIdentifier port : activePorts()) {
         const Peer* directPeer = handshakeWirelessManager.getMacPeer(port);
         auto& prev = previousDirectPeer_[portIndex(port)];
         bool nowPresent = (directPeer != nullptr);
         bool wasPresent = prev.has_value();
 
         if (!nowPresent && wasPresent) {
-            SerialIdentifier otherPort = (port == SerialIdentifier::INPUT_JACK)
-                ? SerialIdentifier::OUTPUT_JACK : SerialIdentifier::INPUT_JACK;
-            const Peer* otherDirect = handshakeWirelessManager.getMacPeer(otherPort);
-            if (otherDirect != nullptr) {
-                // Forward: tell other side that nothing is reachable through changed_port
-                emitAnnouncementVia(otherPort, {});
+            // Notify the other ports about the disconnection
+            for (SerialIdentifier otherPort : activePorts()) {
+                if (otherPort == port) continue;
+                const Peer* otherDirect = handshakeWirelessManager.getMacPeer(otherPort);
+                if (otherDirect != nullptr) {
+                    emitAnnouncementVia(otherPort, {});
+                }
             }
             if (peerLostCallback_) {
                 peerLostCallback_(prev->data());
@@ -156,22 +184,20 @@ void RemoteDeviceCoordinator::sync(Device* PDN) {
 
         if (nowPresent && !wasPresent) {
             registerPeer(directPeer->macAddr.data());
-            SerialIdentifier otherPort = (port == SerialIdentifier::INPUT_JACK)
-                ? SerialIdentifier::OUTPUT_JACK : SerialIdentifier::INPUT_JACK;
-            const Peer* otherDirect = handshakeWirelessManager.getMacPeer(otherPort);
-
-            // Forward: tell other side about new direct peer + its chain.
-            // Only possible if the other side has a direct peer to send to.
-            if (otherDirect != nullptr) {
-                std::vector<std::array<uint8_t, 6>> forwardList;
-                forwardList.push_back(directPeer->macAddr);
-                for (const auto& mac : daisyChainedByPort_[portIndex(port)]) {
-                    forwardList.push_back(mac);
+            // Notify all other ports about the new direct peer.
+            for (SerialIdentifier otherPort : activePorts()) {
+                if (otherPort == port) continue;
+                const Peer* otherDirect = handshakeWirelessManager.getMacPeer(otherPort);
+                if (otherDirect != nullptr) {
+                    std::vector<std::array<uint8_t, 6>> forwardList;
+                    forwardList.push_back(directPeer->macAddr);
+                    for (const auto& mac : daisyChainedByPort_[portIndex(port)]) {
+                        forwardList.push_back(mac);
+                    }
+                    emitAnnouncementVia(otherPort, forwardList);
+                    emitAnnouncementVia(port, peersReachableVia(otherPort));
                 }
-                emitAnnouncementVia(otherPort, forwardList);
             }
-
-            emitAnnouncementVia(port, peersReachableVia(otherPort));
             notifyConnect();
         }
 
@@ -180,17 +206,13 @@ void RemoteDeviceCoordinator::sync(Device* PDN) {
     }
 
     // Retransmit any unacked pending announcements past the ack timeout.
-    for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK}) {
+    for (SerialIdentifier port : activePorts()) {
         PendingAnnouncement& pending = pendingByPort_[portIndex(port)];
         if (pending.active && pending.timer.expired()) {
             const Peer* directPeer = handshakeWirelessManager.getMacPeer(port);
             if (directPeer != nullptr && announcementEmitCallback_ && pending.retries < maxRetries_) {
                 announcementEmitCallback_(directPeer->macAddr.data(), pending.announcementId, pending.peers);
                 pending.retries++;
-                // Exponential backoff between retransmits: 200, 400, 800ms
-                // (maxRetries_=3). Gives the async driver queue time to drain
-                // between retries instead of layering new sends on top of
-                // in-flight ones.
                 pending.timer.setTimer(ackTimeoutMs_ << pending.retries);
                 retryStats_.retries++;
             } else {
@@ -213,7 +235,12 @@ void RemoteDeviceCoordinator::sync(Device* PDN) {
 }
 
 size_t RemoteDeviceCoordinator::portIndex(SerialIdentifier port) const {
-    return port == SerialIdentifier::INPUT_JACK ? 0 : 1;
+    switch (port) {
+        case SerialIdentifier::INPUT_JACK:           return 0;
+        case SerialIdentifier::OUTPUT_JACK:          return 1;
+        case SerialIdentifier::INPUT_JACK_SECONDARY: return 2;
+        default:                                     return 1;
+    }
 }
 
 PortStatus RemoteDeviceCoordinator::getPortStatus(SerialIdentifier port) {
@@ -267,8 +294,6 @@ void RemoteDeviceCoordinator::onChainAnnouncementReceived(
         return;
     }
 
-    // Apply the change as a diff against the current chain so all daisy
-    // mutations route through addDaisyChainedPeer / removeDaisyChainedPeer.
     auto contains = [](const std::vector<std::array<uint8_t, 6>>& v,
                        const std::array<uint8_t, 6>& m) {
         for (const auto& e : v) if (e == m) return true;
@@ -281,18 +306,18 @@ void RemoteDeviceCoordinator::onChainAnnouncementReceived(
 
     notifyDaisyChained();
 
-    // Forward propagation: tell the other side's direct peer about what's reachable
-    // through us via this port (direct peer + filtered daisy peers).
-    SerialIdentifier otherPort = (port == SerialIdentifier::INPUT_JACK)
-        ? SerialIdentifier::OUTPUT_JACK : SerialIdentifier::INPUT_JACK;
-    const Peer* otherDirect = handshakeWirelessManager.getMacPeer(otherPort);
-    if (otherDirect != nullptr) {
-        std::vector<std::array<uint8_t, 6>> forwardList;
-        forwardList.push_back(directPeer->macAddr);
-        for (const auto& mac : filtered) {
-            forwardList.push_back(mac);
+    // Forward propagation to all other ports with a direct peer.
+    for (SerialIdentifier otherPort : activePorts()) {
+        if (otherPort == port) continue;
+        const Peer* otherDirect = handshakeWirelessManager.getMacPeer(otherPort);
+        if (otherDirect != nullptr) {
+            std::vector<std::array<uint8_t, 6>> forwardList;
+            forwardList.push_back(directPeer->macAddr);
+            for (const auto& mac : filtered) {
+                forwardList.push_back(mac);
+            }
+            emitAnnouncementVia(otherPort, forwardList);
         }
-        emitAnnouncementVia(otherPort, forwardList);
     }
 }
 
@@ -301,7 +326,7 @@ void RemoteDeviceCoordinator::emitAnnouncementVia(SerialIdentifier viaPort, cons
     if (directPeer == nullptr || !announcementEmitCallback_) return;
 
     uint8_t id = nextAnnouncementId_++;
-    if (nextAnnouncementId_ == 0) nextAnnouncementId_ = 1;  // skip 0 sentinel
+    if (nextAnnouncementId_ == 0) nextAnnouncementId_ = 1;
 
     PendingAnnouncement& pending = pendingByPort_[portIndex(viaPort)];
     pending.active = true;
@@ -344,7 +369,7 @@ DeviceType RemoteDeviceCoordinator::getPeerDeviceType(SerialIdentifier port) con
 }
 
 PortStatus RemoteDeviceCoordinator::mapHandshakeStateToStatus(SerialIdentifier port) {
-    HandshakeApp* app = (port == SerialIdentifier::INPUT_JACK) ? inputPortHandshake : outputPortHandshake;
+    HandshakeApp* app = handshakeAppForPort(port);
 
     if (!app || !app->getCurrentState()) {
         return PortStatus::DISCONNECTED;
@@ -364,11 +389,6 @@ PortStatus RemoteDeviceCoordinator::mapHandshakeStateToStatus(SerialIdentifier p
         case HandshakeStateId::OUTPUT_IDLE_STATE:
         case HandshakeStateId::INPUT_IDLE_STATE:
         default:
-            // Transient: if HWM has already registered a peer but the state
-            // machine hasn't yet committed the transition out of IDLE (e.g.,
-            // between stringCallback and the next sync()), report CONNECTING
-            // so the StatusMatchesPeerList invariant holds: getPeerMac() is
-            // never non-null while status == DISCONNECTED.
             if (handshakeWirelessManager.getMacPeer(port) != nullptr) {
                 return PortStatus::CONNECTING;
             }
@@ -383,7 +403,7 @@ const uint8_t* RemoteDeviceCoordinator::getPeerMac(SerialIdentifier port) const 
 
 bool RemoteDeviceCoordinator::isDirectPeer(const uint8_t* mac) const {
     if (!mac) return false;
-    for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK}) {
+    for (SerialIdentifier port : activePorts()) {
         const uint8_t* peer = getPeerMac(port);
         if (peer && memcmp(peer, mac, 6) == 0) return true;
     }
@@ -393,7 +413,7 @@ bool RemoteDeviceCoordinator::isDirectPeer(const uint8_t* mac) const {
 bool RemoteDeviceCoordinator::canReachPeer(const uint8_t* mac) const {
     if (!mac) return false;
     if (isDirectPeer(mac)) return true;
-    for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK}) {
+    for (SerialIdentifier port : activePorts()) {
         for (const auto& daisy : daisyChainedByPort_[portIndex(port)]) {
             if (memcmp(daisy.data(), mac, 6) == 0) return true;
         }
@@ -408,11 +428,8 @@ void RemoteDeviceCoordinator::addDaisyChainedPeer(SerialIdentifier port, const u
     for (const auto& existing : chain) {
         if (existing == mac) return;
     }
-    // Hard cap to stay within the ESP-NOW peer-table limit (20 on ESP32-S3).
     if (chain.size() >= kMaxChainPeersPerPort) return;
     chain.push_back(mac);
-    // Register with the ESP-NOW peer table so the champion can unicast game
-    // events to this supporter. Idempotent at the driver level.
     registerPeer(macAddress);
 }
 
@@ -421,17 +438,12 @@ void RemoteDeviceCoordinator::removeDaisyChainedPeer(SerialIdentifier port, cons
     for (auto it = chain.begin(); it != chain.end(); ++it) {
         if (memcmp(it->data(), macAddress, 6) == 0) {
             chain.erase(it);
-            // Free the ESP-NOW peer slot unless the same MAC is still
-            // daisy-chained on the OTHER port (ring-topology remnant) or
-            // is the direct handshake peer on either jack. Without the
-            // direct-peer check, a ring-break chain-announcement diff that
-            // drops a MAC from one port's daisy list would remove the
-            // live peer from the ESP-NOW table even while its cable is
-            // still handshaking on the other jack.
-            SerialIdentifier otherPort = (port == SerialIdentifier::INPUT_JACK)
-                ? SerialIdentifier::OUTPUT_JACK : SerialIdentifier::INPUT_JACK;
-            for (const auto& m : daisyChainedByPort_[portIndex(otherPort)]) {
-                if (memcmp(m.data(), macAddress, 6) == 0) return;
+            // Only unregister if the MAC is not reachable via another port.
+            for (SerialIdentifier otherPort : activePorts()) {
+                if (otherPort == port) continue;
+                for (const auto& m : daisyChainedByPort_[portIndex(otherPort)]) {
+                    if (memcmp(m.data(), macAddress, 6) == 0) return;
+                }
             }
             if (isDirectPeer(macAddress)) return;
             unregisterPeer(macAddress);
@@ -462,11 +474,10 @@ void RemoteDeviceCoordinator::unregisterPeer(const uint8_t* macAddress) {
     if (wirelessManager_ != nullptr) {
         wirelessManager_->removeEspNowPeer(macAddress);
     }
-    for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK}) {
+    for (SerialIdentifier port : activePorts()) {
         const Peer* peer = handshakeWirelessManager.getMacPeer(port);
         if (peer != nullptr && memcmp(peer->macAddr.data(), macAddress, 6) == 0) {
             handshakeWirelessManager.removeMacPeer(port);
         }
     }
 }
-

--- a/lib/core/src/game/symbol.cpp
+++ b/lib/core/src/game/symbol.cpp
@@ -4,11 +4,11 @@
 Symbol::Symbol() {
     setRandomSymbol();
 
-    symbolGlyphMap[SymbolId::SYMBOL_A] = "\u0089";
-    symbolGlyphMap[SymbolId::SYMBOL_B] = "\u0103";
-    symbolGlyphMap[SymbolId::SYMBOL_C] = "\u0107";
-    symbolGlyphMap[SymbolId::SYMBOL_D] = "\u0081";
-    symbolGlyphMap[SymbolId::SYMBOL_E] = "\u0047";
+    symbolGlyphMap[SymbolId::SYMBOL_A] = "\u0089";  // half
+    symbolGlyphMap[SymbolId::SYMBOL_B] = "\u0103";  // sun
+    symbolGlyphMap[SymbolId::SYMBOL_C] = "\u0107";  // target
+    symbolGlyphMap[SymbolId::SYMBOL_D] = "\u0081";  // gear
+    symbolGlyphMap[SymbolId::SYMBOL_E] = "\u0047";  // aperture
 }
 
 Symbol::~Symbol() {

--- a/lib/core/src/wireless/remote-player-manager.cpp
+++ b/lib/core/src/wireless/remote-player-manager.cpp
@@ -99,6 +99,8 @@ int RemotePlayerManager::ProcessPlayerInfoPkt(const uint8_t* srcMacAddr, const u
     auto remotePlayer = std::find_if(remotePlayers.begin(), remotePlayers.end(),
         [srcMacAddr](RemotePlayer rp) { return memcmp(srcMacAddr, rp.wifiMacAddr, 6) == 0;});
 
+    int currentRssi = peerComms->getRssiForPeer(srcMacAddr);
+
     //If we don't currently have a record for them, add them
     if(remotePlayer == remotePlayers.end())
     {
@@ -106,7 +108,7 @@ int RemotePlayerManager::ProcessPlayerInfoPkt(const uint8_t* srcMacAddr, const u
         LOG_D("RPM", "Discovered player %s Allegiance: %u IsHunter: %u\n", pkt->id, pkt->allegiance, pkt->hunter);
 
         remotePlayers.emplace_back(srcMacAddr, pkt->id, pkt->allegiance, pkt->hunter,
-            SimpleTimer::getPlatformClock()->milliseconds(), 0);
+            SimpleTimer::getPlatformClock()->milliseconds(), currentRssi);
         remotePlayer = remotePlayers.end() - 1;
         LOG_I("RPM", "Added discovered player %s (Allegiance: %u, %s) at addr %X:%X:%X:%X:%X:%X\n", 
             remotePlayer->playerInfo.getUserID().c_str(),
@@ -116,12 +118,32 @@ int RemotePlayerManager::ProcessPlayerInfoPkt(const uint8_t* srcMacAddr, const u
             srcMacAddr[3], srcMacAddr[4], srcMacAddr[5]);
     }
 
-    //If we have a local record of this player, update their last seen time, regardless of packet type
+    //If we have a local record of this player, update their last seen time and RSSI
     if(remotePlayer != remotePlayers.end())
     {
         remotePlayer->lastSeenTime = SimpleTimer::getPlatformClock()->milliseconds();
-        // remotePlayer->rssi = EspNowManager::GetInstance()->GetRssiForPeer(srcMacAddr);
-        // LOG_D("RPM", "Updated peer rssi to %i\n", remotePlayer->rssi);
+        remotePlayer->rssi = currentRssi;
     }
+
+    lastRssi = currentRssi;
+    packetReceived = true;
+
     return 0;
+}
+
+bool RemotePlayerManager::consumePacketReceived()
+{
+    bool received = packetReceived;
+    packetReceived = false;
+    return received;
+}
+
+int RemotePlayerManager::getLastRssi() const
+{
+    return lastRssi;
+}
+
+int RemotePlayerManager::getRemotePlayerCount() const
+{
+    return static_cast<int>(remotePlayers.size());
 }

--- a/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
+++ b/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
@@ -224,7 +224,11 @@ public:
         return -1;
     }
 
-    // Public methods for ESP-NOW callback handling 
+    int getRssiForPeer(const uint8_t* macAddr) override {
+        return GetRssiForPeer(macAddr);
+    }
+
+    // Public methods for ESP-NOW callback handling
     // (used when re-initializing ESP-NOW in EspNowState)
     void HandleReceivedData(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int data_len) {
         // This simply forwards to the static callback method

--- a/lib/esp32-drivers/include/device/drivers/esp32-s3/esp32-s3-serial-driver.hpp
+++ b/lib/esp32-drivers/include/device/drivers/esp32-s3/esp32-s3-serial-driver.hpp
@@ -89,7 +89,7 @@ public:
         stringCallback = callback;
     }
 
-    private:
+private:
     SerialStringCallback stringCallback;
     uint8_t txPin;
     uint8_t rxPin;
@@ -172,7 +172,70 @@ public:
         stringCallback = callback;
     }
 
-    private:
+private:
+    SerialStringCallback stringCallback;
+    uint8_t txPin;
+    uint8_t rxPin;
+};
+
+// Secondary input jack — uses Serial1 (same peripheral as SerialOut, only one active at a time).
+// FDN devices have two input jacks and no output jack, so Serial1 is available for a second input.
+class Esp32s3SerialInSecondary : public SerialDriverInterface {
+public:
+    explicit Esp32s3SerialInSecondary(const std::string& name, uint8_t txPin, uint8_t rxPin)
+        : SerialDriverInterface(name), txPin(txPin), rxPin(rxPin) {}
+
+    ~Esp32s3SerialInSecondary() override {
+        stringCallback = nullptr;
+    }
+
+    int initialize() override {
+        gpio_reset_pin(static_cast<gpio_num_t>(txPin));
+        gpio_reset_pin(static_cast<gpio_num_t>(rxPin));
+
+        esp_rom_gpio_pad_select_gpio(static_cast<gpio_num_t>(txPin));
+        esp_rom_gpio_pad_select_gpio(static_cast<gpio_num_t>(rxPin));
+
+        pinMode(txPin, OUTPUT);
+        pinMode(rxPin, INPUT);
+
+        Serial1.begin(BAUDRATE, SERIAL_8N1, rxPin, txPin, true);
+        Serial1.setTimeout(100);
+        return 0;
+    }
+
+    void exec() override {
+        while (Serial1.available() > 0) {
+            char incomingChar = Serial1.read();
+            if (incomingChar == STRING_START) {
+                std::string receivedString = std::string(Serial1.readStringUntil(STRING_TERM).c_str());
+                LOG_D("SERIAL1_SEC", "Received: '%s' (len=%d)", receivedString.c_str(), receivedString.length());
+                if (stringCallback) {
+                    stringCallback(receivedString);
+                }
+            }
+        }
+    }
+
+    int availableForWrite() override { return Serial1.availableForWrite(); }
+    int available() override { return Serial1.available(); }
+    int peek() override { return Serial1.peek(); }
+    int read() override { return Serial1.read(); }
+
+    std::string readStringUntil(char terminator) override {
+        return std::string(Serial1.readStringUntil(terminator).c_str());
+    }
+
+    void print(char msg) override { Serial1.print(msg); }
+    void println(char* msg) override { Serial1.println(msg); }
+    void println(const std::string& msg) override { Serial1.println(msg.c_str()); }
+    void flush() override { Serial1.flush(); }
+
+    void setStringCallback(const SerialStringCallback& callback) override {
+        stringCallback = callback;
+    }
+
+private:
     SerialStringCallback stringCallback;
     uint8_t txPin;
     uint8_t rxPin;

--- a/lib/esp32-drivers/include/device/drivers/esp32-s3/ssd1309-u8g2-driver.hpp
+++ b/lib/esp32-drivers/include/device/drivers/esp32-s3/ssd1309-u8g2-driver.hpp
@@ -1,0 +1,164 @@
+#pragma once
+
+#include "device/drivers/driver-interface.hpp"
+#include <U8g2lib.h>
+#include <Arduino.h>
+
+class SSD1309U8G2Driver : public DisplayDriverInterface {
+public:
+    explicit SSD1309U8G2Driver(const std::string& name, uint8_t csPin, uint8_t dcPin, uint8_t rstPin)
+        : DisplayDriverInterface(name), screen(U8G2_R0, csPin, dcPin, rstPin),
+          csPin(csPin), dcPin(dcPin) {
+        pinMode(csPin, OUTPUT);
+        pinMode(dcPin, OUTPUT);
+        digitalWrite(csPin, 0);
+        digitalWrite(dcPin, 0);
+    }
+
+    ~SSD1309U8G2Driver() override = default;
+
+    int initialize() override {
+        screen.begin();
+        screen.clearBuffer();
+        screen.setContrast(175);
+        screen.setFont(u8g2_font_tenfatguys_tf);
+        screen.setFontMode(1);
+
+        return 0;
+    }
+
+    void exec() override {
+        // Display updates happen on render(), no periodic execution needed
+    }
+
+    Display* invalidateScreen() override {
+        screen.clearBuffer();
+        return this;
+    }
+
+    void render() override {
+        screen.sendBuffer();
+    }
+
+    Display* drawText(const char *text) override {
+        screen.drawStr(0, 8, text);
+        return this;
+    }
+
+    Display* drawText(const char *text, int xStart, int yStart) override {
+        screen.drawStr(xStart, yStart, text);
+        return this;
+    }
+
+    Display* drawImage(Image image, int xStart, int yStart) override {
+        int x = image.defaultStartX;
+        int y = image.defaultStartY;
+
+        if(xStart != -1) {
+            x = xStart;
+        }
+        if(yStart != -1) {
+            y = yStart;
+        }
+
+        screen.drawXBMP(x, y, image.width, image.height, image.rawImage);
+        return this;
+    }
+
+    Display* drawImage(Image image) override {
+        drawImage(image, -1, -1);
+        return this;
+    }
+
+    Display* renderGlyph(const char* unicodeForGlyph, int x, int y) override {
+        screen.drawUTF8(x, y, unicodeForGlyph);
+        return this;
+    }
+
+    Display* drawButton(const char *text, int xCenter, int yCenter) override {
+        screen.drawButtonUTF8(xCenter, yCenter, U8G2_BTN_BW2 | U8G2_BTN_HCENTER | U8G2_BTN_INV, 0, 2, 2, text);
+        return this;
+    }
+
+    int getTextWidth(const char* text) override {
+        if (text == nullptr) return 0;
+        return static_cast<int>(screen.getUTF8Width(text));
+    }
+
+    int getWidth() override { return 128; }
+
+    void reset() {
+        screen.clearBuffer();
+        screen.clearDisplay();
+    }
+
+    Display* setGlyphMode(FontMode mode) override {
+        switch (mode) {
+            case FontMode::TEXT:
+                screen.disableUTF8Print();
+                screen.setFont(u8g2_font_tenfatguys_tr);
+                screen.setDrawColor(1);
+                screen.setFontMode(0);
+                break;
+            case FontMode::NUMBER_GLYPH:
+                screen.enableUTF8Print();
+                screen.setFont(u8g2_font_twelvedings_t_all);
+                screen.setDrawColor(1);
+                screen.setFontMode(0);
+                break;
+            case FontMode::LOADING_GLYPH:
+                screen.enableUTF8Print();
+                screen.setFont(u8g2_font_unifont_t_76);
+                screen.setDrawColor(1);
+                screen.setFontMode(0);
+                break;
+            case FontMode::TEXT_INVERTED_SMALL:
+                screen.setFont(u8g2_font_tenthinnerguys_t_all);
+                screen.setFontMode(1);
+                screen.setDrawColor(2);
+                break;
+            case FontMode::TEXT_INVERTED_LARGE:
+                screen.setFont(u8g2_font_tenfatguys_tr);
+                screen.setFontMode(1);
+                screen.setDrawColor(2);
+                break;
+            case FontMode::SYMBOL_GLYPH:
+                screen.setFont(u8g2_font_open_iconic_all_4x_t);
+                screen.setDrawColor(2);
+                screen.setFontMode(1);
+                break;
+        }
+        return this;
+    }
+
+    Display* whiteScreen() override {
+        screen.clearBuffer();
+        screen.setFontMode(0);
+        screen.setDrawColor(1);
+        screen.drawBox(0, 0, screen.getDisplayWidth(), screen.getDisplayHeight());
+        return this;
+    }
+
+    Display* whiteScreenLeftHalf() override {
+        screen.setFontMode(0);
+        screen.setDrawColor(1);
+        screen.drawBox(0, 0, screen.getDisplayWidth() / 2, screen.getDisplayHeight());
+        return this;
+    }
+
+    Display* whiteScreenRightHalf() override {
+        screen.setFontMode(0);
+        screen.setDrawColor(1);
+        screen.drawBox(screen.getDisplayWidth() / 2, 0, screen.getDisplayWidth() / 2, screen.getDisplayHeight());
+        return this;
+    }
+
+private:
+    // NONAME0 vs NONAME2: u8g2's SSD1309 128x64 "NONAME2" build adds a +2 column address offset when
+    // blitting to the panel (u8x8: default_x_offset=2) for 132-px-wide internal RAM. Use NONAME0 when
+    // the FDN panel maps buffer column 0 to the left edge; NONAME2 otherwise—wrong choice shows a
+    // ghost/fixed column and wrong half-screen split.
+    U8G2_SSD1309_128X64_NONAME0_F_4W_HW_SPI screen;
+    uint8_t csPin;
+    uint8_t dcPin;
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@ extra_configs = wifi_credentials.ini
 ; ESP32-S3 BUILD ENVIRONMENTS
 ; ========================================
 
-; Base configuration for ESP32-S3 builds
+; Base configuration for PDN ESP32-S3 builds
 [env:esp32-s3_base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
 board = esp32-s3-n8r8
@@ -21,6 +21,7 @@ monitor_filters = esp32_exception_decoder
 build_src_filter =
     +<*>
     -<cli/*>
+    -<fdn/*>
 
 build_flags =
     -DBOARD_HAS_PSRAM
@@ -73,6 +74,69 @@ build_flags =
     -DCORE_DEBUG_LEVEL=5
 
 ; ========================================
+; FDN ESP32-S3 BUILD ENVIRONMENTS
+; ========================================
+
+; Base configuration for FDN ESP32-S3 builds
+[env:esp32-s3_fdn_base]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+board = esp32-s3-n8r8
+board_build.arduino.memory_type = dio_opi
+framework = arduino
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+
+build_src_filter =
+    +<*>
+    -<cli/*>
+    -<pdn/*>
+
+build_flags =
+    -DBOARD_HAS_PSRAM
+    '-DWIFI_SSID="${wifi.WIFI_SSID}"'
+    '-DWIFI_PASSWORD="${wifi.WIFI_PASSWORD}"'
+    '-DBASE_URL="${wifi.BASE_URL}"'
+    -I src/fdn
+
+lib_deps =
+    olikraus/U8g2@^2.35.14
+    fastled/FastLED@^3.6.0
+    mathertel/OneButton@^2.5.0
+    ArduinoJson@^7.4.2
+    WiFi
+
+extra_scripts = scripts/multi_flash_target.py
+custom_multi_flash_args =
+
+; FDN debug build
+[env:esp32-s3_fdn_debug]
+extends = env:esp32-s3_fdn_base
+build_type = debug
+build_flags =
+    ${env:esp32-s3_fdn_base.build_flags}
+    -DCORE_DEBUG_LEVEL=5
+    -DARDUINO_USB_MODE=1
+debug_tool = esp-builtin
+debug_init_break = tbreak loop
+
+; FDN release build
+[env:esp32-s3_fdn_release]
+extends = env:esp32-s3_fdn_base
+build_type = release
+build_flags =
+    ${env:esp32-s3_fdn_base.build_flags}
+    -DCORE_DEBUG_LEVEL=2
+custom_multi_flash_args = --clear-nvs
+
+; FDN release with verbose logging
+[env:esp32-s3_fdn_release_verbose]
+extends = env:esp32-s3_fdn_base
+build_type = release
+build_flags =
+    ${env:esp32-s3_fdn_base.build_flags}
+    -DCORE_DEBUG_LEVEL=5
+
+; ========================================
 ; NATIVE TEST ENVIRONMENT
 ; ========================================
 
@@ -89,10 +153,11 @@ build_flags =
     -I src/pdn
     -I src
 
-; Exclude PDN firmware entry point and all CLI entry points from native builds
+; PDN-only: exclude firmware entry points, CLI, and FDN device code
 build_src_filter =
     +<*>
     -<pdn/main.cpp>
+    -<fdn/*>
     -<cli/*>
 
 lib_deps = 
@@ -188,6 +253,7 @@ build_flags =
 build_src_filter =
     +<*>
     -<pdn/main.cpp>
+    -<fdn/*>
     -<cli/cli-main.cpp>
     -<cli/native-main.cpp>
 
@@ -214,10 +280,11 @@ build_flags =
     -I src
     -pthread
 
-; Include cli/cli-main.cpp, exclude PDN firmware entry point and the other native entry points
+; PDN simulator: include cli/cli-main.cpp, exclude firmware entry points and FDN code
 build_src_filter =
     +<*>
     -<pdn/main.cpp>
+    -<fdn/*>
     -<cli/native-main.cpp>
     -<cli/perf-main.cpp>
 
@@ -245,10 +312,11 @@ build_flags =
     -I src
     -pthread
 
-; Exclude all CLI entry points — test binary uses gtest main
+; PDN-only tests: exclude firmware entry points, CLI, and FDN device code
 build_src_filter =
     +<*>
     -<pdn/main.cpp>
+    -<fdn/*>
     -<cli/*>
 
 lib_deps = 

--- a/src/fdn/apps/fdn-app-ids.hpp
+++ b/src/fdn/apps/fdn-app-ids.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+constexpr int SYMBOL_MATCH_APP_ID = 5;
+constexpr int MAIN_MENU_APP_ID    = 1;
+constexpr int HACKING_APP_ID      = 3;
+constexpr int IDLE_APP_ID         = 4;

--- a/src/fdn/apps/hacking/hacked-players-manager.cpp
+++ b/src/fdn/apps/hacking/hacked-players-manager.cpp
@@ -1,0 +1,37 @@
+#include "apps/hacking/hacked-players-manager.hpp"
+#include <algorithm>
+
+HackedPlayersManager::HackedPlayersManager(StorageInterface* storage)
+    : storage(storage) {}
+
+HackedPlayersManager::~HackedPlayersManager() {
+    storage = nullptr;
+}
+
+void HackedPlayersManager::playerHackSuccessful(const std::string& playerId) {
+    storage->writeUChar(playerId, HACK_STATUS_LOCAL);
+    addToPending(playerId);
+}
+
+void HackedPlayersManager::playerHackUploaded(const std::string& playerId) {
+    storage->writeUChar(playerId, HACK_STATUS_UPLOADED);
+    removeFromPending(playerId);
+}
+
+bool HackedPlayersManager::hasPlayerHacked(const std::string& playerId) const {
+    return storage->readUChar(playerId, HACK_STATUS_NONE) >= HACK_STATUS_LOCAL;
+}
+
+std::vector<std::string> HackedPlayersManager::getPendingUploads() const {
+    return pendingCache;
+}
+
+void HackedPlayersManager::addToPending(const std::string& playerId) {
+    pendingCache.push_back(playerId);
+}
+
+void HackedPlayersManager::removeFromPending(const std::string& playerId) {
+    pendingCache.erase(
+        std::remove(pendingCache.begin(), pendingCache.end(), playerId),
+        pendingCache.end());
+}

--- a/src/fdn/apps/hacking/hacked-players-manager.hpp
+++ b/src/fdn/apps/hacking/hacked-players-manager.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "device/drivers/storage-interface.hpp"
+
+static constexpr uint8_t HACK_STATUS_NONE     = 0;
+static constexpr uint8_t HACK_STATUS_LOCAL    = 1;
+static constexpr uint8_t HACK_STATUS_UPLOADED = 2;
+
+class HackedPlayersManager {
+public:
+    explicit HackedPlayersManager(StorageInterface* storage);
+    ~HackedPlayersManager();
+
+    void playerHackSuccessful(const std::string& playerId);
+    void playerHackUploaded(const std::string& playerId);
+
+    bool hasPlayerHacked(const std::string& playerId) const;
+    std::vector<std::string> getPendingUploads() const;
+
+private:
+    StorageInterface* storage;
+    mutable std::vector<std::string> pendingCache;
+
+    void addToPending(const std::string& playerId);
+    void removeFromPending(const std::string& playerId);
+};

--- a/src/fdn/apps/hacking/hacking.cpp
+++ b/src/fdn/apps/hacking/hacking.cpp
@@ -1,0 +1,24 @@
+#include "apps/hacking/hacking.hpp"
+#include "apps/hacking/states/hacking-show-hint-state.hpp"
+#include "apps/fdn-app-ids.hpp"
+
+Hacking::Hacking(FDNConnectWirelessManager* fdnConnectWirelessManager,
+                 HackedPlayersManager* hackedPlayersManager,
+                 RemoteDeviceCoordinator* remoteDeviceCoordinator)
+    : StateMachine(HACKING_APP_ID)
+    , fdnConnectWirelessManager(fdnConnectWirelessManager)
+    , hackedPlayersManager(hackedPlayersManager)
+    , remoteDeviceCoordinator(remoteDeviceCoordinator) {}
+
+Hacking::~Hacking() {}
+
+void Hacking::populateStateMap() {
+    auto* showHintState = new HackingShowHintState(
+        fdnConnectWirelessManager, hackedPlayersManager, remoteDeviceCoordinator);
+
+    showHintState->addAppTransition(
+        std::bind(&HackingShowHintState::shouldTransitionToIdle, showHintState),
+        StateId(SYMBOL_MATCH_APP_ID));
+
+    stateMap.push_back(showHintState);
+}

--- a/src/fdn/apps/hacking/hacking.hpp
+++ b/src/fdn/apps/hacking/hacking.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "state/state-machine.hpp"
+#include "device/remote-device-coordinator.hpp"
+#include "wireless/fdn-connect-wireless-manager.hpp"
+#include "apps/hacking/hacked-players-manager.hpp"
+
+class Hacking : public StateMachine {
+public:
+    Hacking(FDNConnectWirelessManager* fdnConnectWirelessManager,
+            HackedPlayersManager* hackedPlayersManager,
+            RemoteDeviceCoordinator* remoteDeviceCoordinator);
+    ~Hacking();
+
+    void populateStateMap() override;
+
+private:
+    FDNConnectWirelessManager* fdnConnectWirelessManager;
+    HackedPlayersManager* hackedPlayersManager;
+    RemoteDeviceCoordinator* remoteDeviceCoordinator;
+};

--- a/src/fdn/apps/hacking/states/hacking-show-hint-state.cpp
+++ b/src/fdn/apps/hacking/states/hacking-show-hint-state.cpp
@@ -1,0 +1,42 @@
+#include "apps/hacking/states/hacking-show-hint-state.hpp"
+#include "utils/display-utils.hpp"
+#include "device/drivers/logger.hpp"
+
+#define TAG "HACKING_HINT"
+
+HackingShowHintState::HackingShowHintState(
+    FDNConnectWirelessManager* fdnConnectWirelessManager,
+    HackedPlayersManager* hackedPlayersManager,
+    RemoteDeviceCoordinator* remoteDeviceCoordinator)
+    : FDNConnectState(remoteDeviceCoordinator, HackingStateId::HACKING_HINT)
+    , fdnConnectWirelessManager(fdnConnectWirelessManager)
+    , hackedPlayersManager(hackedPlayersManager) {}
+
+HackingShowHintState::~HackingShowHintState() {}
+
+void HackingShowHintState::onStateMounted(FDN* fdn) {
+    LOG_I(TAG, "Mounted");
+    fdn->getDisplay()
+        ->invalidateScreen()
+        ->drawText("PLEASE", centeredTextX("PLEASE"), 32)
+        ->drawText("DISCONNECT", centeredTextX("DISCONNECT"), 48)
+        ->render();
+
+    fdn->getTertiaryButton()->setButtonPress([](void* ctx) {
+        static_cast<HackingShowHintState*>(ctx)->transitionToIdle = true;
+    }, this, ButtonInteraction::PRESS);
+}
+
+void HackingShowHintState::onStateLoop(FDN* fdn) {
+    (void)fdn;
+}
+
+void HackingShowHintState::onStateDismounted(FDN* fdn) {
+    LOG_I(TAG, "Dismounted");
+    fdn->getTertiaryButton()->removeButtonCallbacks();
+    transitionToIdle = false;
+}
+
+bool HackingShowHintState::shouldTransitionToIdle() {
+    return transitionToIdle || !isConnected();
+}

--- a/src/fdn/apps/hacking/states/hacking-show-hint-state.hpp
+++ b/src/fdn/apps/hacking/states/hacking-show-hint-state.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "state/fdn-connect-state.hpp"
+#include "device/fdn.hpp"
+#include "wireless/fdn-connect-wireless-manager.hpp"
+#include "apps/hacking/hacked-players-manager.hpp"
+#include "utils/simple-timer.hpp"
+
+enum HackingStateId {
+    HACKING_HINT = 0,
+};
+
+class HackingShowHintState : public FDNConnectState {
+public:
+    HackingShowHintState(FDNConnectWirelessManager* fdnConnectWirelessManager,
+                         HackedPlayersManager* hackedPlayersManager,
+                         RemoteDeviceCoordinator* remoteDeviceCoordinator);
+    ~HackingShowHintState();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    bool shouldTransitionToIdle();
+
+private:
+    FDNConnectWirelessManager* fdnConnectWirelessManager;
+    HackedPlayersManager* hackedPlayersManager;
+    bool transitionToIdle = false;
+};

--- a/src/fdn/apps/idle/idle-states.hpp
+++ b/src/fdn/apps/idle/idle-states.hpp
@@ -1,0 +1,211 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include "state/fdn-connect-state.hpp"
+#include "state/state.hpp"
+#include "device/fdn.hpp"
+#include "wireless/remote-player-manager.hpp"
+#include "wireless/fdn-connect-wireless-manager.hpp"
+#include "apps/hacking/hacked-players-manager.hpp"
+#include "device/remote-device-coordinator.hpp"
+#include "utils/simple-timer.hpp"
+
+enum IdleStateId {
+    IDLE                = 0,
+    PLAYER_DETECTED     = 1,
+    AUTHORIZED_PDN      = 2,
+    UNAUTHORIZED_PDN    = 3,
+    CONNECTION_DETECTED = 4,
+    UPLOAD_PENDING      = 5,
+};
+
+// ---------------------------------------------------------------------------
+// IdleState
+// ---------------------------------------------------------------------------
+class IdleState : public FDNConnectState {
+public:
+    IdleState(RemotePlayerManager* remotePlayerManager,
+              HackedPlayersManager* hackedPlayersManager,
+              FDNConnectWirelessManager* fdnConnectWirelessManager,
+              RemoteDeviceCoordinator* remoteDeviceCoordinator);
+    ~IdleState();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    void setConnectionHandler(std::function<void(const std::string&, const uint8_t*)> handler);
+
+    bool transitionToPlayerDetected();
+    bool transitionToConnectionDetected();
+    bool transitionToUploadPending();
+
+private:
+    RemotePlayerManager* remotePlayerManager;
+    HackedPlayersManager* hackedPlayersManager;
+    FDNConnectWirelessManager* fdnConnectWirelessManager;
+
+    std::function<void(const std::string&, const uint8_t*)> connectionHandler;
+
+    SimpleTimer uploadTimer;
+    bool connectionResolved = false;
+    bool wasConnected       = false;
+
+    static constexpr int UPLOAD_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+};
+
+// ---------------------------------------------------------------------------
+// PlayerDetectedState
+// ---------------------------------------------------------------------------
+enum class PlayerDetectedStrength { WEAK, MEDIUM, STRONG };
+
+struct PlayerDetectionConfig {
+    PlayerDetectedStrength strength;
+    int timeout;
+    uint8_t intensity;
+};
+
+class PlayerDetectedState : public FDNConnectState {
+public:
+    PlayerDetectedState(RemotePlayerManager* remotePlayerManager,
+                        HackedPlayersManager* hackedPlayersManager,
+                        FDNConnectWirelessManager* fdnConnectWirelessManager,
+                        RemoteDeviceCoordinator* remoteDeviceCoordinator);
+    ~PlayerDetectedState();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    void setConnectionHandler(std::function<void(const std::string&, const uint8_t*)> handler);
+
+    bool transitionToIdle();
+    bool transitionToConnectionDetected();
+
+private:
+    RemotePlayerManager* remotePlayerManager;
+    HackedPlayersManager* hackedPlayersManager;
+    FDNConnectWirelessManager* fdnConnectWirelessManager;
+
+    std::function<void(const std::string&, const uint8_t*)> connectionHandler;
+
+    SimpleTimer playerDetectedTimer;
+    bool connectionResolved = false;
+    bool wasConnected       = false;
+    const PlayerDetectionConfig* activeConfig = nullptr;
+
+    static constexpr int STRONG_RSSI_THRESHOLD = -50;
+    static constexpr int MEDIUM_RSSI_THRESHOLD = -65;
+
+    const PlayerDetectionConfig WEAK_CFG   = { PlayerDetectedStrength::WEAK,   2500,  80 };
+    const PlayerDetectionConfig MEDIUM_CFG = { PlayerDetectedStrength::MEDIUM, 2500, 150 };
+    const PlayerDetectionConfig STRONG_CFG = { PlayerDetectedStrength::STRONG, 5000, 255 };
+};
+
+// ---------------------------------------------------------------------------
+// ConnectionDetectedState
+// ---------------------------------------------------------------------------
+class ConnectionDetectedState : public FDNConnectState {
+public:
+    ConnectionDetectedState(HackedPlayersManager* hackedPlayersManager,
+                            FDNConnectWirelessManager* fdnConnectWirelessManager,
+                            RemoteDeviceCoordinator* remoteDeviceCoordinator);
+    ~ConnectionDetectedState();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    void receivePdnConnection(const std::string& playerId);
+
+    bool transitionToAuth();
+    bool transitionToUnauthorized();
+    bool transitionToIdle();
+
+private:
+    HackedPlayersManager* hackedPlayersManager;
+    FDNConnectWirelessManager* fdnConnectWirelessManager;
+
+    SimpleTimer glyphTimer;
+    bool contentReady = false;
+    bool wasHacked    = false;
+    std::string pendingPlayerId;
+};
+
+// ---------------------------------------------------------------------------
+// AuthDetectedState
+// ---------------------------------------------------------------------------
+class AuthDetectedState : public FDNConnectState {
+public:
+    AuthDetectedState(RemoteDeviceCoordinator* remoteDeviceCoordinator,
+                      FDNConnectWirelessManager* fdnConnectWirelessManager);
+    ~AuthDetectedState();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    bool transitionToIdle();
+    bool transitionToMainMenu();
+
+private:
+    FDNConnectWirelessManager* fdnConnectWirelessManager;
+
+    SimpleTimer glyphTimer;
+    SimpleTimer switchTimer;
+    bool contentReady = false;
+
+    static constexpr int SWITCH_DELAY_MS = 5000;
+    const char* AUTH_MESSAGE[2] = {"WELCOME", "ASSET #"};
+};
+
+// ---------------------------------------------------------------------------
+// UnauthorizedDetectedState
+// ---------------------------------------------------------------------------
+class UnauthorizedDetectedState : public FDNConnectState {
+public:
+    explicit UnauthorizedDetectedState(RemoteDeviceCoordinator* remoteDeviceCoordinator);
+    ~UnauthorizedDetectedState();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    bool transitionToIdle();
+    bool transitionToHacking();
+
+private:
+    SimpleTimer glyphTimer;
+    SimpleTimer switchTimer;
+    bool contentReady = false;
+
+    static constexpr int SWITCH_DELAY_MS = 5000;
+    const char* ACCESS_DENIED_MESSAGE[2] = {"ACCESS", "DENIED"};
+};
+
+// ---------------------------------------------------------------------------
+// UploadPendingHacksState  (no connection required, so uses plain State)
+// ---------------------------------------------------------------------------
+class UploadPendingHacksState : public TypedState<FDN> {
+public:
+    explicit UploadPendingHacksState(HackedPlayersManager* hackedPlayersManager);
+    ~UploadPendingHacksState();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    bool transitionToIdle();
+
+private:
+    HackedPlayersManager* hackedPlayersManager;
+
+    SimpleTimer glyphTimer;
+    SimpleTimer fallbackTimer;
+    bool contentReady  = false;
+    int  pendingCount  = 0;
+    int  completedCount = 0;
+
+    static constexpr int FALLBACK_TIMEOUT_MS = 15000;
+};

--- a/src/fdn/apps/idle/idle.cpp
+++ b/src/fdn/apps/idle/idle.cpp
@@ -1,0 +1,86 @@
+#include "apps/idle/idle.hpp"
+#include "apps/idle/idle-states.hpp"
+#include "apps/fdn-app-ids.hpp"
+
+Idle::Idle(RemotePlayerManager* remotePlayerManager,
+           HackedPlayersManager* hackedPlayersManager,
+           FDNConnectWirelessManager* fdnConnectWirelessManager,
+           RemoteDeviceCoordinator* remoteDeviceCoordinator)
+    : StateMachine(IDLE_APP_ID)
+    , remotePlayerManager(remotePlayerManager)
+    , hackedPlayersManager(hackedPlayersManager)
+    , fdnConnectWirelessManager(fdnConnectWirelessManager)
+    , remoteDeviceCoordinator(remoteDeviceCoordinator) {}
+
+Idle::~Idle() {
+    remotePlayerManager       = nullptr;
+    hackedPlayersManager      = nullptr;
+    fdnConnectWirelessManager = nullptr;
+    remoteDeviceCoordinator   = nullptr;
+}
+
+void Idle::populateStateMap() {
+    auto* idleState = new IdleState(
+        remotePlayerManager, hackedPlayersManager,
+        fdnConnectWirelessManager, remoteDeviceCoordinator);
+    auto* playerDetectedState = new PlayerDetectedState(
+        remotePlayerManager, hackedPlayersManager,
+        fdnConnectWirelessManager, remoteDeviceCoordinator);
+    auto* authDetectedState         = new AuthDetectedState(remoteDeviceCoordinator, fdnConnectWirelessManager);
+    auto* unauthorizedDetectedState = new UnauthorizedDetectedState(remoteDeviceCoordinator);
+    auto* connectionDetectedState   = new ConnectionDetectedState(
+        hackedPlayersManager, fdnConnectWirelessManager, remoteDeviceCoordinator);
+    auto* uploadPendingState = new UploadPendingHacksState(hackedPlayersManager);
+
+    // Shared connect handler: forwards the player ID to ConnectionDetectedState.
+    auto connectHandler = [connectionDetectedState](
+        const std::string& playerId, const uint8_t*) {
+        connectionDetectedState->receivePdnConnection(playerId);
+    };
+    idleState->setConnectionHandler(connectHandler);
+    playerDetectedState->setConnectionHandler(connectHandler);
+
+    idleState->addTransition(new StateTransition(
+        std::bind(&IdleState::transitionToPlayerDetected, idleState), playerDetectedState));
+    idleState->addTransition(new StateTransition(
+        std::bind(&IdleState::transitionToConnectionDetected, idleState), connectionDetectedState));
+    idleState->addTransition(new StateTransition(
+        std::bind(&IdleState::transitionToUploadPending, idleState), uploadPendingState));
+
+    playerDetectedState->addTransition(new StateTransition(
+        std::bind(&PlayerDetectedState::transitionToIdle, playerDetectedState), idleState));
+    playerDetectedState->addTransition(new StateTransition(
+        std::bind(&PlayerDetectedState::transitionToConnectionDetected, playerDetectedState),
+        connectionDetectedState));
+
+    connectionDetectedState->addTransition(new StateTransition(
+        std::bind(&ConnectionDetectedState::transitionToIdle, connectionDetectedState), idleState));
+    connectionDetectedState->addTransition(new StateTransition(
+        std::bind(&ConnectionDetectedState::transitionToAuth, connectionDetectedState),
+        authDetectedState));
+    connectionDetectedState->addAppTransition(
+        std::bind(&ConnectionDetectedState::transitionToUnauthorized, connectionDetectedState),
+        StateId(SYMBOL_MATCH_APP_ID));
+
+    authDetectedState->addTransition(new StateTransition(
+        std::bind(&AuthDetectedState::transitionToIdle, authDetectedState), idleState));
+    authDetectedState->addAppTransition(
+        std::bind(&AuthDetectedState::transitionToMainMenu, authDetectedState),
+        StateId(MAIN_MENU_APP_ID));
+
+    unauthorizedDetectedState->addTransition(new StateTransition(
+        std::bind(&UnauthorizedDetectedState::transitionToIdle, unauthorizedDetectedState), idleState));
+    unauthorizedDetectedState->addAppTransition(
+        std::bind(&UnauthorizedDetectedState::transitionToHacking, unauthorizedDetectedState),
+        StateId(HACKING_APP_ID));
+
+    uploadPendingState->addTransition(new StateTransition(
+        std::bind(&UploadPendingHacksState::transitionToIdle, uploadPendingState), idleState));
+
+    stateMap.push_back(idleState);                 // [0] IDLE
+    stateMap.push_back(playerDetectedState);        // [1] PLAYER_DETECTED
+    stateMap.push_back(authDetectedState);          // [2] AUTHORIZED_PDN
+    stateMap.push_back(unauthorizedDetectedState);  // [3] UNAUTHORIZED_PDN
+    stateMap.push_back(connectionDetectedState);    // [4] CONNECTION_DETECTED
+    stateMap.push_back(uploadPendingState);         // [5] UPLOAD_PENDING
+}

--- a/src/fdn/apps/idle/idle.hpp
+++ b/src/fdn/apps/idle/idle.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "state/state-machine.hpp"
+#include "wireless/remote-player-manager.hpp"
+#include "wireless/fdn-connect-wireless-manager.hpp"
+#include "device/remote-device-coordinator.hpp"
+#include "apps/hacking/hacked-players-manager.hpp"
+
+class Idle : public StateMachine {
+public:
+    Idle(RemotePlayerManager* remotePlayerManager,
+         HackedPlayersManager* hackedPlayersManager,
+         FDNConnectWirelessManager* fdnConnectWirelessManager,
+         RemoteDeviceCoordinator* remoteDeviceCoordinator);
+    ~Idle();
+
+    void populateStateMap() override;
+
+private:
+    RemotePlayerManager* remotePlayerManager;
+    HackedPlayersManager* hackedPlayersManager;
+    FDNConnectWirelessManager* fdnConnectWirelessManager;
+    RemoteDeviceCoordinator* remoteDeviceCoordinator;
+};

--- a/src/fdn/apps/idle/states/auth-detected-state.cpp
+++ b/src/fdn/apps/idle/states/auth-detected-state.cpp
@@ -1,0 +1,52 @@
+#include "apps/idle/idle-states.hpp"
+#include "utils/display-utils.hpp"
+#include "device/drivers/logger.hpp"
+
+#define TAG "AUTH_DETECTED"
+
+AuthDetectedState::AuthDetectedState(RemoteDeviceCoordinator* remoteDeviceCoordinator,
+                                     FDNConnectWirelessManager* fdnConnectWirelessManager)
+    : FDNConnectState(remoteDeviceCoordinator, IdleStateId::AUTHORIZED_PDN)
+    , fdnConnectWirelessManager(fdnConnectWirelessManager) {}
+
+AuthDetectedState::~AuthDetectedState() {
+    fdnConnectWirelessManager = nullptr;
+}
+
+void AuthDetectedState::onStateMounted(FDN* fdn) {
+    LOG_I(TAG, "Mounted — authorized player");
+    contentReady = false;
+    glyphTimer.setTimer(GLYPH_LOADING_DURATION_MS);
+    showLoadingGlyphs(fdn->getDisplay());
+}
+
+void AuthDetectedState::onStateLoop(FDN* fdn) {
+    if (isInGlyphLoadingPhase(fdn->getDisplay(), glyphTimer)) return;
+
+    if (!contentReady) {
+        const std::string& peerId = fdnConnectWirelessManager->getPeerPlayerId();
+        fdn->getDisplay()
+            ->invalidateScreen()
+            ->drawText(AUTH_MESSAGE[0], centeredTextX(AUTH_MESSAGE[0]), 20)
+            ->drawText(AUTH_MESSAGE[1], centeredTextX(AUTH_MESSAGE[1]), 36)
+            ->drawText(peerId.c_str(), centeredTextX(peerId.c_str()), 52)
+            ->render();
+        switchTimer.setTimer(SWITCH_DELAY_MS);
+        contentReady = true;
+    }
+}
+
+void AuthDetectedState::onStateDismounted(FDN* fdn) {
+    (void)fdn;
+    glyphTimer.invalidate();
+    switchTimer.invalidate();
+    contentReady = false;
+}
+
+bool AuthDetectedState::transitionToIdle() {
+    return !isConnected();
+}
+
+bool AuthDetectedState::transitionToMainMenu() {
+    return contentReady && switchTimer.expired();
+}

--- a/src/fdn/apps/idle/states/connection-detected-state.cpp
+++ b/src/fdn/apps/idle/states/connection-detected-state.cpp
@@ -1,0 +1,60 @@
+#include "apps/idle/idle-states.hpp"
+#include "utils/display-utils.hpp"
+#include "device/drivers/logger.hpp"
+
+#define TAG "CONN_DETECTED"
+
+ConnectionDetectedState::ConnectionDetectedState(HackedPlayersManager* hackedPlayersManager,
+                                                 FDNConnectWirelessManager* fdnConnectWirelessManager,
+                                                 RemoteDeviceCoordinator* remoteDeviceCoordinator)
+    : FDNConnectState(remoteDeviceCoordinator, IdleStateId::CONNECTION_DETECTED)
+    , hackedPlayersManager(hackedPlayersManager)
+    , fdnConnectWirelessManager(fdnConnectWirelessManager) {}
+
+ConnectionDetectedState::~ConnectionDetectedState() {
+    hackedPlayersManager      = nullptr;
+    fdnConnectWirelessManager = nullptr;
+}
+
+void ConnectionDetectedState::receivePdnConnection(const std::string& playerId) {
+    pendingPlayerId = playerId;
+}
+
+void ConnectionDetectedState::onStateMounted(FDN* fdn) {
+    LOG_I(TAG, "Mounted — player: %s", pendingPlayerId.c_str());
+    contentReady = false;
+    glyphTimer.setTimer(GLYPH_LOADING_DURATION_MS);
+    showLoadingGlyphs(fdn->getDisplay());
+}
+
+void ConnectionDetectedState::onStateLoop(FDN* fdn) {
+    if (isInGlyphLoadingPhase(fdn->getDisplay(), glyphTimer)) return;
+
+    if (!contentReady) {
+        wasHacked = hackedPlayersManager->hasPlayerHacked(pendingPlayerId);
+        LOG_I(TAG, "Player %s — hacked: %s", pendingPlayerId.c_str(), wasHacked ? "yes" : "no");
+        fdn->getDisplay()->invalidateScreen()->render();
+        contentReady = true;
+    }
+}
+
+void ConnectionDetectedState::onStateDismounted(FDN* fdn) {
+    LOG_I(TAG, "Dismounted");
+    (void)fdn;
+    glyphTimer.invalidate();
+    contentReady    = false;
+    wasHacked       = false;
+    pendingPlayerId.clear();
+}
+
+bool ConnectionDetectedState::transitionToAuth() {
+    return contentReady && wasHacked;
+}
+
+bool ConnectionDetectedState::transitionToUnauthorized() {
+    return contentReady && !wasHacked;
+}
+
+bool ConnectionDetectedState::transitionToIdle() {
+    return !isConnected();
+}

--- a/src/fdn/apps/idle/states/idle-state.cpp
+++ b/src/fdn/apps/idle/states/idle-state.cpp
@@ -1,0 +1,78 @@
+#include "apps/idle/idle-states.hpp"
+#include "utils/display-utils.hpp"
+#include "device/drivers/logger.hpp"
+
+#define TAG "IDLE_STATE"
+
+IdleState::IdleState(RemotePlayerManager* remotePlayerManager,
+                     HackedPlayersManager* hackedPlayersManager,
+                     FDNConnectWirelessManager* fdnConnectWirelessManager,
+                     RemoteDeviceCoordinator* remoteDeviceCoordinator)
+    : FDNConnectState(remoteDeviceCoordinator, IdleStateId::IDLE)
+    , remotePlayerManager(remotePlayerManager)
+    , hackedPlayersManager(hackedPlayersManager)
+    , fdnConnectWirelessManager(fdnConnectWirelessManager) {}
+
+IdleState::~IdleState() {
+    remotePlayerManager       = nullptr;
+    hackedPlayersManager      = nullptr;
+    fdnConnectWirelessManager = nullptr;
+}
+
+void IdleState::setConnectionHandler(
+    std::function<void(const std::string&, const uint8_t*)> handler) {
+    connectionHandler = std::move(handler);
+}
+
+void IdleState::onStateMounted(FDN* fdn) {
+    LOG_I(TAG, "Mounted");
+    fdn->getLightManager()->clear();
+    remotePlayerManager->consumePacketReceived();
+    connectionResolved = false;
+    wasConnected       = false;
+
+    fdnConnectWirelessManager->setConnectCallback(
+        [this](const std::string& playerId, const uint8_t* senderMac) {
+            LOG_I(TAG, "PDN connected, player: %s", playerId.c_str());
+            fdnConnectWirelessManager->setPeer(senderMac);
+            if (connectionHandler) connectionHandler(playerId, senderMac);
+            connectionResolved = true;
+        });
+
+    uploadTimer.setTimer(UPLOAD_CHECK_INTERVAL_MS);
+
+    fdn->getDisplay()
+        ->invalidateScreen()
+        ->drawText("ALLEYCAT", centeredTextX("ALLEYCAT"), 32)
+        ->render();
+}
+
+void IdleState::onStateLoop(FDN* fdn) {
+    remotePlayerManager->Update();
+
+    bool nowConnected = isConnected();
+    if (nowConnected && !wasConnected) {
+        connectionResolved = true;
+    }
+    wasConnected = nowConnected;
+}
+
+void IdleState::onStateDismounted(FDN* fdn) {
+    LOG_I(TAG, "Dismounted");
+    (void)fdn;
+    fdnConnectWirelessManager->clearCallbacks();
+    uploadTimer.invalidate();
+    connectionResolved = false;
+}
+
+bool IdleState::transitionToPlayerDetected() {
+    return remotePlayerManager->consumePacketReceived();
+}
+
+bool IdleState::transitionToConnectionDetected() {
+    return connectionResolved;
+}
+
+bool IdleState::transitionToUploadPending() {
+    return uploadTimer.expired() && !hackedPlayersManager->getPendingUploads().empty();
+}

--- a/src/fdn/apps/idle/states/player-detected-state.cpp
+++ b/src/fdn/apps/idle/states/player-detected-state.cpp
@@ -1,0 +1,99 @@
+#include "apps/idle/idle-states.hpp"
+#include "utils/display-utils.hpp"
+#include "device/drivers/logger.hpp"
+#include "device/animation/fdn-player-detected-animation.hpp"
+
+#define TAG "PLAYER_DETECTED"
+
+PlayerDetectedState::PlayerDetectedState(RemotePlayerManager* remotePlayerManager,
+                                         HackedPlayersManager* hackedPlayersManager,
+                                         FDNConnectWirelessManager* fdnConnectWirelessManager,
+                                         RemoteDeviceCoordinator* remoteDeviceCoordinator)
+    : FDNConnectState(remoteDeviceCoordinator, IdleStateId::PLAYER_DETECTED)
+    , remotePlayerManager(remotePlayerManager)
+    , hackedPlayersManager(hackedPlayersManager)
+    , fdnConnectWirelessManager(fdnConnectWirelessManager) {}
+
+PlayerDetectedState::~PlayerDetectedState() {
+    remotePlayerManager       = nullptr;
+    hackedPlayersManager      = nullptr;
+    fdnConnectWirelessManager = nullptr;
+}
+
+void PlayerDetectedState::setConnectionHandler(
+    std::function<void(const std::string&, const uint8_t*)> handler) {
+    connectionHandler = std::move(handler);
+}
+
+void PlayerDetectedState::onStateMounted(FDN* fdn) {
+    int rssi = remotePlayerManager->getLastRssi();
+    if      (rssi > STRONG_RSSI_THRESHOLD) activeConfig = &STRONG_CFG;
+    else if (rssi > MEDIUM_RSSI_THRESHOLD) activeConfig = &MEDIUM_CFG;
+    else                                   activeConfig = &WEAK_CFG;
+
+    LOG_I(TAG, "Mounted — rssi %d, timeout %dms", rssi, activeConfig->timeout);
+
+    connectionResolved = false;
+    wasConnected       = false;
+
+    fdnConnectWirelessManager->setConnectCallback(
+        [this](const std::string& playerId, const uint8_t* senderMac) {
+            LOG_I(TAG, "PDN connected, player: %s", playerId.c_str());
+            fdnConnectWirelessManager->setPeer(senderMac);
+            if (connectionHandler) connectionHandler(playerId, senderMac);
+            connectionResolved = true;
+        });
+
+    fdn->getDisplay()
+        ->invalidateScreen()
+        ->drawText("PLAYER", centeredTextX("PLAYER"), 24)
+        ->drawText("NEARBY", centeredTextX("NEARBY"), 40)
+        ->render();
+
+    LEDState initialState;
+    static constexpr LEDColor kBlue(0, 150, 255);
+    for (uint8_t i = 0; i < 9; ++i) {
+        initialState.leftLights[i]  = LEDState::SingleLEDState(kBlue, activeConfig->intensity);
+        initialState.rightLights[i] = LEDState::SingleLEDState(kBlue, activeConfig->intensity / 2);
+    }
+
+    uint8_t frameSpeed = static_cast<uint8_t>(
+        std::max(6, (255 - static_cast<int>(activeConfig->intensity)) / 7));
+
+    AnimationConfig cfg{};
+    cfg.loop         = true;
+    cfg.speed        = frameSpeed;
+    cfg.curve        = EaseCurve::EASE_IN_OUT;
+    cfg.initialState = initialState;
+    fdn->getLightManager()->startAnimation(new FDNPlayerDetectedAnimation(), cfg);
+
+    playerDetectedTimer.setTimer(activeConfig->timeout);
+}
+
+void PlayerDetectedState::onStateLoop(FDN* fdn) {
+    (void)fdn;
+    remotePlayerManager->Update();
+
+    bool nowConnected = isConnected();
+    if (nowConnected && !wasConnected) {
+        connectionResolved = true;
+    }
+    wasConnected = nowConnected;
+}
+
+void PlayerDetectedState::onStateDismounted(FDN* fdn) {
+    LOG_I(TAG, "Dismounted");
+    fdnConnectWirelessManager->clearCallbacks();
+    fdn->getLightManager()->stopAnimation();
+    playerDetectedTimer.invalidate();
+    connectionResolved = false;
+    activeConfig       = nullptr;
+}
+
+bool PlayerDetectedState::transitionToIdle() {
+    return playerDetectedTimer.expired();
+}
+
+bool PlayerDetectedState::transitionToConnectionDetected() {
+    return connectionResolved;
+}

--- a/src/fdn/apps/idle/states/unauthorized-detected-state.cpp
+++ b/src/fdn/apps/idle/states/unauthorized-detected-state.cpp
@@ -1,0 +1,46 @@
+#include "apps/idle/idle-states.hpp"
+#include "utils/display-utils.hpp"
+#include "device/drivers/logger.hpp"
+
+#define TAG "UNAUTH_DETECTED"
+
+UnauthorizedDetectedState::UnauthorizedDetectedState(RemoteDeviceCoordinator* remoteDeviceCoordinator)
+    : FDNConnectState(remoteDeviceCoordinator, IdleStateId::UNAUTHORIZED_PDN) {}
+
+UnauthorizedDetectedState::~UnauthorizedDetectedState() {}
+
+void UnauthorizedDetectedState::onStateMounted(FDN* fdn) {
+    LOG_I(TAG, "Mounted — new player");
+    contentReady = false;
+    glyphTimer.setTimer(GLYPH_LOADING_DURATION_MS);
+    showLoadingGlyphs(fdn->getDisplay());
+}
+
+void UnauthorizedDetectedState::onStateLoop(FDN* fdn) {
+    if (isInGlyphLoadingPhase(fdn->getDisplay(), glyphTimer)) return;
+
+    if (!contentReady) {
+        fdn->getDisplay()
+            ->invalidateScreen()
+            ->drawText(ACCESS_DENIED_MESSAGE[0], centeredTextX(ACCESS_DENIED_MESSAGE[0]), 28)
+            ->drawText(ACCESS_DENIED_MESSAGE[1], centeredTextX(ACCESS_DENIED_MESSAGE[1]), 44)
+            ->render();
+        switchTimer.setTimer(SWITCH_DELAY_MS);
+        contentReady = true;
+    }
+}
+
+void UnauthorizedDetectedState::onStateDismounted(FDN* fdn) {
+    (void)fdn;
+    glyphTimer.invalidate();
+    switchTimer.invalidate();
+    contentReady = false;
+}
+
+bool UnauthorizedDetectedState::transitionToIdle() {
+    return !isConnected();
+}
+
+bool UnauthorizedDetectedState::transitionToHacking() {
+    return contentReady && switchTimer.expired();
+}

--- a/src/fdn/apps/idle/states/upload-pending-hacks-state.cpp
+++ b/src/fdn/apps/idle/states/upload-pending-hacks-state.cpp
@@ -1,0 +1,79 @@
+#include "apps/idle/idle-states.hpp"
+#include "utils/display-utils.hpp"
+#include "wireless/wireless-types.hpp"
+#include "fdn-constants.hpp"
+#include "device/drivers/logger.hpp"
+
+#define TAG "UPLOAD_PENDING"
+
+UploadPendingHacksState::UploadPendingHacksState(HackedPlayersManager* hackedPlayersManager)
+    : TypedState<FDN>(IdleStateId::UPLOAD_PENDING)
+    , hackedPlayersManager(hackedPlayersManager) {}
+
+UploadPendingHacksState::~UploadPendingHacksState() {
+    hackedPlayersManager = nullptr;
+}
+
+void UploadPendingHacksState::onStateMounted(FDN* fdn) {
+    contentReady   = false;
+    completedCount = 0;
+
+    auto pending  = hackedPlayersManager->getPendingUploads();
+    pendingCount  = static_cast<int>(pending.size());
+
+    LOG_I(TAG, "Mounted — %d pending upload(s)", pendingCount);
+
+    for (const auto& playerId : pending) {
+        std::string payload =
+            "{\"playerId\":\"" + playerId +
+            "\",\"boxId\":"    + std::to_string(static_cast<int>(FDN_BOX_ID)) +
+            ",\"hacked\":true}";
+
+        HttpRequest req(
+            "/api/boxes",
+            "POST",
+            payload,
+            [this, playerId](const std::string&) {
+                LOG_I(TAG, "Upload succeeded for %s", playerId.c_str());
+                hackedPlayersManager->playerHackUploaded(playerId);
+                completedCount++;
+            },
+            [this, playerId](const WirelessErrorInfo& err) {
+                LOG_E(TAG, "Upload failed for %s: %s", playerId.c_str(), err.message.c_str());
+                completedCount++;
+            });
+
+        fdn->getHttpClient()->queueRequest(req);
+    }
+
+    fallbackTimer.setTimer(FALLBACK_TIMEOUT_MS);
+    glyphTimer.setTimer(GLYPH_LOADING_DURATION_MS);
+    showLoadingGlyphs(fdn->getDisplay());
+}
+
+void UploadPendingHacksState::onStateLoop(FDN* fdn) {
+    if (isInGlyphLoadingPhase(fdn->getDisplay(), glyphTimer)) return;
+
+    if (!contentReady) {
+        fdn->getDisplay()
+            ->invalidateScreen()
+            ->drawText("SYNCING", centeredTextX("SYNCING"), 32)
+            ->render();
+        contentReady = true;
+    }
+}
+
+void UploadPendingHacksState::onStateDismounted(FDN* fdn) {
+    (void)fdn;
+    LOG_I(TAG, "Dismounted — %d/%d uploads completed", completedCount, pendingCount);
+    glyphTimer.invalidate();
+    fallbackTimer.invalidate();
+    contentReady   = false;
+    pendingCount   = 0;
+    completedCount = 0;
+}
+
+bool UploadPendingHacksState::transitionToIdle() {
+    if (pendingCount == 0) return true;
+    return completedCount >= pendingCount || fallbackTimer.expired();
+}

--- a/src/fdn/apps/main-menu/main-menu-state.cpp
+++ b/src/fdn/apps/main-menu/main-menu-state.cpp
@@ -1,0 +1,47 @@
+#include "apps/main-menu/main-menu-states.hpp"
+#include "utils/display-utils.hpp"
+#include "device/drivers/logger.hpp"
+
+#define TAG "MAIN_MENU_STATE"
+
+MainMenuState::MainMenuState(RemoteDeviceCoordinator* remoteDeviceCoordinator)
+    : FDNConnectState(remoteDeviceCoordinator, MainMenuStateId::MAIN_MENU) {}
+
+MainMenuState::~MainMenuState() {}
+
+void MainMenuState::onStateMounted(FDN* fdn) {
+    LOG_I(TAG, "Mounted");
+    screenIndex = 0;
+    fdn->getDisplay()->setGlyphMode(FontMode::TEXT_INVERTED_SMALL);
+    displayTimer.setTimer(DISPLAY_TIMER_MS);
+    renderScreen(fdn);
+}
+
+void MainMenuState::onStateLoop(FDN* fdn) {
+    if (displayTimer.expired()) {
+        screenIndex = (screenIndex + 1) % NUM_SCREENS;
+        renderScreen(fdn);
+        displayTimer.setTimer(DISPLAY_TIMER_MS);
+    }
+}
+
+void MainMenuState::renderScreen(FDN* fdn) {
+    fdn->getDisplay()
+        ->invalidateScreen()
+        ->setGlyphMode(FontMode::TEXT_INVERTED_SMALL)
+        ->drawText(PHRASES[screenIndex][0], 0, 20)
+        ->drawText(PHRASES[screenIndex][1], 0, 36)
+        ->drawText(PHRASES[screenIndex][2], 0, 52)
+        ->render();
+}
+
+void MainMenuState::onStateDismounted(FDN* fdn) {
+    LOG_I(TAG, "Dismounted");
+    fdn->getDisplay()->invalidateScreen();
+    displayTimer.invalidate();
+    screenIndex = 0;
+}
+
+bool MainMenuState::transitionToSymbolMatch() {
+    return !isConnected();
+}

--- a/src/fdn/apps/main-menu/main-menu-states.hpp
+++ b/src/fdn/apps/main-menu/main-menu-states.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "state/fdn-connect-state.hpp"
+#include "device/fdn.hpp"
+#include "device/remote-device-coordinator.hpp"
+#include "utils/simple-timer.hpp"
+
+enum MainMenuStateId {
+    MAIN_MENU = 0,
+};
+
+class MainMenuState : public FDNConnectState {
+public:
+    explicit MainMenuState(RemoteDeviceCoordinator* remoteDeviceCoordinator);
+    ~MainMenuState();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    bool transitionToSymbolMatch();
+    void renderScreen(FDN* fdn);
+
+private:
+    static constexpr int NUM_SCREENS         = 3;
+    static constexpr int DISPLAY_TIMER_MS    = 4000;
+
+    const char* PHRASES[NUM_SCREENS][3] = {
+        {"YOU'VE HACKED INTO", "ONE OF FIVE",        "FIXED DATA NODES"},
+        {"THE 4th WORD OF",    "THE PASSPHRASE IS:", "ORIGINAL"},
+        {"FIND SPHYNX.",       "RECITE THE PHRASE.", "REAP THE REWARDS."},
+    };
+
+    SimpleTimer displayTimer;
+    int screenIndex = 0;
+};

--- a/src/fdn/apps/main-menu/main-menu.cpp
+++ b/src/fdn/apps/main-menu/main-menu.cpp
@@ -1,0 +1,23 @@
+#include "apps/main-menu/main-menu.hpp"
+#include "apps/main-menu/main-menu-states.hpp"
+#include "apps/fdn-app-ids.hpp"
+
+MainMenu::MainMenu(FDN* fdn, RemotePlayerManager* remotePlayerManager)
+    : StateMachine(MAIN_MENU_APP_ID)
+    , remotePlayerManager(remotePlayerManager)
+    , remoteDeviceCoordinator(fdn->getRemoteDeviceCoordinator()) {}
+
+MainMenu::~MainMenu() {
+    remotePlayerManager     = nullptr;
+    remoteDeviceCoordinator = nullptr;
+}
+
+void MainMenu::populateStateMap() {
+    auto* mainMenuState = new MainMenuState(remoteDeviceCoordinator);
+
+    mainMenuState->addAppTransition(
+        std::bind(&MainMenuState::transitionToSymbolMatch, mainMenuState),
+        StateId(SYMBOL_MATCH_APP_ID));
+
+    stateMap.push_back(mainMenuState);
+}

--- a/src/fdn/apps/main-menu/main-menu.hpp
+++ b/src/fdn/apps/main-menu/main-menu.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "state/state-machine.hpp"
+#include "device/fdn.hpp"
+#include "wireless/remote-player-manager.hpp"
+#include "device/remote-device-coordinator.hpp"
+
+class MainMenu : public StateMachine {
+public:
+    MainMenu(FDN* fdn, RemotePlayerManager* remotePlayerManager);
+    ~MainMenu();
+
+    void populateStateMap() override;
+
+private:
+    RemotePlayerManager* remotePlayerManager;
+    RemoteDeviceCoordinator* remoteDeviceCoordinator;
+};

--- a/src/fdn/apps/symbol-match/states/auth-detected-state.cpp
+++ b/src/fdn/apps/symbol-match/states/auth-detected-state.cpp
@@ -1,0 +1,54 @@
+#include "apps/symbol-match/symbol-match-states.hpp"
+#include "wireless/fdn-connect-wireless-manager.hpp"
+#include "utils/display-utils.hpp"
+#include "device/drivers/logger.hpp"
+
+#define TAG "SYMBOL_AUTH_DETECTED"
+
+SymbolMatchAuthDetectedState::SymbolMatchAuthDetectedState(
+    RemoteDeviceCoordinator* remoteDeviceCoordinator,
+    FDNConnectWirelessManager* fdnConnectWirelessManager)
+    : FDNConnectState(remoteDeviceCoordinator, SymbolMatchStateId::SYMBOL_MATCH_AUTHORIZED_PDN)
+    , fdnConnectWirelessManager(fdnConnectWirelessManager) {}
+
+SymbolMatchAuthDetectedState::~SymbolMatchAuthDetectedState() {
+    fdnConnectWirelessManager = nullptr;
+}
+
+void SymbolMatchAuthDetectedState::onStateMounted(FDN* fdn) {
+    LOG_I(TAG, "Mounted - authorized player");
+    contentReady = false;
+    glyphTimer.setTimer(GLYPH_LOADING_DURATION_MS);
+    showLoadingGlyphs(fdn->getDisplay());
+}
+
+void SymbolMatchAuthDetectedState::onStateLoop(FDN* fdn) {
+    if (isInGlyphLoadingPhase(fdn->getDisplay(), glyphTimer)) return;
+
+    if (!contentReady) {
+        const std::string& pid = fdnConnectWirelessManager->getPeerPlayerId();
+        fdn->getDisplay()
+            ->invalidateScreen()
+            ->drawText(authMessage[0], centeredTextX(authMessage[0]), 20)
+            ->drawText(authMessage[1], centeredTextX(authMessage[1]), 36)
+            ->drawText(pid.c_str(), centeredTextX(pid.c_str()), 52)
+            ->render();
+        switchTimer.setTimer(SWITCH_DELAY_MS);
+        contentReady = true;
+    }
+}
+
+void SymbolMatchAuthDetectedState::onStateDismounted(FDN* fdn) {
+    (void)fdn;
+    glyphTimer.invalidate();
+    switchTimer.invalidate();
+    contentReady = false;
+}
+
+bool SymbolMatchAuthDetectedState::transitionToSelection() {
+    return !isConnected();
+}
+
+bool SymbolMatchAuthDetectedState::transitionToMainMenu() {
+    return contentReady && switchTimer.expired();
+}

--- a/src/fdn/apps/symbol-match/states/connection-detected-state.cpp
+++ b/src/fdn/apps/symbol-match/states/connection-detected-state.cpp
@@ -1,0 +1,58 @@
+#include "apps/symbol-match/symbol-match-states.hpp"
+#include "apps/hacking/hacked-players-manager.hpp"
+#include "utils/display-utils.hpp"
+#include "device/drivers/logger.hpp"
+
+#define TAG "SYMBOL_CONN_DETECTED"
+
+SymbolMatchConnectionDetectedState::SymbolMatchConnectionDetectedState(
+    HackedPlayersManager* hackedPlayersManager,
+    RemoteDeviceCoordinator* remoteDeviceCoordinator)
+    : FDNConnectState(remoteDeviceCoordinator, SymbolMatchStateId::SYMBOL_MATCH_CONNECTION_DETECTED)
+    , hackedPlayersManager(hackedPlayersManager) {}
+
+SymbolMatchConnectionDetectedState::~SymbolMatchConnectionDetectedState() {
+    hackedPlayersManager = nullptr;
+}
+
+void SymbolMatchConnectionDetectedState::receivePdnConnection(const std::string& playerId) {
+    pendingPlayerId = playerId;
+}
+
+void SymbolMatchConnectionDetectedState::onStateMounted(FDN* fdn) {
+    LOG_I(TAG, "Mounted - player: %s", pendingPlayerId.c_str());
+    contentReady = false;
+    glyphTimer.setTimer(GLYPH_LOADING_DURATION_MS);
+    showLoadingGlyphs(fdn->getDisplay());
+}
+
+void SymbolMatchConnectionDetectedState::onStateLoop(FDN* fdn) {
+    if (isInGlyphLoadingPhase(fdn->getDisplay(), glyphTimer)) return;
+
+    if (!contentReady) {
+        wasHacked = hackedPlayersManager->hasPlayerHacked(pendingPlayerId);
+        LOG_I(TAG, "Player %s hacked: %s", pendingPlayerId.c_str(), wasHacked ? "yes" : "no");
+        fdn->getDisplay()->invalidateScreen()->render();
+        contentReady = true;
+    }
+}
+
+void SymbolMatchConnectionDetectedState::onStateDismounted(FDN* fdn) {
+    (void)fdn;
+    glyphTimer.invalidate();
+    contentReady = false;
+    wasHacked    = false;
+    pendingPlayerId.clear();
+}
+
+bool SymbolMatchConnectionDetectedState::transitionToAuth() {
+    return contentReady && wasHacked;
+}
+
+bool SymbolMatchConnectionDetectedState::transitionToUnauthorized() {
+    return contentReady && !wasHacked;
+}
+
+bool SymbolMatchConnectionDetectedState::transitionToSelection() {
+    return !isConnected();
+}

--- a/src/fdn/apps/symbol-match/states/match-success-state.cpp
+++ b/src/fdn/apps/symbol-match/states/match-success-state.cpp
@@ -1,0 +1,70 @@
+#include "apps/symbol-match/symbol-match-states.hpp"
+#include "device/animation/animation-base.hpp"
+#include "device/fdn-light-manager.hpp"
+#include "device/drivers/logger.hpp"
+#include "apps/symbol-match/../../device/animation/fdn-match-success-animation.hpp"
+
+static const char* TAG = "MatchSuccess";
+
+MatchSuccess::MatchSuccess(SymbolManager* symbolManager,
+                           RemoteDeviceCoordinator* remoteDeviceCoordinator,
+                           SymbolWirelessManager* symbolWirelessManager)
+    : FDNConnectState(remoteDeviceCoordinator, MATCH_SUCCESS)
+    , symbolManager(symbolManager)
+    , symbolWirelessManager(symbolWirelessManager) {}
+
+MatchSuccess::~MatchSuccess() {
+    symbolManager = nullptr;
+    symbolWirelessManager = nullptr;
+}
+
+void MatchSuccess::onStateMounted(FDN* fdn) {
+    LOG_W(TAG, "Mounted");
+    bufferTimer.setTimer(bufferInterval);
+    renderTimer.setTimer(renderInterval);
+
+    AnimationConfig cfg{};
+    cfg.loop  = true;
+    cfg.speed = 20;
+    fdn->getLightManager()->startAnimation(new FDNMatchSuccessAnimation(), cfg);
+
+    for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::INPUT_JACK_SECONDARY}) {
+        const uint8_t* peerMac = remoteDeviceCoordinator->getPeerMac(port);
+        if (peerMac) {
+            symbolWirelessManager->setMacPeer(peerMac);
+            symbolWirelessManager->sendPacket(SMCommand::SYMBOL_MATCH_SUCCESS, SymbolId::SYMBOL_A, port);
+        }
+    }
+}
+
+void MatchSuccess::onStateLoop(FDN* fdn) {
+    if (renderTimer.expired()) {
+        renderSymbolScreen(fdn);
+        renderTimer.setTimer(renderInterval);
+    }
+}
+
+void MatchSuccess::onStateDismounted(FDN* fdn) {
+    LOG_W(TAG, "Dismounted");
+    bufferTimer.invalidate();
+    renderTimer.invalidate();
+    toggleBlink = true;
+    fdn->getLightManager()->stopAnimation();
+}
+
+void MatchSuccess::renderSymbolScreen(FDN* fdn) {
+    Display* d = fdn->getDisplay();
+    d->invalidateScreen();
+    d->whiteScreen();
+    d->setGlyphMode(FontMode::SYMBOL_GLYPH);
+    if (toggleBlink) {
+        d->renderGlyph(symbolManager->getSymbolGlyph(SerialIdentifier::INPUT_JACK), 24, 40);
+        d->renderGlyph(symbolManager->getSymbolGlyph(SerialIdentifier::INPUT_JACK_SECONDARY), 72, 40);
+    }
+    d->render();
+    toggleBlink = !toggleBlink;
+}
+
+bool MatchSuccess::transitionToMainMenu() {
+    return bufferTimer.expired();
+}

--- a/src/fdn/apps/symbol-match/states/selection-state.cpp
+++ b/src/fdn/apps/symbol-match/states/selection-state.cpp
@@ -1,0 +1,44 @@
+#include "apps/symbol-match/symbol-match-states.hpp"
+#include "utils/display-utils.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "Selection";
+
+Selection::Selection(SymbolManager* symbolManager,
+                     RemoteDeviceCoordinator* remoteDeviceCoordinator,
+                     SymbolWirelessManager* symbolWirelessManager)
+    : FDNConnectState(remoteDeviceCoordinator, SELECTION)
+    , symbolManager(symbolManager)
+    , symbolWirelessManager(symbolWirelessManager) {}
+
+Selection::~Selection() {
+    symbolManager = nullptr;
+    symbolWirelessManager = nullptr;
+}
+
+void Selection::onStateMounted(FDN* fdn) {
+    LOG_W(TAG, "Mounted");
+    symbolManager->getRefreshTimer()->invalidate();
+    symbolManager->refreshSymbols();
+    bufferTimer.setTimer(bufferInterval);
+}
+
+void Selection::onStateLoop(FDN* fdn) {
+    if (bufferTimer.expired()) {
+        transitionToIdleState = true;
+    } else if (bufferTimer.isRunning()) {
+        showLoadingGlyphs(fdn->getDisplay());
+    }
+}
+
+void Selection::onStateDismounted(FDN* fdn) {
+    bufferTimer.invalidate();
+    transitionToIdleState = false;
+    fdn->getDisplay()->invalidateScreen();
+    symbolManager->resetRefreshTimer();
+    LOG_W(TAG, "Dismounted");
+}
+
+bool Selection::transitionToIdle() {
+    return transitionToIdleState;
+}

--- a/src/fdn/apps/symbol-match/states/symbol-idle-state.cpp
+++ b/src/fdn/apps/symbol-match/states/symbol-idle-state.cpp
@@ -1,0 +1,234 @@
+#include <cstring>
+#include "apps/symbol-match/symbol-match-states.hpp"
+#include "device/fdn-light-manager.hpp"
+#include "device/remote-device-coordinator.hpp"
+#include "device/drivers/light-interface.hpp"
+#include "device/drivers/logger.hpp"
+#include "symbol.hpp"
+
+static const char* TAG = "SymbolIdle";
+
+namespace {
+constexpr uint8_t kNumFin    = 9;
+constexpr uint8_t kNumRecess = 22;
+
+// Build a light state for the half-screen match indicators.
+// leftOn  → illuminate left  half of recess + left-side fin lights
+// rightOn → illuminate right half of recess + right-side fin lights
+void applyMatchSideHalves(FDNLightManager* lm, bool leftOn, bool rightOn) {
+    constexpr LEDColor kColor(100, 160, 255);
+    constexpr uint8_t kBright = 90;
+
+    // Clear all
+    lm->clearAllLights(kNumRecess, kNumFin);
+
+    if (leftOn) {
+        // Left recess half: indices 0-10
+        for (uint8_t i = 0; i < 11; ++i) {
+            lm->setRecessLight((i + 2) % kNumRecess, kColor, kBright);
+        }
+        // Left fin lights: indices 4-8
+        for (uint8_t i = 4; i < kNumFin; ++i) {
+            lm->setFinLight(i, kColor, kBright);
+        }
+    }
+    if (rightOn) {
+        // Right recess half: indices 11-21
+        for (uint8_t i = 11; i < 22; ++i) {
+            lm->setRecessLight((i + 2) % kNumRecess, kColor, kBright);
+        }
+        // Right fin lights: indices 0-3
+        for (uint8_t i = 0; i < 4; ++i) {
+            lm->setFinLight(i, kColor, kBright);
+        }
+    }
+}
+}  // namespace
+
+SymbolIdle::SymbolIdle(SymbolManager* symbolManager,
+                       RemoteDeviceCoordinator* remoteDeviceCoordinator,
+                       SymbolWirelessManager* symbolWirelessManager)
+    : FDNConnectState(remoteDeviceCoordinator, SYMBOL_IDLE)
+    , symbolManager(symbolManager)
+    , symbolWirelessManager(symbolWirelessManager) {}
+
+SymbolIdle::~SymbolIdle() {
+    symbolWirelessManager = nullptr;
+}
+
+void SymbolIdle::onStateMounted(FDN* fdn) {
+    LOG_W(TAG, "Mounted");
+    mountedFdn = fdn;
+    renderSymbolScreen(fdn);
+
+    symbolWirelessManager->setPacketReceivedCallback(
+        [this](const SymbolMatchCommand& command) {
+            if (command.command != SMCommand::SEND_SYMBOL) return;
+            const SymbolId local = symbolManager->getSymbol(SerialIdentifier::INPUT_JACK)->getSymbolId();
+            symbolManager->setMatched(SerialIdentifier::INPUT_JACK, command.symbolId == local);
+            if (mountedFdn) { renderSymbolScreen(mountedFdn); syncMatchSideLights(mountedFdn); }
+        }, SerialIdentifier::INPUT_JACK);
+
+    symbolWirelessManager->setPacketReceivedCallback(
+        [this](const SymbolMatchCommand& command) {
+            if (command.command != SMCommand::SEND_SYMBOL) return;
+            const SymbolId local = symbolManager->getSymbol(SerialIdentifier::INPUT_JACK_SECONDARY)->getSymbolId();
+            symbolManager->setMatched(SerialIdentifier::INPUT_JACK_SECONDARY, command.symbolId == local);
+            if (mountedFdn) { renderSymbolScreen(mountedFdn); syncMatchSideLights(mountedFdn); }
+        }, SerialIdentifier::INPUT_JACK_SECONDARY);
+
+    for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::INPUT_JACK_SECONDARY}) {
+        const uint8_t* peerMac = remoteDeviceCoordinator->getPeerMac(port);
+        if (peerMac) {
+            symbolWirelessManager->setMacPeer(peerMac);
+            symbolWirelessManager->sendPacket(
+                SMCommand::SEND_SYMBOL,
+                symbolManager->getSymbol(port)->getSymbolId(),
+                port);
+        }
+    }
+
+    leftConnected  = remoteDeviceCoordinator->getPortStatus(SerialIdentifier::INPUT_JACK) == PortStatus::CONNECTED;
+    rightConnected = remoteDeviceCoordinator->getPortStatus(SerialIdentifier::INPUT_JACK_SECONDARY) == PortStatus::CONNECTED;
+    bool leftLeds  = symbolManager->isMatched(SerialIdentifier::INPUT_JACK) && symbolSentLeft;
+    bool rightLeds = symbolManager->isMatched(SerialIdentifier::INPUT_JACK_SECONDARY) && symbolSentRight;
+    lastSideLightLeft_  = leftLeds;
+    lastSideLightRight_ = rightLeds;
+    updateMatchSideLights(fdn, leftLeds, rightLeds);
+}
+
+void SymbolIdle::onStateLoop(FDN* fdn) {
+    if (symbolManager->getRefreshTimer()->expired()) {
+        transitionToSelectionState = true;
+        return;
+    }
+
+    leftConnected  = remoteDeviceCoordinator->getPortStatus(SerialIdentifier::INPUT_JACK) == PortStatus::CONNECTED;
+    rightConnected = remoteDeviceCoordinator->getPortStatus(SerialIdentifier::INPUT_JACK_SECONDARY) == PortStatus::CONNECTED;
+
+    if (!leftConnected) {
+        symbolManager->setMatched(SerialIdentifier::INPUT_JACK, false);
+        if (mountedFdn) { renderSymbolScreen(mountedFdn); syncMatchSideLights(mountedFdn); }
+    }
+    if (!rightConnected) {
+        symbolManager->setMatched(SerialIdentifier::INPUT_JACK_SECONDARY, false);
+        if (mountedFdn) { renderSymbolScreen(mountedFdn); syncMatchSideLights(mountedFdn); }
+    }
+
+    if (!symbolSentLeft && leftConnected) {
+        const uint8_t* peerMac = remoteDeviceCoordinator->getPeerMac(SerialIdentifier::INPUT_JACK);
+        if (peerMac) {
+            symbolWirelessManager->setMacPeer(peerMac);
+            symbolWirelessManager->sendPacket(SMCommand::SEND_SYMBOL,
+                symbolManager->getSymbol(SerialIdentifier::INPUT_JACK)->getSymbolId(),
+                SerialIdentifier::INPUT_JACK);
+            symbolSentLeft = true;
+        }
+    } else if (!leftConnected) {
+        symbolSentLeft = false;
+    }
+
+    if (!symbolSentRight && rightConnected) {
+        const uint8_t* peerMac = remoteDeviceCoordinator->getPeerMac(SerialIdentifier::INPUT_JACK_SECONDARY);
+        if (peerMac) {
+            symbolWirelessManager->setMacPeer(peerMac);
+            symbolWirelessManager->sendPacket(SMCommand::SEND_SYMBOL,
+                symbolManager->getSymbol(SerialIdentifier::INPUT_JACK_SECONDARY)->getSymbolId(),
+                SerialIdentifier::INPUT_JACK_SECONDARY);
+            symbolSentRight = true;
+        }
+    } else if (!rightConnected) {
+        symbolSentRight = false;
+    }
+
+    if (symbolManager->getRefreshTimer()->isRunning()) {
+        int elapsed = symbolManager->getRefreshTimer()->getElapsedTime();
+        if (elapsed - lastTimeRendered >= 500) {
+            lastTimeRendered = elapsed;
+            renderSymbolScreen(fdn);
+            blinkToggle = !blinkToggle;
+        }
+    }
+
+    syncMatchSideLights(fdn);
+}
+
+void SymbolIdle::onStateDismounted(FDN* fdn) {
+    transitionToSelectionState = false;
+    transitionToMainMenuApp    = false;
+    mountedFdn                 = nullptr;
+    lastTimeRendered           = 0;
+    symbolSentLeft             = false;
+    symbolSentRight            = false;
+
+    symbolWirelessManager->clearCallback();
+    symbolManager->setMatched(SerialIdentifier::INPUT_JACK, false);
+    symbolManager->setMatched(SerialIdentifier::INPUT_JACK_SECONDARY, false);
+
+    for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::INPUT_JACK_SECONDARY}) {
+        const uint8_t* peerMac = remoteDeviceCoordinator->getPeerMac(port);
+        if (peerMac) {
+            symbolWirelessManager->setMacPeer(peerMac);
+            symbolWirelessManager->sendPacket(SMCommand::SYMBOLS_REFRESHED, SymbolId::SYMBOL_A, port);
+        }
+    }
+
+    fdn->getLightManager()->stopAnimation();
+    LOG_W(TAG, "Dismounted");
+}
+
+void SymbolIdle::updateMatchSideLights(FDN* fdn, bool leftOn, bool rightOn) {
+    auto* lm = static_cast<FDNLightManager*>(fdn->getLightManager());
+    applyMatchSideHalves(lm, leftOn, rightOn);
+}
+
+void SymbolIdle::syncMatchSideLights(FDN* fdn) {
+    const bool l = symbolManager->isMatched(SerialIdentifier::INPUT_JACK) && symbolSentLeft;
+    const bool r = symbolManager->isMatched(SerialIdentifier::INPUT_JACK_SECONDARY) && symbolSentRight;
+    if (l != lastSideLightLeft_ || r != lastSideLightRight_) {
+        lastSideLightLeft_  = l;
+        lastSideLightRight_ = r;
+        updateMatchSideLights(fdn, l, r);
+    }
+}
+
+void SymbolIdle::renderSymbolScreen(FDN* fdn) {
+    Display* d = fdn->getDisplay();
+    d->invalidateScreen();
+
+    if (symbolManager->isMatched(SerialIdentifier::INPUT_JACK))           d->whiteScreenLeftHalf();
+    if (symbolManager->isMatched(SerialIdentifier::INPUT_JACK_SECONDARY)) d->whiteScreenRightHalf();
+
+    d->setGlyphMode(FontMode::SYMBOL_GLYPH);
+
+    if (symbolManager->isMatched(SerialIdentifier::INPUT_JACK) || !leftConnected || blinkToggle)
+        d->renderGlyph(symbolManager->getSymbolGlyph(SerialIdentifier::INPUT_JACK), 24, 40);
+
+    if (symbolManager->isMatched(SerialIdentifier::INPUT_JACK_SECONDARY) || !rightConnected || blinkToggle)
+        d->renderGlyph(symbolManager->getSymbolGlyph(SerialIdentifier::INPUT_JACK_SECONDARY), 72, 40);
+
+    d->setGlyphMode(FontMode::TEXT_INVERTED_LARGE);
+
+    int timeLeft = symbolManager->getTimeLeftToRefresh();
+    int minutes  = timeLeft / 60000;
+    int seconds  = (timeLeft % 60000) / 1000;
+    char buf[6];
+    snprintf(buf, sizeof(buf), "%02d:%02d", minutes, seconds);
+    d->drawText(buf, 40, 64);
+
+    d->render();
+}
+
+bool SymbolIdle::transitionToSelection() {
+    return transitionToSelectionState;
+}
+
+bool SymbolIdle::transitionToMatchSuccess() {
+    return symbolManager->isMatched(SerialIdentifier::INPUT_JACK)
+        && symbolManager->isMatched(SerialIdentifier::INPUT_JACK_SECONDARY)
+        && symbolSentLeft && symbolSentRight;
+}
+
+bool SymbolIdle::transitionToMainMenu() {
+    return transitionToMainMenuApp;
+}

--- a/src/fdn/apps/symbol-match/states/unauthorized-detected-state.cpp
+++ b/src/fdn/apps/symbol-match/states/unauthorized-detected-state.cpp
@@ -1,0 +1,47 @@
+#include "apps/symbol-match/symbol-match-states.hpp"
+#include "utils/display-utils.hpp"
+#include "device/drivers/logger.hpp"
+
+#define TAG "SYMBOL_UNAUTH_DETECTED"
+
+SymbolMatchUnauthorizedDetectedState::SymbolMatchUnauthorizedDetectedState(
+    RemoteDeviceCoordinator* remoteDeviceCoordinator)
+    : FDNConnectState(remoteDeviceCoordinator, SymbolMatchStateId::SYMBOL_MATCH_UNAUTHORIZED_PDN) {}
+
+SymbolMatchUnauthorizedDetectedState::~SymbolMatchUnauthorizedDetectedState() {}
+
+void SymbolMatchUnauthorizedDetectedState::onStateMounted(FDN* fdn) {
+    LOG_I(TAG, "Mounted - new player");
+    contentReady = false;
+    glyphTimer.setTimer(GLYPH_LOADING_DURATION_MS);
+    showLoadingGlyphs(fdn->getDisplay());
+}
+
+void SymbolMatchUnauthorizedDetectedState::onStateLoop(FDN* fdn) {
+    if (isInGlyphLoadingPhase(fdn->getDisplay(), glyphTimer)) return;
+
+    if (!contentReady) {
+        fdn->getDisplay()
+            ->invalidateScreen()
+            ->drawText(accessDeniedMessage[0], centeredTextX(accessDeniedMessage[0]), 28)
+            ->drawText(accessDeniedMessage[1], centeredTextX(accessDeniedMessage[1]), 44)
+            ->render();
+        switchTimer.setTimer(SWITCH_DELAY_MS);
+        contentReady = true;
+    }
+}
+
+void SymbolMatchUnauthorizedDetectedState::onStateDismounted(FDN* fdn) {
+    (void)fdn;
+    glyphTimer.invalidate();
+    switchTimer.invalidate();
+    contentReady = false;
+}
+
+bool SymbolMatchUnauthorizedDetectedState::transitionToSelection() {
+    return !isConnected();
+}
+
+bool SymbolMatchUnauthorizedDetectedState::transitionToHacking() {
+    return contentReady && switchTimer.expired();
+}

--- a/src/fdn/apps/symbol-match/states/upload-pending-hacks-state.cpp
+++ b/src/fdn/apps/symbol-match/states/upload-pending-hacks-state.cpp
@@ -1,0 +1,80 @@
+#include "apps/symbol-match/symbol-match-states.hpp"
+#include "apps/hacking/hacked-players-manager.hpp"
+#include "utils/display-utils.hpp"
+#include "device/drivers/logger.hpp"
+#include "wireless/wireless-types.hpp"
+#include "fdn-constants.hpp"
+#include <string>
+
+#define TAG "SYMBOL_UPLOAD_PENDING"
+
+SymbolMatchUploadPendingHacksState::SymbolMatchUploadPendingHacksState(HackedPlayersManager* hackedPlayersManager)
+    : TypedState<FDN>(SymbolMatchStateId::SYMBOL_MATCH_UPLOAD_PENDING)
+    , hackedPlayersManager(hackedPlayersManager) {}
+
+SymbolMatchUploadPendingHacksState::~SymbolMatchUploadPendingHacksState() {
+    hackedPlayersManager = nullptr;
+}
+
+void SymbolMatchUploadPendingHacksState::onStateMounted(FDN* fdn) {
+    contentReady  = false;
+    completedCount = 0;
+
+    auto pending = hackedPlayersManager->getPendingUploads();
+    pendingCount  = static_cast<int>(pending.size());
+    LOG_I(TAG, "Mounted - %d pending upload(s)", pendingCount);
+
+    for (const auto& playerId : pending) {
+        std::string payload =
+            "{\"playerId\":\"" + playerId +
+            "\",\"boxId\":" + std::to_string(static_cast<int>(FDN_BOX_ID)) +
+            ",\"hacked\":true}";
+
+        HttpRequest req(
+            "/api/boxes",
+            "POST",
+            payload,
+            [this, playerId](const std::string&) {
+                LOG_I(TAG, "Upload succeeded for %s", playerId.c_str());
+                hackedPlayersManager->playerHackUploaded(playerId);
+                completedCount++;
+            },
+            [this, playerId](const WirelessErrorInfo& err) {
+                LOG_E(TAG, "Upload failed for %s: %s", playerId.c_str(), err.message.c_str());
+                completedCount++;
+            });
+
+        fdn->getHttpClient()->queueRequest(req);
+    }
+
+    fallbackTimer.setTimer(FALLBACK_TIMEOUT_MS);
+    glyphTimer.setTimer(GLYPH_LOADING_DURATION_MS);
+    showLoadingGlyphs(fdn->getDisplay());
+}
+
+void SymbolMatchUploadPendingHacksState::onStateLoop(FDN* fdn) {
+    if (isInGlyphLoadingPhase(fdn->getDisplay(), glyphTimer)) return;
+
+    if (!contentReady) {
+        fdn->getDisplay()
+            ->invalidateScreen()
+            ->drawText("SYNCING", 30, 32)
+            ->render();
+        contentReady = true;
+    }
+}
+
+void SymbolMatchUploadPendingHacksState::onStateDismounted(FDN* fdn) {
+    (void)fdn;
+    LOG_I(TAG, "Dismounted - %d/%d uploads completed", completedCount, pendingCount);
+    glyphTimer.invalidate();
+    fallbackTimer.invalidate();
+    contentReady   = false;
+    pendingCount   = 0;
+    completedCount = 0;
+}
+
+bool SymbolMatchUploadPendingHacksState::transitionToIdle() {
+    if (pendingCount == 0) return true;
+    return completedCount >= pendingCount || fallbackTimer.expired();
+}

--- a/src/fdn/apps/symbol-match/symbol-manager.cpp
+++ b/src/fdn/apps/symbol-match/symbol-manager.cpp
@@ -1,0 +1,60 @@
+#include "apps/symbol-match/symbol-manager.hpp"
+
+SymbolManager::SymbolManager() {
+    symbols[SerialIdentifier::INPUT_JACK] = new Symbol();
+    symbols[SerialIdentifier::INPUT_JACK_SECONDARY] = new Symbol();
+    matchedByPort[SerialIdentifier::INPUT_JACK] = false;
+    matchedByPort[SerialIdentifier::INPUT_JACK_SECONDARY] = false;
+
+    std::srand(35);
+    refreshSymbols();
+}
+
+SymbolManager::~SymbolManager() {
+    for (auto& symbol : symbols) {
+        delete symbol.second;
+    }
+    symbols.clear();
+}
+
+void SymbolManager::refreshSymbols() {
+    const SymbolId prevLeft  = symbols[SerialIdentifier::INPUT_JACK]->getSymbolId();
+    const SymbolId prevRight = symbols[SerialIdentifier::INPUT_JACK_SECONDARY]->getSymbolId();
+    do {
+        symbols[SerialIdentifier::INPUT_JACK]->setRandomSymbol();
+    } while (symbols[SerialIdentifier::INPUT_JACK]->getSymbolId() == prevLeft
+          || symbols[SerialIdentifier::INPUT_JACK]->getSymbolId() == prevRight);
+    do {
+        symbols[SerialIdentifier::INPUT_JACK_SECONDARY]->setRandomSymbol();
+    } while (symbols[SerialIdentifier::INPUT_JACK_SECONDARY]->getSymbolId() == prevLeft
+          || symbols[SerialIdentifier::INPUT_JACK_SECONDARY]->getSymbolId() == prevRight);
+}
+
+Symbol* SymbolManager::getSymbol(SerialIdentifier port) {
+    return symbols[port];
+}
+
+const char* SymbolManager::getSymbolGlyph(SerialIdentifier port) {
+    return symbols[port]->getSymbolGlyph();
+}
+
+SimpleTimer* SymbolManager::getRefreshTimer() {
+    return &refreshTimer;
+}
+
+int SymbolManager::getTimeLeftToRefresh() {
+    return refreshInterval - refreshTimer.getElapsedTime();
+}
+
+void SymbolManager::resetRefreshTimer() {
+    refreshTimer.setTimer(refreshInterval);
+}
+
+void SymbolManager::setMatched(const SerialIdentifier port, const bool matched) {
+    matchedByPort[port] = matched;
+}
+
+bool SymbolManager::isMatched(const SerialIdentifier port) const {
+    const auto it = matchedByPort.find(port);
+    return it != matchedByPort.end() && it->second;
+}

--- a/src/fdn/apps/symbol-match/symbol-manager.hpp
+++ b/src/fdn/apps/symbol-match/symbol-manager.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <map>
+#include "symbol.hpp"
+#include "device/drivers/serial-wrapper.hpp"
+#include "utils/simple-timer.hpp"
+
+class SymbolManager {
+public:
+    SymbolManager();
+    ~SymbolManager();
+
+    Symbol* getSymbol(SerialIdentifier port);
+    const char* getSymbolGlyph(SerialIdentifier port);
+    void refreshSymbols();
+
+    void resetRefreshTimer();
+    int getTimeLeftToRefresh();
+    SimpleTimer* getRefreshTimer();
+
+    bool isMatched(SerialIdentifier port) const;
+    void setMatched(SerialIdentifier port, bool matched);
+
+private:
+    std::map<SerialIdentifier, Symbol*> symbols;
+    std::map<SerialIdentifier, bool> matchedByPort;
+
+    SimpleTimer refreshTimer;
+    int refreshInterval = 30 * 60 * 1000;
+};

--- a/src/fdn/apps/symbol-match/symbol-match-states.hpp
+++ b/src/fdn/apps/symbol-match/symbol-match-states.hpp
@@ -1,0 +1,197 @@
+#pragma once
+
+#include "state/state.hpp"
+#include "state/fdn-connect-state.hpp"
+#include "apps/symbol-match/symbol-manager.hpp"
+#include "device/fdn.hpp"
+#include "utils/simple-timer.hpp"
+#include "wireless/symbol-wireless-manager.hpp"
+#include <string>
+
+class HackedPlayersManager;
+class FDNConnectWirelessManager;
+
+enum SymbolMatchStateId {
+    SELECTION,
+    SYMBOL_IDLE,
+    MATCH_SUCCESS,
+    SYMBOL_MATCH_UPLOAD_PENDING,
+    SYMBOL_MATCH_CONNECTION_DETECTED,
+    SYMBOL_MATCH_AUTHORIZED_PDN,
+    SYMBOL_MATCH_UNAUTHORIZED_PDN,
+};
+
+// ── Selection ────────────────────────────────────────────────────────────────
+class Selection : public FDNConnectState {
+public:
+    Selection(SymbolManager* symbolManager,
+              RemoteDeviceCoordinator* remoteDeviceCoordinator,
+              SymbolWirelessManager* symbolWirelessManager);
+    ~Selection();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    bool transitionToIdle();
+
+private:
+    SymbolManager* symbolManager;
+    SymbolWirelessManager* symbolWirelessManager;
+    SimpleTimer bufferTimer;
+    bool transitionToIdleState = false;
+    int bufferInterval = 1 * 1000;
+};
+
+// ── SymbolIdle ───────────────────────────────────────────────────────────────
+class SymbolIdle : public FDNConnectState {
+public:
+    SymbolIdle(SymbolManager* symbolManager,
+               RemoteDeviceCoordinator* remoteDeviceCoordinator,
+               SymbolWirelessManager* symbolWirelessManager);
+    ~SymbolIdle();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    bool transitionToSelection();
+    bool transitionToMatchSuccess();
+    bool transitionToMainMenu();
+
+private:
+    void renderSymbolScreen(FDN* fdn);
+    void updateMatchSideLights(FDN* fdn, bool leftOn, bool rightOn);
+    void syncMatchSideLights(FDN* fdn);
+
+    SymbolManager* symbolManager;
+    SymbolWirelessManager* symbolWirelessManager;
+    FDN* mountedFdn = nullptr;
+
+    bool transitionToSelectionState   = false;
+    bool transitionToMainMenuApp      = false;
+    bool leftConnected  = false;
+    bool rightConnected = false;
+    bool lastSideLightLeft_  = false;
+    bool lastSideLightRight_ = false;
+    bool blinkToggle   = true;
+    bool symbolSentLeft  = false;
+    bool symbolSentRight = false;
+    int  lastTimeRendered = 0;
+};
+
+// ── MatchSuccess ─────────────────────────────────────────────────────────────
+class MatchSuccess : public FDNConnectState {
+public:
+    MatchSuccess(SymbolManager* symbolManager,
+                 RemoteDeviceCoordinator* remoteDeviceCoordinator,
+                 SymbolWirelessManager* symbolWirelessManager);
+    ~MatchSuccess();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    bool transitionToMainMenu();
+
+private:
+    void renderSymbolScreen(FDN* fdn);
+
+    SymbolManager* symbolManager;
+    SymbolWirelessManager* symbolWirelessManager;
+    bool toggleBlink = true;
+    SimpleTimer bufferTimer;
+    int bufferInterval = 3 * 1000;
+    SimpleTimer renderTimer;
+    int renderInterval = 200;
+};
+
+// ── SymbolMatchUploadPendingHacksState ────────────────────────────────────────
+class SymbolMatchUploadPendingHacksState : public TypedState<FDN> {
+public:
+    explicit SymbolMatchUploadPendingHacksState(HackedPlayersManager* hackedPlayersManager);
+    ~SymbolMatchUploadPendingHacksState();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    bool transitionToIdle();
+
+private:
+    HackedPlayersManager* hackedPlayersManager;
+    SimpleTimer glyphTimer;
+    SimpleTimer fallbackTimer;
+    bool contentReady  = false;
+    int  pendingCount  = 0;
+    int  completedCount = 0;
+    static constexpr int FALLBACK_TIMEOUT_MS = 15000;
+};
+
+// ── SymbolMatchConnectionDetectedState ────────────────────────────────────────
+class SymbolMatchConnectionDetectedState : public FDNConnectState {
+public:
+    SymbolMatchConnectionDetectedState(HackedPlayersManager* hackedPlayersManager,
+                                       RemoteDeviceCoordinator* remoteDeviceCoordinator);
+    ~SymbolMatchConnectionDetectedState();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    void receivePdnConnection(const std::string& playerId);
+    bool transitionToAuth();
+    bool transitionToUnauthorized();
+    bool transitionToSelection();
+
+private:
+    HackedPlayersManager* hackedPlayersManager;
+    SimpleTimer glyphTimer;
+    bool contentReady = false;
+    bool wasHacked    = false;
+    std::string pendingPlayerId;
+};
+
+// ── SymbolMatchAuthDetectedState ──────────────────────────────────────────────
+class SymbolMatchAuthDetectedState : public FDNConnectState {
+public:
+    SymbolMatchAuthDetectedState(RemoteDeviceCoordinator* remoteDeviceCoordinator,
+                                 FDNConnectWirelessManager* fdnConnectWirelessManager);
+    ~SymbolMatchAuthDetectedState();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    bool transitionToSelection();
+    bool transitionToMainMenu();
+
+private:
+    FDNConnectWirelessManager* fdnConnectWirelessManager;
+    SimpleTimer glyphTimer;
+    SimpleTimer switchTimer;
+    bool contentReady = false;
+    static constexpr int SWITCH_DELAY_MS = 5000;
+    const char* authMessage[2] = {"WELCOME", "ASSET #"};
+};
+
+// ── SymbolMatchUnauthorizedDetectedState ──────────────────────────────────────
+class SymbolMatchUnauthorizedDetectedState : public FDNConnectState {
+public:
+    explicit SymbolMatchUnauthorizedDetectedState(RemoteDeviceCoordinator* remoteDeviceCoordinator);
+    ~SymbolMatchUnauthorizedDetectedState();
+
+    void onStateMounted(FDN* fdn) override;
+    void onStateLoop(FDN* fdn) override;
+    void onStateDismounted(FDN* fdn) override;
+
+    bool transitionToSelection();
+    bool transitionToHacking();
+
+private:
+    SimpleTimer glyphTimer;
+    SimpleTimer switchTimer;
+    bool contentReady = false;
+    static constexpr int SWITCH_DELAY_MS = 5000;
+    const char* accessDeniedMessage[2] = {"ACCESS", "DENIED"};
+};

--- a/src/fdn/apps/symbol-match/symbol-match.cpp
+++ b/src/fdn/apps/symbol-match/symbol-match.cpp
@@ -56,6 +56,27 @@ void SymbolMatch::onStateMounted(Device* device) {
     StateMachine::onStateMounted(device);
 }
 
+std::unique_ptr<Snapshot> SymbolMatch::onStatePaused(Device* device) {
+    uploadCheckTimer.invalidate();
+    nearbyAnimationTimer.invalidate();
+    nearbyAnimationActive = false;
+    return StateMachine::onStatePaused(device);
+}
+
+void SymbolMatch::onStateResumed(Device* device, Snapshot* snapshot) {
+    StateMachine::onStateResumed(device, snapshot);
+
+    FDN* fdn = static_cast<FDN*>(device);
+    connectionResolved = false;
+    pendingConnectedPlayerId.clear();
+    uploadCheckTimer.invalidate();
+    nearbyAnimationTimer.invalidate();
+    nearbyAnimationActive = false;
+
+    skipToState(device, kSelectionStateIndex);
+    startIdleLightAnimation(fdn);
+}
+
 void SymbolMatch::onStateDismounted(Device* device) {
     FDN* fdn = static_cast<FDN*>(device);
     uploadCheckTimer.invalidate();

--- a/src/fdn/apps/symbol-match/symbol-match.cpp
+++ b/src/fdn/apps/symbol-match/symbol-match.cpp
@@ -1,0 +1,224 @@
+#include "apps/symbol-match/symbol-match.hpp"
+#include "apps/fdn-app-ids.hpp"
+#include "wireless/remote-player-manager.hpp"
+#include "apps/hacking/hacked-players-manager.hpp"
+#include "wireless/fdn-connect-wireless-manager.hpp"
+#include "device/animation/animation-base.hpp"
+#include "device/drivers/logger.hpp"
+#include "device/fdn-light-manager.hpp"
+#include "device/animation/fdn-idle-animation.hpp"
+#include "device/animation/fdn-player-detected-animation.hpp"
+#include <algorithm>
+
+namespace {
+constexpr uint8_t kIdleSpeed = 20;
+static const char* TAG = "SymbolMatch";
+}
+
+SymbolMatch::SymbolMatch(FDN* fdn,
+                         SymbolWirelessManager* symbolWirelessManager,
+                         RemotePlayerManager* remotePlayerManager,
+                         HackedPlayersManager* hackedPlayersManager,
+                         FDNConnectWirelessManager* fdnConnectWirelessManager)
+    : StateMachine(SYMBOL_MATCH_APP_ID) {
+    remoteDeviceCoordinator = fdn->getRemoteDeviceCoordinator();
+    symbolManager           = new SymbolManager();
+    this->symbolWirelessManager   = symbolWirelessManager;
+    this->remotePlayerManager     = remotePlayerManager;
+    this->hackedPlayersManager    = hackedPlayersManager;
+    this->fdnConnectWirelessManager = fdnConnectWirelessManager;
+}
+
+SymbolMatch::~SymbolMatch() {
+    delete symbolManager;
+    remoteDeviceCoordinator = nullptr;
+    symbolWirelessManager   = nullptr;
+    remotePlayerManager     = nullptr;
+    hackedPlayersManager    = nullptr;
+    fdnConnectWirelessManager = nullptr;
+}
+
+void SymbolMatch::onStateMounted(Device* device) {
+    FDN* fdn = static_cast<FDN*>(device);
+    remotePlayerManager->consumePacketReceived();
+    connectionResolved = false;
+    pendingConnectedPlayerId.clear();
+    fdnConnectWirelessManager->setConnectCallback(
+        [this](const std::string& playerId, const uint8_t* senderMac) {
+            LOG_I(TAG, "PDN connected, player: %s", playerId.c_str());
+            fdnConnectWirelessManager->setPeer(senderMac);
+            pendingConnectedPlayerId = playerId;
+            connectionResolved = true;
+        });
+    nearbyAnimationTimer.invalidate();
+    nearbyAnimationActive = false;
+    startIdleLightAnimation(fdn);
+    StateMachine::onStateMounted(device);
+}
+
+void SymbolMatch::onStateDismounted(Device* device) {
+    FDN* fdn = static_cast<FDN*>(device);
+    uploadCheckTimer.invalidate();
+    fdnConnectWirelessManager->clearCallbacks();
+    connectionResolved = false;
+    pendingConnectedPlayerId.clear();
+    nearbyAnimationTimer.invalidate();
+    nearbyAnimationActive = false;
+    fdn->getLightManager()->stopAnimation();
+    StateMachine::onStateDismounted(device);
+}
+
+bool SymbolMatch::shouldTransitionToUploadPending() {
+    return uploadCheckTimer.expired() && !hackedPlayersManager->getPendingUploads().empty();
+}
+
+void SymbolMatch::startIdleLightAnimation(FDN* fdn) {
+    AnimationConfig cfg{};
+    cfg.loop  = true;
+    cfg.speed = kIdleSpeed;
+    fdn->getLightManager()->startAnimation(new FDNIdleAnimation(), cfg);
+}
+
+void SymbolMatch::triggerNearbyDeviceAnimation(FDN* fdn, int rssi) {
+    uint8_t intensity  = 80;
+    int     timeoutMs  = 2500;
+    uint8_t frameSpeed = 12;
+
+    if (rssi > STRONG_RSSI_THRESHOLD) {
+        intensity  = 255;
+        timeoutMs  = 5000;
+        frameSpeed = 6;
+    } else if (rssi > MEDIUM_RSSI_THRESHOLD) {
+        intensity  = 150;
+        frameSpeed = 9;
+    }
+
+    LEDState initialState;
+    static constexpr LEDColor kColor(0, 200, 255);
+    for (uint8_t i = 0; i < 9; ++i) {
+        initialState.leftLights[i]  = LEDState::SingleLEDState(kColor, intensity);
+        initialState.rightLights[i] = LEDState::SingleLEDState(kColor, intensity / 2);
+    }
+
+    AnimationConfig cfg{};
+    cfg.loop         = true;
+    cfg.speed        = frameSpeed;
+    cfg.curve        = EaseCurve::EASE_IN_OUT;
+    cfg.initialState = initialState;
+    fdn->getLightManager()->startAnimation(new FDNPlayerDetectedAnimation(), cfg);
+
+    nearbyAnimationTimer.setTimer(timeoutMs);
+    nearbyAnimationActive = true;
+}
+
+void SymbolMatch::updateNearbyDeviceAnimation(FDN* fdn) {
+    if (!nearbyAnimationActive) return;
+    if (nearbyAnimationTimer.expired()) {
+        nearbyAnimationTimer.invalidate();
+        nearbyAnimationActive = false;
+        startIdleLightAnimation(fdn);
+    }
+}
+
+void SymbolMatch::onStateLoop(Device* device) {
+    FDN* fdn = static_cast<FDN*>(device);
+
+    remotePlayerManager->Update();
+    if (remotePlayerManager->consumePacketReceived()) {
+        triggerNearbyDeviceAnimation(fdn, remotePlayerManager->getLastRssi());
+    }
+    updateNearbyDeviceAnimation(fdn);
+
+    if (connectionResolved && currentState &&
+        (currentState->getStateId() == SymbolMatchStateId::SELECTION ||
+         currentState->getStateId() == SymbolMatchStateId::SYMBOL_IDLE)) {
+        auto* connectionDetected =
+            static_cast<SymbolMatchConnectionDetectedState*>(stateMap[kConnectionDetectedStateIndex]);
+        connectionDetected->receivePdnConnection(pendingConnectedPlayerId);
+        skipToState(device, kConnectionDetectedStateIndex);
+        connectionResolved = false;
+        return;
+    }
+
+    if (currentState && currentState->getStateId() == SymbolMatchStateId::SELECTION) {
+        if (!uploadCheckTimer.isRunning()) {
+            uploadCheckTimer.setTimer(UPLOAD_CHECK_INTERVAL_MS);
+        }
+        if (shouldTransitionToUploadPending()) {
+            const auto pending = hackedPlayersManager->getPendingUploads();
+            LOG_I(TAG, "Upload: %u pending hack(s) queued",
+                  static_cast<unsigned>(pending.size()));
+            skipToState(device, kUploadPendingStateIndex);
+            uploadCheckTimer.invalidate();
+            return;
+        }
+    } else {
+        uploadCheckTimer.invalidate();
+    }
+
+    StateMachine::onStateLoop(device);
+}
+
+void SymbolMatch::populateStateMap() {
+    auto* selection = new Selection(symbolManager, remoteDeviceCoordinator, symbolWirelessManager);
+    auto* symbolIdle = new SymbolIdle(symbolManager, remoteDeviceCoordinator, symbolWirelessManager);
+    auto* matchSuccess = new MatchSuccess(symbolManager, remoteDeviceCoordinator, symbolWirelessManager);
+    auto* uploadPending = new SymbolMatchUploadPendingHacksState(hackedPlayersManager);
+    auto* connectionDetected = new SymbolMatchConnectionDetectedState(hackedPlayersManager, remoteDeviceCoordinator);
+    auto* authDetected = new SymbolMatchAuthDetectedState(remoteDeviceCoordinator, fdnConnectWirelessManager);
+    auto* unauthorizedDetected = new SymbolMatchUnauthorizedDetectedState(remoteDeviceCoordinator);
+
+    uploadPending->addTransition(new StateTransition(
+        std::bind(&SymbolMatchUploadPendingHacksState::transitionToIdle, uploadPending),
+        selection));
+
+    connectionDetected->addTransition(new StateTransition(
+        std::bind(&SymbolMatchConnectionDetectedState::transitionToSelection, connectionDetected),
+        selection));
+    connectionDetected->addTransition(new StateTransition(
+        std::bind(&SymbolMatchConnectionDetectedState::transitionToAuth, connectionDetected),
+        authDetected));
+    connectionDetected->addAppTransition(
+        std::bind(&SymbolMatchConnectionDetectedState::transitionToUnauthorized, connectionDetected),
+        StateId(HACKING_APP_ID));
+
+    authDetected->addTransition(new StateTransition(
+        std::bind(&SymbolMatchAuthDetectedState::transitionToSelection, authDetected),
+        selection));
+    authDetected->addAppTransition(
+        std::bind(&SymbolMatchAuthDetectedState::transitionToMainMenu, authDetected),
+        StateId(MAIN_MENU_APP_ID));
+
+    unauthorizedDetected->addTransition(new StateTransition(
+        std::bind(&SymbolMatchUnauthorizedDetectedState::transitionToSelection, unauthorizedDetected),
+        selection));
+    unauthorizedDetected->addAppTransition(
+        std::bind(&SymbolMatchUnauthorizedDetectedState::transitionToHacking, unauthorizedDetected),
+        StateId(HACKING_APP_ID));
+
+    selection->addTransition(new StateTransition(
+        std::bind(&Selection::transitionToIdle, selection),
+        symbolIdle));
+
+    symbolIdle->addTransition(new StateTransition(
+        std::bind(&SymbolIdle::transitionToSelection, symbolIdle),
+        selection));
+    symbolIdle->addAppTransition(
+        std::bind(&SymbolIdle::transitionToMainMenu, symbolIdle),
+        StateId(MAIN_MENU_APP_ID));
+    symbolIdle->addTransition(new StateTransition(
+        std::bind(&SymbolIdle::transitionToMatchSuccess, symbolIdle),
+        matchSuccess));
+
+    matchSuccess->addAppTransition(
+        std::bind(&MatchSuccess::transitionToMainMenu, matchSuccess),
+        StateId(MAIN_MENU_APP_ID));
+
+    stateMap.push_back(selection);          // 0
+    stateMap.push_back(symbolIdle);         // 1
+    stateMap.push_back(matchSuccess);       // 2
+    stateMap.push_back(uploadPending);      // 3
+    stateMap.push_back(connectionDetected); // 4
+    stateMap.push_back(authDetected);       // 5
+    stateMap.push_back(unauthorizedDetected); // 6
+}

--- a/src/fdn/apps/symbol-match/symbol-match.hpp
+++ b/src/fdn/apps/symbol-match/symbol-match.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "state/state-machine.hpp"
+#include "apps/symbol-match/symbol-match-states.hpp"
+#include "apps/symbol-match/symbol-manager.hpp"
+#include "utils/simple-timer.hpp"
+#include <string>
+
+class SymbolWirelessManager;
+class RemotePlayerManager;
+class HackedPlayersManager;
+class FDNConnectWirelessManager;
+
+class SymbolMatch : public StateMachine {
+public:
+    SymbolMatch(FDN* fdn,
+                SymbolWirelessManager* symbolWirelessManager,
+                RemotePlayerManager* remotePlayerManager,
+                HackedPlayersManager* hackedPlayersManager,
+                FDNConnectWirelessManager* fdnConnectWirelessManager);
+    ~SymbolMatch();
+
+    void populateStateMap() override;
+
+    void onStateMounted(Device* device) override;
+    void onStateDismounted(Device* device) override;
+    void onStateLoop(Device* device) override;
+
+private:
+    bool shouldTransitionToUploadPending();
+    void startIdleLightAnimation(FDN* fdn);
+    void triggerNearbyDeviceAnimation(FDN* fdn, int rssi);
+    void updateNearbyDeviceAnimation(FDN* fdn);
+
+    RemoteDeviceCoordinator* remoteDeviceCoordinator;
+    SymbolManager* symbolManager;
+    SymbolWirelessManager* symbolWirelessManager;
+    RemotePlayerManager* remotePlayerManager;
+    HackedPlayersManager* hackedPlayersManager;
+    FDNConnectWirelessManager* fdnConnectWirelessManager;
+
+    bool connectionResolved = false;
+    std::string pendingConnectedPlayerId;
+
+    SimpleTimer uploadCheckTimer;
+    SimpleTimer nearbyAnimationTimer;
+    bool nearbyAnimationActive = false;
+
+    static constexpr int UPLOAD_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+    static constexpr int kUploadPendingStateIndex      = 3;
+    static constexpr int kConnectionDetectedStateIndex = 4;
+    static constexpr int STRONG_RSSI_THRESHOLD = -50;
+    static constexpr int MEDIUM_RSSI_THRESHOLD = -60;
+};

--- a/src/fdn/apps/symbol-match/symbol-match.hpp
+++ b/src/fdn/apps/symbol-match/symbol-match.hpp
@@ -23,6 +23,8 @@ public:
     void populateStateMap() override;
 
     void onStateMounted(Device* device) override;
+    std::unique_ptr<Snapshot> onStatePaused(Device* device) override;
+    void onStateResumed(Device* device, Snapshot* snapshot) override;
     void onStateDismounted(Device* device) override;
     void onStateLoop(Device* device) override;
 
@@ -47,6 +49,7 @@ private:
     bool nearbyAnimationActive = false;
 
     static constexpr int UPLOAD_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+    static constexpr int kSelectionStateIndex          = 0;
     static constexpr int kUploadPendingStateIndex      = 3;
     static constexpr int kConnectionDetectedStateIndex = 4;
     static constexpr int STRONG_RSSI_THRESHOLD = -50;

--- a/src/fdn/device/animation/fdn-idle-animation.hpp
+++ b/src/fdn/device/animation/fdn-idle-animation.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "device/animation/animation-base.hpp"
+
+// Gentle breathing animation on FDN LEDs.
+// leftLights[0-8]  → fin lights
+// rightLights[0-8] → first 9 recess lights
+class FDNIdleAnimation : public AnimationBase {
+public:
+    FDNIdleAnimation() = default;
+
+protected:
+    void onInit() override {
+        step_         = 0;
+        goingUp_      = true;
+        brightness_   = 0;
+        currentState_ = config_.initialState;
+    }
+
+    LEDState onAnimate() override {
+        const uint8_t MIN_B = 20;
+        const uint8_t MAX_B = 120;
+        const int     STEPS = 60;
+
+        if (goingUp_) {
+            brightness_ = static_cast<uint8_t>(MIN_B + (MAX_B - MIN_B) * step_ / STEPS);
+            if (++step_ > STEPS) { step_ = STEPS; goingUp_ = false; }
+        } else {
+            brightness_ = static_cast<uint8_t>(MIN_B + (MAX_B - MIN_B) * step_ / STEPS);
+            if (step_-- == 0) { step_ = 0; goingUp_ = true; }
+        }
+
+        static constexpr LEDColor kColor(0, 180, 255);
+        for (uint8_t i = 0; i < 9; ++i) {
+            currentState_.leftLights[i]  = LEDState::SingleLEDState(kColor, brightness_);
+            currentState_.rightLights[i] = LEDState::SingleLEDState(kColor, brightness_ / 2);
+        }
+        return currentState_;
+    }
+
+private:
+    int     step_       = 0;
+    bool    goingUp_    = true;
+    uint8_t brightness_ = 0;
+};

--- a/src/fdn/device/animation/fdn-match-success-animation.hpp
+++ b/src/fdn/device/animation/fdn-match-success-animation.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "device/animation/animation-base.hpp"
+#include <random>
+
+// Celebration animation: all LEDs flash white with a twinkle fade.
+class FDNMatchSuccessAnimation : public AnimationBase {
+public:
+    FDNMatchSuccessAnimation() = default;
+
+protected:
+    void onInit() override {
+        currentState_ = config_.initialState;
+        currentState_.clear();
+    }
+
+    LEDState onAnimate() override {
+        // Decay all lights
+        for (uint8_t i = 0; i < 9; ++i) {
+            currentState_.leftLights[i].brightness
+                = static_cast<uint8_t>(currentState_.leftLights[i].brightness * 92 / 100);
+            currentState_.rightLights[i].brightness
+                = static_cast<uint8_t>(currentState_.rightLights[i].brightness * 92 / 100);
+        }
+
+        // Random twinkles
+        static constexpr LEDColor kWhite(255, 255, 255);
+        static constexpr LEDColor kGold(255, 180, 0);
+        if (rng() % 3 == 0) {
+            uint8_t idx = static_cast<uint8_t>(rng() % 9);
+            bool isLeft = (rng() % 2 == 0);
+            LEDColor color = (rng() % 2 == 0) ? kWhite : kGold;
+            if (isLeft) {
+                currentState_.leftLights[idx] = LEDState::SingleLEDState(color, 255);
+            } else {
+                currentState_.rightLights[idx] = LEDState::SingleLEDState(color, 255);
+            }
+        }
+        return currentState_;
+    }
+
+private:
+    std::minstd_rand rng{42};
+};

--- a/src/fdn/device/animation/fdn-player-detected-animation.hpp
+++ b/src/fdn/device/animation/fdn-player-detected-animation.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "device/animation/animation-base.hpp"
+
+// Pulsing animation triggered when a nearby player is detected.
+// config_.initialState should have the brightness of each light pre-set to the
+// desired peak intensity so different RSSI levels can be reflected.
+class FDNPlayerDetectedAnimation : public AnimationBase {
+public:
+    FDNPlayerDetectedAnimation() = default;
+
+protected:
+    void onInit() override {
+        step_      = 0;
+        goingUp_   = true;
+        currentState_ = config_.initialState;
+    }
+
+    LEDState onAnimate() override {
+        const int STEPS = 40;
+        float factor = static_cast<float>(step_) / STEPS;
+        if (config_.curve == EaseCurve::EASE_IN_OUT) {
+            factor = factor * factor * (3.0f - 2.0f * factor);
+        }
+
+        for (uint8_t i = 0; i < 9; ++i) {
+            uint8_t peak = config_.initialState.leftLights[i].brightness;
+            currentState_.leftLights[i].brightness  = static_cast<uint8_t>(peak * factor);
+            currentState_.leftLights[i].color        = config_.initialState.leftLights[i].color;
+
+            peak = config_.initialState.rightLights[i].brightness;
+            currentState_.rightLights[i].brightness = static_cast<uint8_t>(peak * factor);
+            currentState_.rightLights[i].color       = config_.initialState.rightLights[i].color;
+        }
+
+        if (goingUp_) {
+            if (++step_ >= STEPS) { step_ = STEPS; goingUp_ = false; }
+        } else {
+            if (step_-- == 0) { step_ = 0; goingUp_ = true; }
+        }
+
+        return currentState_;
+    }
+
+private:
+    int  step_    = 0;
+    bool goingUp_ = true;
+};

--- a/src/fdn/device/fdn-light-manager.hpp
+++ b/src/fdn/device/fdn-light-manager.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "device/light-manager.hpp"
+
+// FDN physical LED layout:
+//   DISPLAY_LIGHTS → recess strip  (22 LEDs, indices 0-21)
+//   GRIP_LIGHTS    → fin strip     (9 LEDs,  indices 0-8)
+//
+// Mapping from LEDState (leftLights[9] / rightLights[9]):
+//   Fin  (GRIP_LIGHTS) 0-8  → leftLights[0-8]
+//   Recess (DISPLAY_LIGHTS) 0-8  → rightLights[0-8]
+//   Recess 9-17 are left dark (not enough LEDState entries for all 22).
+//
+// For explicit half-screen effects (e.g. match-side lights) call the
+// stripSetLight() helpers below which write directly to the LightStrip.
+class FDNLightManager : public LightManager {
+public:
+    explicit FDNLightManager(LightStrip& strip)
+        : LightManager(strip) {}
+
+    ~FDNLightManager() override = default;
+
+    // Direct LightStrip access for patterns that need more than 18 LEDs.
+    void setRecessLight(uint8_t index, LEDColor color, uint8_t brightness) {
+        pdnLights.setLight(
+            LightIdentifier::DISPLAY_LIGHTS,
+            index,
+            LEDState::SingleLEDState(color, brightness));
+    }
+
+    void setFinLight(uint8_t index, LEDColor color, uint8_t brightness) {
+        pdnLights.setLight(
+            LightIdentifier::GRIP_LIGHTS,
+            index,
+            LEDState::SingleLEDState(color, brightness));
+    }
+
+    void clearAllLights(uint8_t numRecess, uint8_t numFin) {
+        LEDState::SingleLEDState off;
+        for (uint8_t i = 0; i < numRecess; ++i) {
+            pdnLights.setLight(LightIdentifier::DISPLAY_LIGHTS, i, off);
+        }
+        for (uint8_t i = 0; i < numFin; ++i) {
+            pdnLights.setLight(LightIdentifier::GRIP_LIGHTS, i, off);
+        }
+    }
+
+protected:
+    // Map LEDState entries to FDN's physical strips.
+    //   leftLights[0-8]  → fin lights  0-8  (GRIP_LIGHTS)
+    //   rightLights[0-8] → recess lights 0-8 (DISPLAY_LIGHTS)
+    void applyLEDState(const LEDState& state) override {
+        for (uint8_t i = 0; i < 9; ++i) {
+            pdnLights.setLight(LightIdentifier::GRIP_LIGHTS,    i, state.leftLights[i]);
+            pdnLights.setLight(LightIdentifier::DISPLAY_LIGHTS, i, state.rightLights[i]);
+        }
+    }
+};

--- a/src/fdn/device/fdn.cpp
+++ b/src/fdn/device/fdn.cpp
@@ -1,0 +1,72 @@
+#include "device/fdn.hpp"
+#include "device/fdn-light-manager.hpp"
+#include "device/driver-names.hpp"
+#include "device/drivers/logger.hpp"
+
+FDN* FDN::createFDN(DriverConfig& driverConfig) {
+    return new FDN(driverConfig);
+}
+
+FDN::~FDN() {}
+
+FDN::FDN(DriverConfig& driverConfig) : Device(driverConfig) {
+    lightManager = new FDNLightManager(
+        *getPeripheral<LightStrip>(LIGHT_DRIVER_NAME));
+
+    // FDN has two input jacks and no output jack.
+    // SerialManager is constructed with nullptr for the output jack.
+    auto* primaryIn   = getPeripheral<HWSerialWrapper>(SERIAL_IN_DRIVER_NAME);
+    auto* secondaryIn = getPeripheral<HWSerialWrapper>(SERIAL_IN_SECONDARY_DRIVER_NAME);
+
+    serialManager = new SerialManager(/*outputJack=*/nullptr, primaryIn);
+    serialManager->setSecondaryInputJack(secondaryIn);
+
+    wirelessManager = new WirelessManager(getPeerComms(), getHttpClient());
+    remoteDeviceCoordinator = new RemoteDeviceCoordinator();
+}
+
+int FDN::begin() {
+    wirelessManager->initialize();
+    remoteDeviceCoordinator->initialize(wirelessManager, serialManager, this);
+    return 1;
+}
+
+std::string FDN::getDeviceId() {
+    return deviceId;
+}
+
+DeviceType FDN::getDeviceType() {
+    return DeviceType::FDN;
+}
+
+void FDN::loop() {
+    Device::loop();
+    lightManager->loop();
+    if (remoteDeviceCoordinator) {
+        remoteDeviceCoordinator->sync(this);
+    }
+}
+
+LightManager* FDN::getLightManager() {
+    return lightManager;
+}
+
+SerialManager* FDN::getSerialManager() {
+    return serialManager;
+}
+
+WirelessManager* FDN::getWirelessManager() {
+    return wirelessManager;
+}
+
+RemoteDeviceCoordinator* FDN::getRemoteDeviceCoordinator() {
+    return remoteDeviceCoordinator;
+}
+
+Button* FDN::getTertiaryButton() {
+    return getPeripheral<Button>(TERTIARY_BUTTON_DRIVER_NAME);
+}
+
+void FDN::setDeviceId(const std::string& id) {
+    deviceId = id;
+}

--- a/src/fdn/device/fdn.hpp
+++ b/src/fdn/device/fdn.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "device/device.hpp"
+#include "device/light-manager.hpp"
+#include "device/serial-manager.hpp"
+
+#include <string>
+
+class FDN : public Device {
+
+public:
+
+    static FDN* createFDN(DriverConfig& driverConfig);
+
+    ~FDN() override;
+
+    int begin() override;
+
+    void loop() override;
+
+    void setDeviceId(const std::string& deviceId) override;
+
+    std::string getDeviceId() override;
+    DeviceType getDeviceType() override;
+
+    LightManager* getLightManager() override;
+    WirelessManager* getWirelessManager() override;
+    SerialManager* getSerialManager() override;
+    RemoteDeviceCoordinator* getRemoteDeviceCoordinator() override;
+
+    // Convenience accessor for the tertiary (third) button unique to FDN.
+    Button* getTertiaryButton();
+
+protected:
+    FDN(DriverConfig& driverConfig);
+
+private:
+    LightManager* lightManager;
+    SerialManager* serialManager;
+    WirelessManager* wirelessManager;
+    RemoteDeviceCoordinator* remoteDeviceCoordinator;
+
+    std::string deviceId;
+};

--- a/src/fdn/fdn-constants.hpp
+++ b/src/fdn/fdn-constants.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <cstddef>
+#include "game/player.hpp"
+
+// --- GPIO pin assignments ---
+constexpr uint8_t fdnPrimaryButtonPin    = 15;
+constexpr uint8_t fdnSecondaryButtonPin  = 16;
+constexpr uint8_t fdnTertiaryButtonPin   = 6;
+constexpr uint8_t fdnMotorPin            = 17;
+
+// Primary input jack (Serial2: RXr=41, RXt=40)
+constexpr uint8_t fdnRXr                 = 41;
+constexpr uint8_t fdnRXt                 = 40;
+
+// Secondary input jack (Serial1: RXr2=39, RXt2=38)
+constexpr uint8_t fdnRXr2               = 39;
+constexpr uint8_t fdnRXt2               = 38;
+
+// LED strips
+constexpr uint8_t fdnRecessLightsPin    = 21;
+constexpr uint8_t fdnFinLightsPin       = 13;
+constexpr uint8_t fdnNumRecessLights    = 22;
+constexpr uint8_t fdnNumFinLights       = 9;
+
+// SSD1309 display
+constexpr uint8_t fdnDisplayCS          = 10;
+constexpr uint8_t fdnDisplayDC          = 9;
+constexpr uint8_t fdnDisplayRST         = 14;
+
+// --- Persistent storage namespace ---
+constexpr const char* FDN_PREF_NAMESPACE = "fdn_hacks";
+
+// --- RSSI thresholds for player proximity detection ---
+constexpr int FDN_STRONG_RSSI_THRESHOLD = -30;
+constexpr int FDN_MEDIUM_RSSI_THRESHOLD = -50;
+
+// --- FDN device identity ---
+// Player ID is 4 characters, zero-padded (e.g. FDN box 0 = "0000")
+constexpr uint8_t FDN_BOX_ID = 0;
+constexpr size_t  FDN_PLAYER_ID_LENGTH = 4;
+
+inline const std::string FDN_PLAYER_ID =
+    std::string(FDN_PLAYER_ID_LENGTH - std::to_string(FDN_BOX_ID).length(), '0') +
+    std::to_string(FDN_BOX_ID);
+
+inline Player FDN_PLAYER = Player(FDN_PLAYER_ID, Allegiance::ALLEYCAT, false);

--- a/src/fdn/main.cpp
+++ b/src/fdn/main.cpp
@@ -195,7 +195,7 @@ void setup() {
         {StateId(HACKING_APP_ID),      hackingApp},
         {StateId(IDLE_APP_ID),         idleApp},
     };
-    fdn->loadAppConfig(apps, StateId(IDLE_APP_ID));
+    fdn->loadAppConfig(apps, StateId(SYMBOL_MATCH_APP_ID));
 }
 
 void loop() {

--- a/src/fdn/main.cpp
+++ b/src/fdn/main.cpp
@@ -1,0 +1,203 @@
+#include <Arduino.h>
+
+#include <WiFi.h>
+#include <FastLED.h>
+#include <Preferences.h>
+
+#include "device/drivers/esp32-s3/esp32-s3-logger-driver.hpp"
+#include "device/drivers/esp32-s3/esp32-s3-clock-driver.hpp"
+#include "device/drivers/esp32-s3/esp32-s3-1-button-driver.hpp"
+#include "device/drivers/esp32-s3/ws2812b-fastled-driver.hpp"
+#include "device/drivers/esp32-s3/esp32-s3-haptics-driver.hpp"
+#include "device/drivers/esp32-s3/esp32-s3-serial-driver.hpp"
+#include "device/drivers/esp32-s3/esp32-s3-http-client-driver.hpp"
+#include "device/drivers/esp32-s3/esp-now-driver.hpp"
+#include "device/drivers/esp32-s3/ssd1309-u8g2-driver.hpp"
+#include "device/drivers/esp32-s3/esp32-s3-prefs-driver.hpp"
+
+#include "fdn-constants.hpp"
+#include "utils/simple-timer.hpp"
+#include "game/player.hpp"
+#include "device/fdn.hpp"
+#include "wireless/remote-player-manager.hpp"
+#include "wireless/fdn-connect-wireless-manager.hpp"
+#include "wireless/symbol-wireless-manager.hpp"
+#include "wireless/wireless-types.hpp"
+#include "device/drivers/peer-comms-interface.hpp"
+#include "apps/main-menu/main-menu.hpp"
+#include "apps/idle/idle.hpp"
+#include "apps/hacking/hacking.hpp"
+#include "apps/hacking/hacked-players-manager.hpp"
+#include "apps/symbol-match/symbol-match.hpp"
+#include "apps/fdn-app-ids.hpp"
+
+// WiFi configuration - injected at compile time from wifi_credentials.ini
+// See wifi_credentials.ini.example for template
+#ifndef WIFI_SSID
+#error "WIFI_SSID not defined. Please create wifi_credentials.ini from wifi_credentials.ini.example"
+#endif
+#ifndef WIFI_PASSWORD
+#error "WIFI_PASSWORD not defined. Please create wifi_credentials.ini from wifi_credentials.ini.example"
+#endif
+#ifndef BASE_URL
+#error "BASE_URL not defined. Please create wifi_credentials.ini from wifi_credentials.ini.example"
+#endif
+
+WifiConfig* wifiConfig = nullptr;
+
+// ESP32-S3 Drivers
+Esp32S3Clock*    clockDriver              = nullptr;
+SSD1309U8G2Driver* displayDriver         = nullptr;
+Esp32S31ButtonDriver* primaryButtonDriver   = nullptr;
+Esp32S31ButtonDriver* secondaryButtonDriver = nullptr;
+Esp32S31ButtonDriver* tertiaryButtonDriver  = nullptr;
+// Recess lights on DISPLAY pin slot, fin lights on GRIP pin slot
+WS2812BFastLEDDriver<fdnRecessLightsPin, fdnFinLightsPin>* lightDriver = nullptr;
+Esp32S3HapticsDriver* hapticsDriver      = nullptr;
+Esp32s3SerialIn* serialInDriver          = nullptr;
+Esp32s3SerialInSecondary* serialInSecondaryDriver = nullptr;
+Esp32S3HttpClient* httpClientDriver      = nullptr;
+EspNowManager*   peerCommsDriver         = nullptr;
+Esp32S3Logger*   loggerDriver            = nullptr;
+Esp32S3PrefsDriver* storageDriver        = nullptr;
+
+// FDN device
+FDN* fdn = nullptr;
+
+// Player identity
+Player fdnPlayer = FDN_PLAYER;
+
+// Managers
+RemotePlayerManager*      remotePlayerManager      = nullptr;
+FDNConnectWirelessManager* fdnConnectWirelessManager = nullptr;
+HackedPlayersManager*     hackedPlayersManager     = nullptr;
+SymbolWirelessManager*    symbolWirelessManager    = nullptr;
+
+// Apps
+MainMenu*    mainMenu        = nullptr;
+Idle*        idleApp         = nullptr;
+Hacking*     hackingApp      = nullptr;
+SymbolMatch* symbolMatchApp  = nullptr;
+
+static constexpr unsigned long PLAYER_BROADCAST_INTERVAL_MS = 12000;
+
+static void setupEspNow(PeerCommsInterface* peerComms) {
+    peerComms->setPacketHandler(
+        PktType::kPlayerInfoBroadcast,
+        [](const uint8_t* src, const uint8_t* data, size_t len, void* arg) {
+            static_cast<RemotePlayerManager*>(arg)->ProcessPlayerInfoPkt(src, data, len);
+        },
+        remotePlayerManager);
+
+    peerComms->setPacketHandler(
+        PktType::kFdnConnect,
+        [](const uint8_t* src, const uint8_t* data, size_t len, void* arg) {
+            static_cast<FDNConnectWirelessManager*>(arg)->processPacket(src, data, len);
+        },
+        fdnConnectWirelessManager);
+
+    peerComms->setPacketHandler(
+        PktType::kSymbolMatchCommand,
+        [](const uint8_t* src, const uint8_t* data, size_t len, void* arg) {
+            static_cast<SymbolWirelessManager*>(arg)->processSymbolMatchCommand(src, data, len);
+        },
+        symbolWirelessManager);
+}
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial) delay(100);
+
+    // Construct platform drivers first — logging and timers depend on these.
+    loggerDriver = new Esp32S3Logger(LOGGER_DRIVER_NAME);
+    clockDriver  = new Esp32S3Clock(PLATFORM_CLOCK_DRIVER_NAME);
+
+    g_logger = loggerDriver;
+    SimpleTimer::setPlatformClock(clockDriver);
+    esp_log_level_set("*", ESP_LOG_VERBOSE);
+
+    // Remaining drivers (safe to log now)
+    displayDriver = new SSD1309U8G2Driver(
+        DISPLAY_DRIVER_NAME, fdnDisplayCS, fdnDisplayDC, fdnDisplayRST);
+    primaryButtonDriver   = new Esp32S31ButtonDriver(PRIMARY_BUTTON_DRIVER_NAME,   fdnPrimaryButtonPin);
+    secondaryButtonDriver = new Esp32S31ButtonDriver(SECONDARY_BUTTON_DRIVER_NAME, fdnSecondaryButtonPin);
+    tertiaryButtonDriver  = new Esp32S31ButtonDriver(TERTIARY_BUTTON_DRIVER_NAME,  fdnTertiaryButtonPin);
+    lightDriver = new WS2812BFastLEDDriver<fdnRecessLightsPin, fdnFinLightsPin>(
+        LIGHT_DRIVER_NAME, fdnNumRecessLights, fdnNumFinLights);
+    hapticsDriver = new Esp32S3HapticsDriver(HAPTICS_DRIVER_NAME, fdnMotorPin);
+    serialInDriver          = new Esp32s3SerialIn(SERIAL_IN_DRIVER_NAME, fdnRXt, fdnRXr);
+    serialInSecondaryDriver = new Esp32s3SerialInSecondary(SERIAL_IN_SECONDARY_DRIVER_NAME, fdnRXt2, fdnRXr2);
+
+    wifiConfig    = new WifiConfig(WIFI_SSID, WIFI_PASSWORD, BASE_URL);
+    peerCommsDriver = EspNowManager::CreateEspNowManager(PEER_COMMS_DRIVER_NAME);
+    httpClientDriver = new Esp32S3HttpClient(HTTP_CLIENT_DRIVER_NAME, wifiConfig);
+    storageDriver = new Esp32S3PrefsDriver(STORAGE_DRIVER_NAME, FDN_PREF_NAMESPACE);
+
+    DriverConfig fdnConfig = {
+        {DISPLAY_DRIVER_NAME,              displayDriver},
+        {PRIMARY_BUTTON_DRIVER_NAME,       primaryButtonDriver},
+        {SECONDARY_BUTTON_DRIVER_NAME,     secondaryButtonDriver},
+        {TERTIARY_BUTTON_DRIVER_NAME,      tertiaryButtonDriver},
+        {LIGHT_DRIVER_NAME,                lightDriver},
+        {HAPTICS_DRIVER_NAME,              hapticsDriver},
+        {SERIAL_IN_DRIVER_NAME,            serialInDriver},
+        {SERIAL_IN_SECONDARY_DRIVER_NAME,  serialInSecondaryDriver},
+        {HTTP_CLIENT_DRIVER_NAME,          httpClientDriver},
+        {PEER_COMMS_DRIVER_NAME,           peerCommsDriver},
+        {PLATFORM_CLOCK_DRIVER_NAME,       clockDriver},
+        {LOGGER_DRIVER_NAME,               loggerDriver},
+        {STORAGE_DRIVER_NAME,              storageDriver},
+    };
+
+    fdn = FDN::createFDN(fdnConfig);
+    fdn->begin();
+
+    // Managers — constructed after fdn->begin() so wireless is ready.
+    remotePlayerManager = new RemotePlayerManager(peerCommsDriver);
+    remotePlayerManager->StartBroadcastingPlayerInfo(&fdnPlayer, PLAYER_BROADCAST_INTERVAL_MS);
+
+    fdnConnectWirelessManager = new FDNConnectWirelessManager();
+    fdnConnectWirelessManager->initialize(fdn->getWirelessManager());
+
+    hackedPlayersManager  = new HackedPlayersManager(fdn->getStorage());
+
+    symbolWirelessManager = new SymbolWirelessManager();
+    symbolWirelessManager->initialize(fdn->getWirelessManager(), fdn->getRemoteDeviceCoordinator());
+
+    setupEspNow(peerCommsDriver);
+
+    // Apps
+    idleApp = new Idle(
+        remotePlayerManager, hackedPlayersManager,
+        fdnConnectWirelessManager, fdn->getRemoteDeviceCoordinator());
+
+    mainMenu = new MainMenu(fdn, remotePlayerManager);
+
+    hackingApp = new Hacking(
+        fdnConnectWirelessManager, hackedPlayersManager,
+        fdn->getRemoteDeviceCoordinator());
+
+    symbolMatchApp = new SymbolMatch(
+        fdn, symbolWirelessManager,
+        remotePlayerManager, hackedPlayersManager,
+        fdnConnectWirelessManager);
+
+    // Splash screen
+    fdn->getDisplay()
+        ->invalidateScreen()
+        ->drawText("ALLEYCAT", 20, 32)
+        ->render();
+    delay(2000);
+
+    AppConfig apps = {
+        {StateId(SYMBOL_MATCH_APP_ID), symbolMatchApp},
+        {StateId(MAIN_MENU_APP_ID),    mainMenu},
+        {StateId(HACKING_APP_ID),      hackingApp},
+        {StateId(IDLE_APP_ID),         idleApp},
+    };
+    fdn->loadAppConfig(apps, StateId(IDLE_APP_ID));
+}
+
+void loop() {
+    fdn->loop();
+}

--- a/src/fdn/state/fdn-connect-state.hpp
+++ b/src/fdn/state/fdn-connect-state.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "state/connect-state.hpp"
+#include "device/fdn.hpp"
+
+// Base class for FDN states that check for player connections.
+// FDN has two input jacks (INPUT_JACK and INPUT_JACK_SECONDARY) and no output jack.
+// isConnected() returns true when either input jack has a connected or daisy-chained peer.
+class FDNConnectState : public ConnectState<FDN> {
+public:
+    FDNConnectState(RemoteDeviceCoordinator* remoteDeviceCoordinator, int stateId)
+        : ConnectState<FDN>(remoteDeviceCoordinator, stateId) {}
+
+    // FDN has no output jack.
+    bool isPrimaryRequired() override { return false; }
+
+    // FDN input jacks — both considered for connectivity.
+    bool isAuxRequired() override { return true; }
+    bool isSecondaryRequired() override { return true; }
+};

--- a/src/fdn/utils/display-utils.hpp
+++ b/src/fdn/utils/display-utils.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdlib>
+#include <cstring>
+#include "device/drivers/display.hpp"
+#include "utils/simple-timer.hpp"
+
+constexpr int GLYPH_LOADING_DURATION_MS = 500;
+constexpr int FDN_SCREEN_WIDTH = 128;
+constexpr int FDN_CHAR_WIDTH   = 10;
+
+static const char* fdnLoadingGlyphs[] = {
+    "\u2630", "\u2631", "\u2632", "\u2633",
+    "\u2634", "\u2635", "\u2636", "\u2637"
+};
+
+inline int centeredTextX(const char* text) {
+    if (text == nullptr) return 0;
+    int start = (FDN_SCREEN_WIDTH - static_cast<int>(strlen(text)) * FDN_CHAR_WIDTH) / 2;
+    return (start < 0) ? 0 : start;
+}
+
+inline void showLoadingGlyphs(Display* display) {
+    constexpr int GLYPH_SIZE    = 14;
+    constexpr int SCREEN_WIDTH  = 128;
+    constexpr int GLYPHS_PER_ROW = SCREEN_WIDTH / GLYPH_SIZE;
+    constexpr int GLYPHS_PER_COL = 5;
+
+    display->invalidateScreen();
+    display->setGlyphMode(FontMode::LOADING_GLYPH);
+
+    for (int row = 0; row < GLYPHS_PER_COL; row++) {
+        for (int col = 0; col < GLYPHS_PER_ROW; col++) {
+            if (rand() % 100 < 50) {
+                display->renderGlyph(
+                    fdnLoadingGlyphs[rand() % 8],
+                    col * GLYPH_SIZE,
+                    14 + row * GLYPH_SIZE);
+            }
+        }
+    }
+
+    display->render();
+}
+
+inline bool isInGlyphLoadingPhase(Display* display, SimpleTimer& timer) {
+    if (!timer.expired()) {
+        showLoadingGlyphs(display);
+        return true;
+    }
+    display->setGlyphMode(FontMode::TEXT);
+    return false;
+}

--- a/src/fdn/wireless/fdn-connect-wireless-manager.cpp
+++ b/src/fdn/wireless/fdn-connect-wireless-manager.cpp
@@ -1,0 +1,113 @@
+#include "wireless/fdn-connect-wireless-manager.hpp"
+#include "device/drivers/peer-comms-types.hpp"
+#include "device/drivers/logger.hpp"
+
+#define TAG "FDN_CWM"
+
+struct FdnConnectPacket {
+    uint8_t command;
+    char playerId[FDN_PLAYER_ID_BUFFER_SIZE];
+    uint8_t sequence[FDN_HACK_SEQUENCE_LENGTH];
+    uint8_t buttonValue;
+} __attribute__((packed));
+
+FDNConnectWirelessManager::FDNConnectWirelessManager() {}
+
+FDNConnectWirelessManager::~FDNConnectWirelessManager() {
+    wirelessManager = nullptr;
+}
+
+void FDNConnectWirelessManager::initialize(WirelessManager* wm) {
+    wirelessManager = wm;
+}
+
+void FDNConnectWirelessManager::setPeer(const uint8_t* macAddr) {
+    memcpy(peerMac.data(), macAddr, 6);
+    hasPeer = true;
+}
+
+void FDNConnectWirelessManager::clearPeer() {
+    peerMac.fill(0);
+    hasPeer = false;
+    peerPlayerId.clear();
+}
+
+const std::string& FDNConnectWirelessManager::getPeerPlayerId() const {
+    return peerPlayerId;
+}
+
+int FDNConnectWirelessManager::sendHackSequence(const ButtonIdentifier* sequence) {
+    if (!hasPeer) {
+        LOG_E(TAG, "Cannot send hack sequence — no peer set");
+        return -1;
+    }
+
+    FdnConnectPacket pkt{};
+    pkt.command = SEND_HACK_SEQUENCE;
+    for (int i = 0; i < FDN_HACK_SEQUENCE_LENGTH; i++) {
+        pkt.sequence[i] = static_cast<uint8_t>(sequence[i]);
+    }
+
+    LOG_I(TAG, "Sending hack sequence to PDN");
+    return wirelessManager->sendEspNowData(
+        peerMac.data(),
+        PktType::kFdnConnect,
+        reinterpret_cast<const uint8_t*>(&pkt),
+        sizeof(pkt));
+}
+
+void FDNConnectWirelessManager::setConnectCallback(
+    std::function<void(const std::string& playerId, const uint8_t* senderMac)> callback) {
+    connectCallback = std::move(callback);
+}
+
+void FDNConnectWirelessManager::setButtonPressCallback(
+    std::function<void(ButtonIdentifier btn)> callback) {
+    buttonPressCallback = std::move(callback);
+}
+
+void FDNConnectWirelessManager::clearCallbacks() {
+    connectCallback = nullptr;
+    buttonPressCallback = nullptr;
+}
+
+int FDNConnectWirelessManager::processPacket(const uint8_t* senderMac, const uint8_t* data, size_t dataLen) {
+    if (dataLen != sizeof(FdnConnectPacket)) {
+        LOG_E(TAG, "Unexpected packet length. Got %lu, expected %lu",
+              static_cast<unsigned long>(dataLen),
+              static_cast<unsigned long>(sizeof(FdnConnectPacket)));
+        return -1;
+    }
+
+    const FdnConnectPacket* pkt = reinterpret_cast<const FdnConnectPacket*>(data);
+
+    if (pkt->command >= FDN_CONNECT_CMD_COUNT) {
+        LOG_E(TAG, "Invalid command %d, dropping", pkt->command);
+        return -1;
+    }
+
+    switch (pkt->command) {
+        case PDN_CONNECT:
+            peerPlayerId = std::string(pkt->playerId);
+            LOG_I(TAG, "PDN connected, player ID: %s", pkt->playerId);
+            if (connectCallback) {
+                connectCallback(peerPlayerId, senderMac);
+            }
+            break;
+
+        case BUTTON_PRESS: {
+            ButtonIdentifier btn = static_cast<ButtonIdentifier>(pkt->buttonValue);
+            LOG_I(TAG, "Button press received: %d", pkt->buttonValue);
+            if (buttonPressCallback) {
+                buttonPressCallback(btn);
+            }
+            break;
+        }
+
+        default:
+            LOG_W(TAG, "Unhandled command %d", pkt->command);
+            break;
+    }
+
+    return 1;
+}

--- a/src/fdn/wireless/fdn-connect-wireless-manager.hpp
+++ b/src/fdn/wireless/fdn-connect-wireless-manager.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <string>
+#include "device/wireless-manager.hpp"
+#include "device/drivers/button.hpp"
+
+constexpr int FDN_HACK_SEQUENCE_LENGTH = 8;
+
+// Player ID is 4 characters + null terminator
+constexpr size_t FDN_PLAYER_ID_BUFFER_SIZE = 5;
+
+enum FdnConnectCmd {
+    PDN_CONNECT = 0,        // PDN → FDN: announces connection, carries player ID
+    SEND_HACK_SEQUENCE = 1, // FDN → PDN: transmits the 8-button sequence
+    BUTTON_PRESS = 2,       // PDN → FDN: player pressed a button
+    FDN_CONNECT_CMD_COUNT,
+    FDN_CONNECT_INVALID_CMD = 0xFF
+};
+
+class FDNConnectWirelessManager {
+public:
+    FDNConnectWirelessManager();
+    ~FDNConnectWirelessManager();
+
+    void initialize(WirelessManager* wirelessManager);
+
+    void setPeer(const uint8_t* macAddr);
+    void clearPeer();
+
+    const std::string& getPeerPlayerId() const;
+
+    int sendHackSequence(const ButtonIdentifier* sequence);
+
+    void setConnectCallback(std::function<void(const std::string& playerId, const uint8_t* senderMac)> callback);
+    void setButtonPressCallback(std::function<void(ButtonIdentifier btn)> callback);
+    void clearCallbacks();
+
+    int processPacket(const uint8_t* senderMac, const uint8_t* data, size_t dataLen);
+
+private:
+    WirelessManager* wirelessManager = nullptr;
+    std::array<uint8_t, 6> peerMac{};
+    bool hasPeer = false;
+    std::string peerPlayerId;
+
+    std::function<void(const std::string&, const uint8_t*)> connectCallback;
+    std::function<void(ButtonIdentifier)> buttonPressCallback;
+};

--- a/src/fdn/wireless/symbol-wireless-manager.cpp
+++ b/src/fdn/wireless/symbol-wireless-manager.cpp
@@ -1,0 +1,108 @@
+#include "wireless/symbol-wireless-manager.hpp"
+#include "device/remote-device-coordinator.hpp"
+#include "device/drivers/peer-comms-types.hpp"
+#include "device/drivers/logger.hpp"
+#include "wireless/mac-functions.hpp"
+#include <cstring>
+
+static const char* SWM_TAG = "SWM";
+
+SymbolWirelessManager::SymbolWirelessManager() {
+    std::memset(macPeer, 0, sizeof(macPeer));
+    remoteDeviceCoordinator = nullptr;
+    wirelessManager = nullptr;
+}
+
+SymbolWirelessManager::~SymbolWirelessManager() {
+    wirelessManager = nullptr;
+}
+
+void SymbolWirelessManager::initialize(WirelessManager* wm, RemoteDeviceCoordinator* rdc) {
+    wirelessManager = wm;
+    remoteDeviceCoordinator = rdc;
+}
+
+void SymbolWirelessManager::setMacPeer(const uint8_t* macAddress) {
+    memcpy(macPeer, macAddress, 6);
+}
+
+int SymbolWirelessManager::sendPacket(int command, SymbolId symbolId, SerialIdentifier serialPort) {
+    SymbolMatchPacket packet{};
+    packet.command = command;
+    packet.symbolId = symbolId;
+
+    LOG_W(SWM_TAG,
+          "TX symbol command %d to %s (symbolId=%d, targetPort=%d)",
+          command,
+          MacToString(macPeer),
+          static_cast<int>(symbolId),
+          static_cast<int>(serialPort));
+
+    return wirelessManager->sendEspNowData(
+        macPeer,
+        PktType::kSymbolMatchCommand,
+        reinterpret_cast<const uint8_t*>(&packet),
+        sizeof(packet));
+}
+
+int SymbolWirelessManager::processSymbolMatchCommand(const uint8_t* macAddress, const uint8_t* data, size_t dataLen) {
+    if (dataLen != sizeof(SymbolMatchPacket)) {
+        LOG_E(SWM_TAG, "RX symbol pkt bad len: got %u expected %u from %s",
+              static_cast<unsigned>(dataLen),
+              static_cast<unsigned>(sizeof(SymbolMatchPacket)),
+              macAddress ? MacToString(macAddress) : "(null)");
+        return -1;
+    }
+
+    const SymbolMatchPacket* packet = reinterpret_cast<const SymbolMatchPacket*>(data);
+
+    LOG_W(SWM_TAG,
+          "RX symbol command %d from %s (symbolId=%d)",
+          packet->command,
+          MacToString(macAddress),
+          static_cast<int>(packet->symbolId));
+
+    if (remoteDeviceCoordinator == nullptr) {
+        LOG_E(SWM_TAG, "RemoteDeviceCoordinator unavailable, dropping symbol packet");
+        return -1;
+    }
+
+    SerialIdentifier resolvedPort = SerialIdentifier::INPUT_JACK;
+    bool portResolved = false;
+
+    for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::INPUT_JACK_SECONDARY}) {
+        PortState portState = remoteDeviceCoordinator->getPortState(port);
+        for (const auto& peerMac : portState.peerMacAddresses) {
+            if (macAddress != nullptr && std::memcmp(peerMac.data(), macAddress, 6) == 0) {
+                resolvedPort = port;
+                portResolved = true;
+                break;
+            }
+        }
+        if (portResolved) break;
+    }
+
+    if (!portResolved) {
+        LOG_W(SWM_TAG, "No matching input port for symbol packet from %s",
+              macAddress ? MacToString(macAddress) : "(null)");
+        return -1;
+    }
+
+    SymbolMatchCommand command(macAddress, packet->command, packet->symbolId);
+
+    auto callbackIt = packetReceivedCallbacks.find(resolvedPort);
+    if (callbackIt != packetReceivedCallbacks.end() && callbackIt->second) {
+        callbackIt->second(command);
+    }
+
+    return 1;
+}
+
+void SymbolWirelessManager::setPacketReceivedCallback(
+    const std::function<void(const SymbolMatchCommand&)>& callback, SerialIdentifier port) {
+    packetReceivedCallbacks[port] = callback;
+}
+
+void SymbolWirelessManager::clearCallback() {
+    packetReceivedCallbacks.clear();
+}

--- a/src/fdn/wireless/symbol-wireless-manager.hpp
+++ b/src/fdn/wireless/symbol-wireless-manager.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstring>
+#include <functional>
+#include <map>
+
+#include "device/drivers/serial-wrapper.hpp"
+#include "device/wireless-manager.hpp"
+#include "symbol.hpp"
+
+class RemoteDeviceCoordinator;
+
+struct SymbolMatchPacket {
+    int command;
+    SymbolId symbolId;
+} __attribute__((packed));
+
+enum SMCommand {
+    SEND_SYMBOL = 0,
+    SYMBOL_MATCH_SUCCESS = 1,
+    SYMBOLS_REFRESHED = 2,
+    SM_COMMAND_COUNT,
+    SM_INVALID_COMMAND = 0xFF
+};
+
+struct SymbolMatchCommand {
+    uint8_t wifiMacAddr[6];
+    bool wifiMacAddrValid;
+    int command;
+    SymbolId symbolId;
+
+    SymbolMatchCommand() = delete;
+
+    SymbolMatchCommand(const uint8_t* macAddress, int command, SymbolId symbolId)
+        : wifiMacAddrValid(macAddress != nullptr), command(command), symbolId(symbolId) {
+        if (macAddress) {
+            memcpy(wifiMacAddr, macAddress, 6);
+        } else {
+            memset(wifiMacAddr, 0, 6);
+        }
+    }
+};
+
+class SymbolWirelessManager {
+public:
+    SymbolWirelessManager();
+    ~SymbolWirelessManager();
+
+    void initialize(WirelessManager* wirelessManager, RemoteDeviceCoordinator* remoteDeviceCoordinator);
+
+    int processSymbolMatchCommand(const uint8_t* macAddress, const uint8_t* data, size_t dataLen);
+
+    int sendPacket(int command, SymbolId symbolId, SerialIdentifier serialPort);
+
+    void setMacPeer(const uint8_t* macAddress);
+
+    void setPacketReceivedCallback(const std::function<void(const SymbolMatchCommand&)>& callback, SerialIdentifier port);
+
+    void clearCallback();
+
+private:
+    WirelessManager* wirelessManager;
+    RemoteDeviceCoordinator* remoteDeviceCoordinator;
+    uint8_t macPeer[6];
+
+    std::map<SerialIdentifier, std::function<void(const SymbolMatchCommand&)>> packetReceivedCallbacks;
+};


### PR DESCRIPTION
## Summary

Adds FDN firmware alongside the existing PDN monorepo, building on the `cyonic/116` migration. FDN shares `lib/core` and `lib/esp32-drivers` but lives in its own `src/fdn/` tree with dedicated PlatformIO environments.

---

### Build system (`platformio.ini`)

- New FDN envs: `esp32-s3_fdn_debug`, `esp32-s3_fdn_release`, `esp32-s3_fdn_release_verbose`
- `build_src_filter` excludes `src/pdn/*` and `src/cli/*`; `-I src/fdn` for includes
- Release env clears NVS on multi-flash

---

### Shared core (`lib/core/`)

**Serial / handshake**
- Added `INPUT_JACK_SECONDARY` to `SerialIdentifier`; `SerialManager` routes a third optional input jack with null-safe accessors
- `RemoteDeviceCoordinator` runs a second input-port handshake app on the secondary jack
- Handshake states take a `SerialIdentifier` so each port handshake is independent

**State machine**
- `StateMachine::loop` checks `checkAppTransitions()` after intra-app transitions (enables MatchSuccess → Main Menu app switch)
- `skipToState()` used by FDN Symbol Match on resume

**Connect states**
- `ConnectState` adds optional `isSecondaryRequired()` hook for dual-input-jack devices

**Lights**
- `LightManager` made subclass-friendly: virtual destructor, `applyLEDState()` overridable; removed unused `getCurrentAnimation()`

**Wireless / players**
- `PeerCommsInterface::getRssiForPeer()` default hook for proximity detection
- `RemotePlayerManager`: RSSI tracking, player count, `consumePacketReceived()`

**Game**
- `Symbol::setRandomSymbol()` no longer hardcodes `SYMBOL_E` (fixes boot hang in `SymbolManager::refreshSymbols()`)

**Driver names**
- Added `TERTIARY_BUTTON_DRIVER_NAME`, `SERIAL_IN_SECONDARY_DRIVER_NAME`

---

### ESP32 drivers (`lib/esp32-drivers/`)

- New `SSD1309U8G2Driver` (`U8G2_SSD1309_128X64_NONAME0`) for FDN OLED
- `Esp32S3SerialIn` extended for a second serial input instance (secondary jack)
- `EspNowDriver` exposes peer RSSI via `getRssiForPeer()`

---

### FDN firmware (`src/fdn/`)

**Boot / device**
- `main.cpp`: wires FDN-specific drivers (SSD1309, dual serial in, tertiary button, recess + fin LED strips), managers, and four apps; boots into Symbol Match
- `fdn-constants.hpp`: GPIO pins, LED counts, player ID, NVS namespace, RSSI thresholds
- `device/fdn.hpp` + `fdn.cpp`: `FDN` subclass with `FDNLightManager` and tertiary-button accessor
- `fdn-light-manager.hpp`: FDN LED layout (22 recess + 9 fin) overriding `applyLEDState()`
- FDN animations: idle, player-detected, match-success

**Wireless**
- `FDNConnectWirelessManager`: PDN serial connect / peer pairing
- `SymbolWirelessManager`: symbol-match ESP-NOW protocol

**Apps**
- **Symbol Match** — full state machine (selection, idle, connection/auth/unauthorized, upload-pending, match-success); `SymbolManager` for glyph display
- **Main Menu** — disconnect-driven return to Symbol Match
- **Idle** — player proximity / hack upload flow (mirrors Symbol Match connect states)
- **Hacking** — hacked-player hints via `HackedPlayersManager`
- `fdn-app-ids.hpp`, `fdn-connect-state.hpp`, `display-utils.hpp`

---

### Bug fixes

- **Boot freeze / blank second FDN**: removed debug override forcing both symbols to aperture; `refreshSymbols()` could never pick distinct symbols
- **MatchSuccess ↔ Main Menu loop**: on app resume, Symbol Match resets to Selection state, clears connection/session timers, and restarts idle LEDs instead of resuming into expired MatchSuccess

---

### PDN cleanup (no behavior change)

- Removed stale `#include "game/quickdraw-states.hpp"` from several PDN state files after monorepo move

---

## Test plan

- [ ] `pio run -e esp32-s3_fdn_debug` builds cleanly
- [ ] Flash two FDN units; both boot to Symbol Match splash and selection screen
- [ ] Connect PDNs, complete a symbol match, verify MatchSuccess → Main Menu → disconnect returns to Selection (no oscillation)
- [ ] Verify secondary serial jack handshake on dual-jack wiring
- [ ] Confirm PDN builds still pass: `pio run -e esp32-s3_pdn_release`