### PR TITLE
transport: Resender and ReliableChannel (#148)

### DIFF
--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -3,8 +3,7 @@
 #include <cstdint>
 
 //PktType determines which callback will handle the packet on the receiving end
-enum class PktType : uint8_t
-{
+enum class PktType : uint8_t {
     kPlayerInfoBroadcast = 0,
     kQuickdrawCommand = 1,
     kDebugPacket = 2,
@@ -20,8 +19,14 @@ enum class PktType : uint8_t
     kShootoutCommandAck = 12,
     kSymbolMatchCommand = 13,
     kFdnConnect = 14,
-    kNumPacketTypes //Not a real packet type, DO NOT USE
+    ACK = 15,
+    kNumPacketTypes  // Not a real packet type, DO NOT USE
 };
+
+struct AckPayload {
+    uint8_t originalType;
+    uint8_t seqId;
+} __attribute__((packed));
 
 struct DataPktHdr
 {

--- a/lib/core/include/wireless/reliable-channel.hpp
+++ b/lib/core/include/wireless/reliable-channel.hpp
@@ -1,0 +1,179 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <vector>
+
+#include "device/drivers/peer-comms-types.hpp"
+#include "wireless/resender.hpp"
+
+// A ReliableChannel is a typed, reliable pipe for exactly one PktType: game
+// code sends a packed payload struct and receives decoded structs back, and
+// the channel supplies everything reliability needs underneath — seqId
+// stamping, retry-until-ack via the shared Resender, ack emission on receipt,
+// duplicate suppression, and an abandon callback when a peer stays
+// unreachable past the retry budget. The struct itself is the wire format
+// (packed, memcpy'd); both ends run the same firmware, so field layout is the
+// protocol. ReliableChannelBase holds the untyped mechanics; the
+// ReliableChannel<P> template below binds them to a payload type. Channels
+// are created and owned by WirelessTransport, one per PktType.
+class ReliableChannelBase {
+public:
+    using OnAbandon = std::function<void(uint8_t seqId, const uint8_t* targetMac)>;
+
+    /// wirelessManager may be nullptr in probe-style unit tests; every use is
+    /// null-tolerant.
+    ReliableChannelBase(WirelessManager* wirelessManager,
+                        Resender* resender,
+                        PktType type,
+                        OnAbandon onAbandon,
+                        Resender::SendMode sendMode = Resender::SendMode::SUPERSEDE_PER_TARGET);
+    /// Virtual: channels are owned and deleted through the base pointer.
+    virtual ~ReliableChannelBase() = default;
+
+    /// The PktType this channel claims.
+    PktType type() const { return packetType; }
+
+    /// Routes an ack for this channel's PktType into the Resender.
+    void onAck(uint8_t seqId, const uint8_t* fromMac);
+
+    /// Relays a Resender abandonment to this channel's OnAbandon callback.
+    void onResenderAbandon(uint8_t seqId, const uint8_t* targetMac);
+
+    /// True when at least one send to this MAC is still awaiting its ack.
+    bool isPending(const uint8_t* mac) const;
+
+    /// Silently drops every pending send to this MAC (no abandon callback).
+    void cancel(const uint8_t* mac);
+
+    /// Counts peers with at least one in-flight entry on this channel.
+    size_t pendingCount(const std::vector<std::array<uint8_t, 6>>& peers) const {
+        size_t n = 0;
+        for (const std::array<uint8_t, 6>& p : peers)
+            if (isPending(p.data())) ++n;
+        return n;
+    }
+
+    /// Silently drops every pending send to each peer in the set.
+    void cancel(const std::vector<std::array<uint8_t, 6>>& peers) {
+        for (const std::array<uint8_t, 6>& p : peers)
+            cancel(p.data());
+    }
+
+    /// Typed subclass deserializes bytes into its payload type and dispatches
+    /// to its onReceive callback. Returns true if delivered.
+    virtual bool deliverBytes(const uint8_t* fromMac, const uint8_t* data, size_t len) = 0;
+
+protected:
+    uint8_t nextSeqId();
+    // nullptr in probe-style unit tests; every use is null-tolerant.
+    WirelessManager* getWirelessManager() const { return wirelessManager; }
+    // Own MAC, for self-exclusion in multi-target sends; nullptr without a manager.
+    const uint8_t* selfMac() const;
+    void sendOnceBytes(const uint8_t* mac, const uint8_t* data, size_t len);
+    // Defined in the .cpp so the logger stays out of this template header.
+    static void logLengthMismatch(PktType type, size_t got, size_t want);
+    // Suppress re-dispatch of a duplicate reliable delivery from the same
+    // sender, the expected consequence of a lost ack on a resent packet.
+    // seqId==0 is the unsequenced/sendOnce sentinel (see nextSeqId) and is
+    // never deduped here; those payloads dedup by domain identity at the
+    // caller. Returns true if (fromMac,seqId) was already delivered. Call only
+    // AFTER acking, so a duplicate still silences the sender's resends.
+    bool isDuplicateReliableRx(const uint8_t* fromMac, uint8_t seqId);
+
+    Resender* resender;
+    PktType packetType;
+    WirelessManager* wirelessManager;
+    Resender::SendMode sendMode;
+
+private:
+    struct RxSeqRecord {
+        std::array<uint8_t, 6> mac;
+        uint8_t lastSeqId;
+    };
+    OnAbandon onAbandon;
+    uint8_t lastSentSeqId = 0;
+    // Last nonzero seqId delivered per sender. Bounded by the physical peer
+    // count present in a session.
+    std::vector<RxSeqRecord> rxSeq;
+};
+
+template <class P>
+class ReliableChannel : public ReliableChannelBase {
+public:
+    using OnReceive = std::function<void(const uint8_t* fromMac, const P&)>;
+
+    /// See ReliableChannelBase; the payload struct P is the wire format.
+    ReliableChannel(WirelessManager* wirelessManager,
+                    Resender* resender,
+                    PktType type,
+                    OnAbandon onAbandon,
+                    Resender::SendMode sendMode = Resender::SendMode::SUPERSEDE_PER_TARGET)
+        : ReliableChannelBase(wirelessManager, resender, type,
+                              std::move(onAbandon), sendMode) {}
+
+    /// Reliable send: stamps a fresh nonzero seqId and hands the payload to the
+    /// Resender for retry-until-ack. Returns the stamped seqId.
+    uint8_t sendReliable(const uint8_t* mac, P p) {
+        p.seqId = nextSeqId();
+        resender->send(mac, packetType, p.seqId,
+                       reinterpret_cast<const uint8_t*>(&p), sizeof(P), sendMode);
+        return p.seqId;
+    }
+
+    /// Fire-and-forget send: seqId 0, no retry, no ack expected.
+    void sendOnce(const uint8_t* mac, P p) {
+        sendOnceBytes(mac, reinterpret_cast<const uint8_t*>(&p), sizeof(P));
+    }
+
+    /// Broadcast the same payload reliably to a peer set, skipping self. Each
+    /// target gets its own seqId just as a single-target send would.
+    void sendReliable(const std::vector<std::array<uint8_t, 6>>& peers, P p) {
+        broadcast(peers, [&](const uint8_t* mac) { sendReliable(mac, p); });
+    }
+
+    /// Broadcast the same payload fire-and-forget to a peer set, skipping self.
+    void sendOnce(const std::vector<std::array<uint8_t, 6>>& peers, P p) {
+        broadcast(peers, [&](const uint8_t* mac) { sendOnce(mac, p); });
+    }
+
+    /// Decode + dispatch one inbound packet: ack first (a retransmit means our
+    /// prior ack was lost), then dedup, then the onReceive callback.
+    bool deliver(const uint8_t* fromMac, const uint8_t* data, size_t len) {
+        if (len != sizeof(P)) {
+            // Drop without acking: a corrupt/truncated ESP-NOW frame (no CRC on
+            // this path) would otherwise be retransmitted to abandonment with no
+            // trace. Log so it's diagnosable rather than silent.
+            logLengthMismatch(packetType, len, sizeof(P));
+            return false;
+        }
+        P p;
+        std::memcpy(&p, data, sizeof(P));
+        Resender::sendAck(getWirelessManager(), fromMac, packetType, p.seqId);
+        if (isDuplicateReliableRx(fromMac, p.seqId)) return true;
+        if (onReceiveCallback) onReceiveCallback(fromMac, p);
+        return true;
+    }
+
+    /// Untyped entry point used by the transport's rx routing.
+    bool deliverBytes(const uint8_t* fromMac, const uint8_t* data, size_t len) override {
+        return deliver(fromMac, data, len);
+    }
+
+    /// Registers the decoded-payload handler.
+    void onReceive(OnReceive cb) { onReceiveCallback = std::move(cb); }
+
+private:
+    template <typename SendToTarget>
+    void broadcast(const std::vector<std::array<uint8_t, 6>>& peers, SendToTarget sendToTarget) {
+        const uint8_t* self = selfMac();
+        for (const std::array<uint8_t, 6>& target : peers) {
+            if (self && std::memcmp(target.data(), self, 6) == 0) continue;
+            sendToTarget(target.data());
+        }
+    }
+
+    OnReceive onReceiveCallback;
+};

--- a/lib/core/include/wireless/resender.hpp
+++ b/lib/core/include/wireless/resender.hpp
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <vector>
+
+#include "utils/simple-timer.hpp"
+#include "device/drivers/peer-comms-types.hpp"
+
+class WirelessManager;
+
+// Reliable unicast: send a packet to a peer, retransmit on timeout, abandon
+// after maxRetries. Per-target pending granularity depends on SendMode: state
+// channels keep one entry per (PktType, target); stream channels keep one per
+// (PktType, target, seqId) so a batch of distinct packets to the same peer all
+// retain their own retry slots. sync() must be called every loop tick to drive
+// retransmits.
+
+// One retry policy for every channel; Resender::RETRY_POLICY is the single
+// instance. (Namespace scope because a nested struct's default member
+// initializers can't be evaluated inside the enclosing class definition.)
+struct ResenderRetryPolicy {
+    unsigned long initialTimeoutMs = 100;
+    uint8_t maxRetries = 3;
+
+    /// Exponential backoff for the given retry number: 100, 200, 400 ...
+    constexpr unsigned long backoffMs(uint8_t retryNum) const {
+        // unsigned long is 32-bit on the ESP32; an unclamped shift from a
+        // caller-set maxRetries would be UB past ~25 doublings.
+        unsigned shift = retryNum > 16 ? 16u : retryNum;
+        return initialTimeoutMs << shift;
+    }
+
+    /// Time from the first transmission until the last retransmit leaves the
+    /// radio; after this window a reliable send can no longer reach the peer
+    /// (abandonment fires one further backoff later).
+    constexpr unsigned long totalBudgetMs() const {
+        unsigned long total = 0;
+        for (uint8_t i = 0; i < maxRetries; ++i)
+            total += backoffMs(i);
+        return total;
+    }
+};
+
+class Resender {
+public:
+    // How a send relates to other in-flight sends to the same peer on the same
+    // channel. SUPERSEDE_PER_TARGET (default): the payload is current state, so a
+    // newer send obsoletes any prior unacked one and only the latest survives
+    // (an older retransmit arriving last would otherwise reinstate stale state).
+    // KEEP_DISTINCT: the payload is one item of a stream (e.g. a bracket slot),
+    // so each seqId keeps its own retry slot and a dropped one still retransmits.
+    enum class SendMode { SUPERSEDE_PER_TARGET,
+                          KEEP_DISTINCT };
+
+    using RetryPolicy = ResenderRetryPolicy;
+    static constexpr RetryPolicy RETRY_POLICY{};
+
+    /// Fires once per pending entry that exhausts its retry budget. Invoked
+    /// from sync() AFTER all retransmits have been processed and the
+    /// abandoned entries removed, so callbacks may freely call send() or
+    /// cancel() on this Resender without invalidating the iteration.
+    using AbandonCallback = std::function<void(PktType type, uint8_t seqId,
+                                               const uint8_t* targetMac)>;
+
+    /// wirelessManager may be nullptr in unit tests; transmit() then no-ops.
+    explicit Resender(WirelessManager* wirelessManager)
+        : wirelessManager(wirelessManager) {}
+    /// Pending entries own their payload copies; nothing external to release.
+    ~Resender() = default;
+
+    /// Send the shared ack wire format for a reliably-received packet.
+    static void sendAck(WirelessManager* wm, const uint8_t* toMac,
+                        PktType originalType, uint8_t seqId);
+
+    /// Registers the once-per-abandoned-entry callback (see AbandonCallback).
+    void setAbandonCallback(AbandonCallback cb) {
+        abandonCallback = std::move(cb);
+    }
+
+    /// Reliable send. SendMode controls how it relates to other pending sends to
+    /// the same (type, target): SUPERSEDE_PER_TARGET drops any prior one,
+    /// KEEP_DISTINCT keeps prior sends with a different seqId. payload bytes are
+    /// copied.
+    void send(const uint8_t* target, PktType type, uint8_t seqId,
+              const uint8_t* payload, size_t len,
+              SendMode mode = SendMode::SUPERSEDE_PER_TARGET);
+
+    /// Clears the matching pending entry. Returns true when one matched.
+    bool onAck(PktType type, uint8_t seqId, const uint8_t* fromMac);
+
+    /// Silent drop; use when the target is known unreachable. No abandon callback.
+    void cancel(PktType type, const uint8_t* target);
+
+    /// Drives retransmits and abandonment. Must be called every loop tick.
+    void sync();
+
+    /// Number of pending entries on this channel, across all targets.
+    size_t pendingCount(PktType type) const {
+        size_t count = 0;
+        for (const Pending& p : pending) {
+            if (p.type == type) ++count;
+        }
+        return count;
+    }
+
+    /// True when at least one entry to this target is pending on this channel.
+    bool isPending(PktType type, const uint8_t* target) const {
+        if (target == nullptr) return false;
+        for (const Pending& p : pending) {
+            if (p.type != type) continue;
+            if (memcmp(p.target.data(), target, 6) == 0) return true;
+        }
+        return false;
+    }
+
+private:
+    struct Pending {
+        PktType type;
+        std::array<uint8_t, 6> target;
+        uint8_t seqId;
+        std::vector<uint8_t> payload;
+        uint8_t retries;
+        SimpleTimer timer;
+    };
+
+    std::vector<Pending>::iterator findPending(
+        PktType type, uint8_t seqId, const uint8_t* target);
+
+    // Drop every pending entry to `target` on this PktType, across all seqIds.
+    void eraseAllToTarget(PktType type, const uint8_t* target);
+
+    // Returns false when the frame never reached the radio, so the caller can
+    // avoid spending a retry on a packet that was not actually sent.
+    bool transmit(const Pending& p);
+
+    WirelessManager* wirelessManager;
+    std::vector<Pending> pending;
+    AbandonCallback abandonCallback;
+};

--- a/lib/core/src/wireless/reliable-channel.cpp
+++ b/lib/core/src/wireless/reliable-channel.cpp
@@ -1,0 +1,86 @@
+#include "wireless/reliable-channel.hpp"
+#include "device/wireless-manager.hpp"
+#include "device/drivers/logger.hpp"
+
+namespace {
+constexpr const char* RELIABLE_CHANNEL_TAG = "ReliableChannel";
+// Caps the per-channel RX dedup cursor table. The live peer set is bounded by
+// the ESP-NOW peer cap, but senders come and go across a session and this table
+// never otherwise shrinks; evicting the oldest cursor when full keeps it
+// bounded. A wrongly-evicted still-active sender just re-seeds on its next
+// packet, costing at most one re-dispatch that downstream domain dedup absorbs.
+constexpr size_t MAX_RX_SENDERS = 32;
+}
+
+ReliableChannelBase::ReliableChannelBase(WirelessManager* wirelessManager,
+                                         Resender* resender,
+                                         PktType type,
+                                         OnAbandon onAbandon,
+                                         Resender::SendMode sendMode)
+    : resender(resender)
+    , packetType(type)
+    , wirelessManager(wirelessManager)
+    , sendMode(sendMode)
+    , onAbandon(std::move(onAbandon)) {}
+
+void ReliableChannelBase::onAck(uint8_t seqId, const uint8_t* fromMac) {
+    if (resender) {
+        resender->onAck(packetType, seqId, fromMac);
+    }
+}
+
+void ReliableChannelBase::onResenderAbandon(uint8_t seqId, const uint8_t* targetMac) {
+    if (onAbandon) onAbandon(seqId, targetMac);
+}
+
+bool ReliableChannelBase::isPending(const uint8_t* mac) const {
+    return resender && resender->isPending(packetType, mac);
+}
+
+void ReliableChannelBase::cancel(const uint8_t* mac) {
+    if (resender) resender->cancel(packetType, mac);
+}
+
+uint8_t ReliableChannelBase::nextSeqId() {
+    // 0 is reserved for "no ack expected"; skip it on wrap.
+    lastSentSeqId = lastSentSeqId == 255 ? 1 : lastSentSeqId + 1;
+    return lastSentSeqId;
+}
+
+const uint8_t* ReliableChannelBase::selfMac() const {
+    WirelessManager* wm = getWirelessManager();
+    return wm ? wm->getMacAddress() : nullptr;
+}
+
+bool ReliableChannelBase::isDuplicateReliableRx(const uint8_t* fromMac, uint8_t seqId) {
+    if (seqId == 0 || fromMac == nullptr) return false;
+    for (RxSeqRecord& r : rxSeq) {
+        if (std::memcmp(r.mac.data(), fromMac, 6) == 0) {
+            if (r.lastSeqId == seqId) return true;
+            r.lastSeqId = seqId;
+            return false;
+        }
+    }
+    RxSeqRecord rec;
+    std::memcpy(rec.mac.data(), fromMac, 6);
+    rec.lastSeqId = seqId;
+    if (rxSeq.size() >= MAX_RX_SENDERS) {
+        rxSeq.erase(rxSeq.begin());
+    }
+    rxSeq.push_back(rec);
+    return false;
+}
+
+void ReliableChannelBase::logLengthMismatch(PktType type, size_t got, size_t want) {
+    LOG_W(RELIABLE_CHANNEL_TAG, "reliable rx len mismatch type=%u got=%zu want=%zu",
+          (unsigned)type, got, want);
+}
+
+void ReliableChannelBase::sendOnceBytes(const uint8_t* mac, const uint8_t* data, size_t len) {
+    WirelessManager* wm = getWirelessManager();
+    if (wm == nullptr) {
+        LOG_E(RELIABLE_CHANNEL_TAG, "sendOnceBytes called with null WirelessManager");
+        return;
+    }
+    wm->sendEspNowData(mac, packetType, data, len);
+}

--- a/lib/core/src/wireless/resender.cpp
+++ b/lib/core/src/wireless/resender.cpp
@@ -1,0 +1,146 @@
+#include "wireless/resender.hpp"
+
+#include "device/wireless-manager.hpp"
+#include "device/drivers/logger.hpp"
+
+namespace {
+constexpr const char* RSND_TAG = "RSND";
+}
+
+void Resender::sendAck(WirelessManager* wm, const uint8_t* toMac,
+                       PktType originalType, uint8_t seqId) {
+    if (wm == nullptr || toMac == nullptr) return;
+    // seqId=0 is the fire-and-forget sentinel; no sender-side pending entry
+    // exists for the ack to match, so emitting one wastes airtime.
+    if (seqId == 0) return;
+    AckPayload payload{static_cast<uint8_t>(originalType), seqId};
+    wm->sendEspNowData(toMac, PktType::ACK,
+                       reinterpret_cast<const uint8_t*>(&payload), sizeof(payload));
+}
+
+void Resender::send(const uint8_t* target, PktType type, uint8_t seqId,
+                    const uint8_t* payload, size_t len, SendMode mode) {
+    if (target == nullptr) return;
+
+    if (mode == SendMode::SUPERSEDE_PER_TARGET) {
+        // State channel: a newer send obsoletes any prior unacked one to this
+        // peer, so drop every prior entry regardless of seqId. Keeping a stale
+        // one armed risks an old retransmit landing after the new state.
+        eraseAllToTarget(type, target);
+    } else {
+        // Stream channel: distinct seqIds to the same peer coexist, so a batch
+        // of reliable sends (e.g. one BRACKET_ENTRY per bracket slot) each keep
+        // their own retry slot. Only a true resend of the same seqId replaces.
+        std::vector<Pending>::iterator it = findPending(type, seqId, target);
+        if (it != pending.end()) {
+            pending.erase(it);
+        }
+    }
+
+    Pending p;
+    p.type = type;
+    memcpy(p.target.data(), target, 6);
+    p.seqId = seqId;
+    p.payload.assign(payload, payload + len);
+    p.retries = 0;
+    p.timer.setTimer(RETRY_POLICY.backoffMs(0));
+    pending.push_back(std::move(p));
+
+    transmit(pending.back());
+}
+
+bool Resender::onAck(PktType type, uint8_t seqId, const uint8_t* fromMac) {
+    if (fromMac == nullptr) return false;
+    for (std::vector<Pending>::iterator it = pending.begin(); it != pending.end(); ++it) {
+        if (it->type != type) continue;
+        if (memcmp(it->target.data(), fromMac, 6) != 0) continue;
+        if (it->seqId != seqId) continue;
+
+        pending.erase(it);
+        return true;
+    }
+    return false;
+}
+
+void Resender::cancel(PktType type, const uint8_t* target) {
+    if (target == nullptr) return;
+    eraseAllToTarget(type, target);
+}
+
+void Resender::eraseAllToTarget(PktType type, const uint8_t* target) {
+    for (std::vector<Pending>::iterator it = pending.begin(); it != pending.end();) {
+        if (it->type == type &&
+            memcmp(it->target.data(), target, 6) == 0) {
+            it = pending.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void Resender::sync() {
+    // Collect abandoned entries first so the abandon callback can safely
+    // mutate pending (cancel, send) without invalidating this loop's
+    // iteration. Retransmits stay inline because they don't structurally
+    // change the vector.
+    struct AbandonedEntry {
+        PktType type;
+        uint8_t seqId;
+        std::array<uint8_t, 6> target;
+    };
+    std::vector<AbandonedEntry> abandoned;
+
+    for (size_t i = 0; i < pending.size();) {
+        Pending& p = pending[i];
+        if (!p.timer.expired()) {
+            ++i;
+            continue;
+        }
+
+        if (p.retries >= RETRY_POLICY.maxRetries) {
+            LOG_E(RSND_TAG, "abandon type=%u seq=%u to=%02X%02X",
+                  (unsigned)p.type, p.seqId, p.target[4], p.target[5]);
+            abandoned.push_back({p.type, p.seqId, p.target});
+            pending.erase(pending.begin() + i);
+            continue;
+        }
+
+        if (transmit(p)) {
+            p.retries++;
+            LOG_W(RSND_TAG, "retransmit type=%u seq=%u retry=%u to=%02X%02X",
+                  (unsigned)p.type, p.seqId, p.retries, p.target[4], p.target[5]);
+        }
+        // Re-arm either way. A send that never reached the radio leaves retries
+        // unchanged, so a packet that was not actually transmitted keeps being
+        // retried rather than being abandoned against an exhausted budget.
+        p.timer.setTimer(RETRY_POLICY.backoffMs(p.retries));
+        ++i;
+    }
+
+    if (abandonCallback) {
+        for (const AbandonedEntry& a : abandoned) {
+            abandonCallback(a.type, a.seqId, a.target.data());
+        }
+    }
+}
+
+std::vector<Resender::Pending>::iterator Resender::findPending(
+    PktType type, uint8_t seqId, const uint8_t* target) {
+    for (std::vector<Pending>::iterator it = pending.begin(); it != pending.end(); ++it) {
+        if (it->type != type) continue;
+        if (it->seqId != seqId) continue;
+        if (memcmp(it->target.data(), target, 6) != 0) continue;
+        return it;
+    }
+    return pending.end();
+}
+
+bool Resender::transmit(const Pending& p) {
+    // Null manager is the unit-test no-op path: nothing is sent, but nothing can
+    // fail either, so report success and let retry bookkeeping run.
+    if (wirelessManager == nullptr) return true;
+    // A negative return means the frame never reached the radio (transient PSRAM
+    // pressure, or a brief ESP-NOW-not-ready window during a WiFi mode switch).
+    return wirelessManager->sendEspNowData(p.target.data(), p.type,
+                                           p.payload.data(), p.payload.size()) >= 0;
+}

--- a/test/test_core/reliable-channel-tests.hpp
+++ b/test/test_core/reliable-channel-tests.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include "wireless/reliable-channel.hpp"
+
+// Probe subclass exposing protected nextSeqId for testing.
+// Provides a no-op deliverBytes so the (otherwise pure-virtual) base
+// becomes instantiable.
+class ProbeChannel : public ReliableChannelBase {
+public:
+    using ReliableChannelBase::isDuplicateReliableRx;
+    using ReliableChannelBase::nextSeqId;
+    using ReliableChannelBase::ReliableChannelBase;
+    /// No-op body so the otherwise pure-virtual base becomes instantiable.
+    bool deliverBytes(const uint8_t*, const uint8_t*, size_t) override { return false; }
+};
+
+TEST(ReliableChannelBaseTest, nextSeqIdWrapsAfter255) {
+    Resender resender(nullptr);
+    ProbeChannel ch(nullptr, &resender, PktType::kChainGameEvent,
+                    [](uint8_t, const uint8_t*) {});
+    for (int i = 1; i <= 255; ++i) {
+        ASSERT_EQ(ch.nextSeqId(), static_cast<uint8_t>(i));
+    }
+    // The 256th call wraps back to 1 (zero is reserved for "no ack expected").
+    ASSERT_EQ(ch.nextSeqId(), uint8_t{1});
+}
+
+TEST(ReliableChannelBaseTest, rxDedupEvictsOldestSenderWhenFull) {
+    // The per-channel RX dedup cursor table is capped (kMaxRxSenders=32). Senders
+    // come and go across a session, so when a 33rd distinct sender arrives the
+    // oldest cursor is evicted to keep the table bounded. A wrongly-evicted
+    // still-active sender just re-seeds on its next packet (one tolerated
+    // re-dispatch); a tracked sender keeps deduping.
+    Resender resender(nullptr);
+    ProbeChannel ch(nullptr, &resender, PktType::kChainGameEvent,
+                    [](uint8_t, const uint8_t*) {});
+
+    auto sender = [](uint8_t i) {
+        return std::array<uint8_t, 6>{0x10, 0x20, 0x30, 0x40, 0x50, i};
+    };
+    const uint8_t seqId = 7;
+
+    // Fill to the cap: each sender's first packet is fresh, not a duplicate.
+    for (uint8_t i = 1; i <= 32; ++i) {
+        std::array<uint8_t, 6> m = sender(i);
+        EXPECT_FALSE(ch.isDuplicateReliableRx(m.data(), seqId));
+    }
+    // The oldest (sender 1) is still tracked: a repeat is deduped.
+    std::array<uint8_t, 6> first = sender(1);
+    EXPECT_TRUE(ch.isDuplicateReliableRx(first.data(), seqId));
+
+    // A 33rd distinct sender overflows the table and evicts the oldest cursor.
+    std::array<uint8_t, 6> overflow = sender(33);
+    EXPECT_FALSE(ch.isDuplicateReliableRx(overflow.data(), seqId));
+
+    // Sender 1's cursor was evicted, so the same packet now reads as fresh.
+    EXPECT_FALSE(ch.isDuplicateReliableRx(first.data(), seqId));
+
+    // A sender that was never evicted still dedupes its repeat.
+    std::array<uint8_t, 6> stillTracked = sender(32);
+    EXPECT_TRUE(ch.isDuplicateReliableRx(stillTracked.data(), seqId));
+}
+
+TEST(ResenderTest, distinctSeqIdsToSameTargetCoexist) {
+    // A batch of distinct reliable packets to one peer on one channel (e.g. one
+    // BRACKET_ENTRY per bracket slot) must each retain an independent retry
+    // slot keyed by seqId; sharing (type, target) must not collapse them into
+    // one, or a dropped non-final slot would never retransmit.
+    Resender resender(nullptr);  // null wm: transmit() no-ops, retry bookkeeping intact
+    uint8_t target[6] = {1, 2, 3, 4, 5, 6};
+    uint8_t payload[4] = {0};
+    const Resender::SendMode kStream = Resender::SendMode::KEEP_DISTINCT;
+    for (uint8_t seq = 1; seq <= 3; ++seq) {
+        resender.send(target, PktType::kShootoutCommand, seq,
+                      payload, sizeof(payload), kStream);
+    }
+    EXPECT_EQ(resender.pendingCount(PktType::kShootoutCommand), 3u);
+
+    // Acking the middle seqId clears only that slot.
+    EXPECT_TRUE(resender.onAck(PktType::kShootoutCommand, 2, target));
+    EXPECT_EQ(resender.pendingCount(PktType::kShootoutCommand), 2u);
+
+    // A genuine re-send of an existing seqId replaces rather than duplicates.
+    resender.send(target, PktType::kShootoutCommand, 1,
+                  payload, sizeof(payload), kStream);
+    EXPECT_EQ(resender.pendingCount(PktType::kShootoutCommand), 2u);
+
+    // cancel() drops every remaining slot to the target on that channel.
+    resender.cancel(PktType::kShootoutCommand, target);
+    EXPECT_EQ(resender.pendingCount(PktType::kShootoutCommand), 0u);
+}
+
+TEST(ResenderTest, supersedeDropsPriorAndStaleAckDoesNotResurrect) {
+    // The whole point of SupersedePerTarget (DRAW_RESULT / NEVER_PRESSED): a
+    // newer send to the same peer obsoletes the prior unacked one, so only the
+    // latest is armed. A late ack for the superseded seqId must match nothing and
+    // must not resurrect it or disturb the surviving entry; otherwise a stale
+    // retransmit could land after the newer state.
+    Resender resender(nullptr);  // null wm: transmit() no-ops, retry bookkeeping intact
+    uint8_t target[6] = {1, 2, 3, 4, 5, 6};
+    uint8_t payload[4] = {0};
+    const Resender::SendMode kState = Resender::SendMode::SUPERSEDE_PER_TARGET;
+
+    // Send A, then supersede with B before A is acked.
+    resender.send(target, PktType::kQuickdrawCommand, /*seqA=*/5,
+                  payload, sizeof(payload), kState);
+    resender.send(target, PktType::kQuickdrawCommand, /*seqB=*/6,
+                  payload, sizeof(payload), kState);
+    // A was dropped on supersede; only B remains.
+    EXPECT_EQ(resender.pendingCount(PktType::kQuickdrawCommand), 1u);
+
+    // A stale ack for the superseded A matches nothing and leaves B armed.
+    EXPECT_FALSE(resender.onAck(PktType::kQuickdrawCommand, /*seqA=*/5, target));
+    EXPECT_EQ(resender.pendingCount(PktType::kQuickdrawCommand), 1u);
+
+    // The surviving entry is B (not a resurrected A): acking B clears it.
+    EXPECT_TRUE(resender.onAck(PktType::kQuickdrawCommand, /*seqB=*/6, target));
+    EXPECT_EQ(resender.pendingCount(PktType::kQuickdrawCommand), 0u);
+}

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -20,6 +20,7 @@
 #include "chain-duel-multi-device-fixture.hpp"
 #include "shootout-manager-tests.hpp"
 #include "match-manager-concurrent.hpp"
+#include "reliable-channel-tests.hpp"
 
 #if defined(ARDUINO)
 #include <Arduino.h>


### PR DESCRIPTION
Ports `Resender` and `ReliableChannel` from `tire-fire/reliable-duel-delivery` (the branch the 6-device hardware validation ran on) onto the clean base. Scope is #148 only; `WirelessTransport` follows as its own PR (#151) stacked on this one.

**Deviations from "port cleanly" — the parts worth reviewing hardest:**

- **Channels take `WirelessManager*` directly.** The source had channels hold a `WirelessTransport*` solely to call `getWirelessManager()` through it. That indirection was the only thing coupling #148's files to #151's, so it's removed — which is what makes the two issues independently buildable and reviewable. The transport passes its manager in at channel construction (visible in the #151 PR).
- **subType is removed.** Channel identity is the PktType alone; the ack payload is 2 bytes (`originalType`, `seqId`). Shootout's seven commands get their own PktTypes when #169 lands.
- **Per-channel stats are replaced by two log events** (retransmit `LOG_W`, abandon `LOG_E`, tag `RSND`). This also deletes #151's `sumStats` scope. If bench debugging misses the counters, this is the piece to argue about.
- **`kAck` is appended at 15**, not renumbered per the source — the legacy enum entries (incl. the four old per-manager `*Ack` types) stay untouched until their owners are deleted by later issues.

**Fragile spots:** `Resender::sync()` (abandon collection is deferred past iteration so callbacks can safely re-enter) and `ReliableChannel::deliver()` (ack-before-dedup ordering — a duplicate must still re-ack to silence the sender, but dispatch exactly once).

Adjacent-scope heads-up: #152's "hardware ACK as delivery signal; remove kAck" clause is unsound — `SEND_SUCCESS` is a MAC-layer ack that fires even when the receiver's app is deaf (mode transitions, our documented WiFi-excursion windows). Evidence and a proposed re-scope coming on #143/#152; this PR keeps kAck accordingly.

Verification: this commit standalone passes 267/267 native tests (4 new: seqId wrap, dedup-table eviction, keep-distinct slot independence, supersede + stale-ack). With the stacked #151 commit: 276/276.
