### PR TITLE
transport: SerialFrameParser and encodeFramed (#149)

### DIFF
--- a/lib/core/include/device/serial-frame-parser.hpp
+++ b/lib/core/include/device/serial-frame-parser.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+// Serial frame protocol constants. HELLO is the sole opcode on the wire:
+// serial carries physical-connectivity discovery/liveness only, everything
+// else rides ESP-NOW. The framing (preamble + opcode + payload + CRC-16)
+// recreates for UART what 802.11 gives ESP-NOW for free: message boundaries
+// and integrity on a raw byte stream with flaky TRS contacts.
+constexpr uint8_t FRAME_PREAMBLE_0 = 0xAA;
+constexpr uint8_t FRAME_PREAMBLE_1 = 0x55;
+constexpr uint8_t OP_HELLO = 0x00;
+// Payload bytes after the opcode, before the CRC: source mac[6] +
+// deviceType[1] + headMac[6] + confirmed[1]. The packed HelloPayload struct
+// that owns this layout arrives with the HELLO wire-format work; the parser
+// only needs the length to frame it.
+constexpr size_t HELLO_PAYLOAD_LEN = 14;
+
+// Wraps a payload in the framed wire format: preamble, opcode, payload,
+// CRC-16 over (opcode + payload). The inverse of SerialFrameParser.
+std::vector<uint8_t> encodeFramed(uint8_t opcode, const std::vector<uint8_t>& payload);
+
+// A validated binary frame surfaced to downstream consumers (RDC's serial
+// ingest, bound via setBinaryFrameHandler). payload holds the raw bytes
+// between the opcode and the CRC.
+struct Frame {
+    uint8_t opcode;
+    std::vector<uint8_t> payload;
+};
+
+using BinaryFrameHandler = std::function<void(const Frame&)>;
+
+// Parses one jack's serial byte stream into framed binary frames
+// (preamble 0xAA 0x55 + opcode + payload + CRC-16). One instance per jack.
+// Binary framing because the jacks are physically unreliable (TRS contacts,
+// partial insertion): a corrupted delimited string still parses as *some*
+// string, while a frame failing CRC is dropped and the preamble resyncs.
+// feed() runs on the UART event task; requestReset() is callable from the main
+// loop and is honored at the start of the next feed(), so the parser's
+// std::vector state is only ever mutated by the feeding thread.
+class SerialFrameParser {
+public:
+    /// Consumes one burst of raw serial bytes; fires the frame handler for
+    /// every CRC-valid frame completed within it.
+    void feed(const uint8_t* data, size_t len);
+
+    /// Request a parser reset from another thread. The actual clear happens at
+    /// the start of the next feed(), keeping parser state single-owner.
+    void requestReset() { resetRequested.store(true); }
+
+    /// Registers the validated-frame consumer.
+    void setBinaryFrameHandler(BinaryFrameHandler cb) { binaryFrameHandler = std::move(cb); }
+
+private:
+    enum class ParseState {
+        SCAN_FOR_SYNC,
+        GOT_AA,
+        READING_OPCODE,
+        READING_PAYLOAD,
+        READING_CRC,
+    };
+
+    struct ParserState {
+        ParseState state = ParseState::SCAN_FOR_SYNC;
+        uint8_t opcode = 0;
+        std::vector<uint8_t> payloadBuf;
+        size_t expectedPayloadLen = 0;
+        uint8_t crcBytes[2] = {0, 0};
+        size_t crcBytesRead = 0;
+    };
+
+    ParserState parser;
+
+    // Timestamp of the last arriving byte; checkTimeout() uses it to clear a
+    // stalled mid-frame parse.
+    unsigned long lastByteMs = 0;
+
+    std::atomic<bool> resetRequested{false};
+
+    BinaryFrameHandler binaryFrameHandler;
+
+    // Wall-clock window after which a mid-frame parser resets to scan-for-sync.
+    static constexpr unsigned long PARSER_TIMEOUT_MS = 50;
+
+    void resetParser();
+    void checkTimeout();
+    static size_t opcodePayloadLen(uint8_t opcode);
+    static unsigned long nowMs();
+};

--- a/lib/core/include/wireless/crc16.hpp
+++ b/lib/core/include/wireless/crc16.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <cstdint>
+#include <cstddef>
+
+// CRC-16/CCITT XMODEM: poly 0x1021, init 0x0000, no reflection, no xorout.
+// Generic byte-span checksum; today its only caller is serial UART framing
+// (the ESP-NOW path relies on the radio's hardware FCS instead).
+
+// Fold one more span into a running CRC. Lets a caller checksum several
+// non-contiguous spans (e.g. opcode then payload) without concatenating them.
+inline uint16_t crc16Update(uint16_t crc, const uint8_t* data, size_t len) {
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= static_cast<uint16_t>(data[i]) << 8;
+        for (int j = 0; j < 8; ++j) {
+            crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : (crc << 1);
+        }
+    }
+    return crc;
+}
+
+inline uint16_t crc16(const uint8_t* data, size_t len) {
+    return crc16Update(0x0000, data, len);
+}

--- a/lib/core/src/device/serial-frame-parser.cpp
+++ b/lib/core/src/device/serial-frame-parser.cpp
@@ -1,0 +1,143 @@
+#include "device/serial-frame-parser.hpp"
+
+#include "utils/simple-timer.hpp"
+#include "wireless/crc16.hpp"
+
+#include <limits>
+#include <utility>
+
+namespace {
+constexpr size_t PREAMBLE_BYTES = 2;
+constexpr size_t CRC_BYTES = 2;
+}
+
+std::vector<uint8_t> encodeFramed(uint8_t opcode, const std::vector<uint8_t>& payload) {
+    // CRC covers opcode + payload, folded as two spans so the frame is built
+    // in a single buffer (mirrors the parser's RX-side computation).
+    uint16_t crc = crc16(&opcode, 1);
+    crc = crc16Update(crc, payload.data(), payload.size());
+
+    std::vector<uint8_t> frame;
+    frame.reserve(PREAMBLE_BYTES + 1 + payload.size() + CRC_BYTES);
+    frame.push_back(FRAME_PREAMBLE_0);
+    frame.push_back(FRAME_PREAMBLE_1);
+    frame.push_back(opcode);
+    frame.insert(frame.end(), payload.begin(), payload.end());
+    frame.push_back(static_cast<uint8_t>(crc >> 8));
+    frame.push_back(static_cast<uint8_t>(crc & 0xFF));
+    return frame;
+}
+
+unsigned long SerialFrameParser::nowMs() {
+    PlatformClock* clk = SimpleTimer::getPlatformClock();
+    if (clk == nullptr) {
+        // A null clock must fail loud, not silently disable timeouts: max()
+        // forces the next gap computation to time out immediately.
+        return std::numeric_limits<unsigned long>::max();
+    }
+    return clk->milliseconds();
+}
+
+size_t SerialFrameParser::opcodePayloadLen(uint8_t opcode) {
+    switch (opcode) {
+        case OP_HELLO: return HELLO_PAYLOAD_LEN;
+        default:       return 0;
+    }
+}
+
+void SerialFrameParser::resetParser() {
+    parser.state = ParseState::SCAN_FOR_SYNC;
+    parser.opcode = 0;
+    parser.payloadBuf.clear();
+    parser.expectedPayloadLen = 0;
+    parser.crcBytes[0] = 0;
+    parser.crcBytes[1] = 0;
+    parser.crcBytesRead = 0;
+}
+
+void SerialFrameParser::checkTimeout() {
+    if (parser.state == ParseState::SCAN_FOR_SYNC) return;
+    const unsigned long now = nowMs();
+    // Clamp a backwards clock (now < lastByteMs) to gap 0 so unsigned
+    // subtraction can't underflow to ~UINT_MAX and fire a spurious mid-frame
+    // resync. The null-clock case still times out: nowMs() returns max() there,
+    // which is never below lastByteMs, so it yields a large gap unclamped.
+    const unsigned long gap = now >= lastByteMs ? now - lastByteMs : 0;
+    if (gap > PARSER_TIMEOUT_MS) {
+        resetParser();
+    }
+}
+
+void SerialFrameParser::feed(const uint8_t* data, size_t len) {
+    // Honor a reset requested from another thread before consuming this burst,
+    // so the only thread that ever clears the parser is this one. Then check the
+    // mid-frame timeout, also before consuming, so a stale partial frame is
+    // cleared before a late byte completes a corrupt one.
+    if (resetRequested.exchange(false)) {
+        resetParser();
+    }
+    checkTimeout();
+    const unsigned long now = nowMs();
+    lastByteMs = now;
+    for (size_t i = 0; i < len; ++i) {
+        const uint8_t b = data[i];
+        switch (parser.state) {
+            case ParseState::SCAN_FOR_SYNC:
+                if (b == FRAME_PREAMBLE_0) {
+                    parser.state = ParseState::GOT_AA;
+                }
+                break;
+            case ParseState::GOT_AA:
+                if (b == FRAME_PREAMBLE_1) {
+                    parser.state = ParseState::READING_OPCODE;
+                } else if (b == FRAME_PREAMBLE_0) {
+                    // Stay in GOT_AA: a stray 0xAA followed by the real preamble (0xAA 0x55) should
+                    // still detect the frame start. Going back to SCAN_FOR_SYNC would drop the second
+                    // 0xAA, requiring a 3-byte preamble before re-syncing.
+                } else {
+                    resetParser();
+                }
+                break;
+            case ParseState::READING_OPCODE:
+                if (b != OP_HELLO) {  // HELLO is the sole serial opcode
+                    resetParser();
+                    break;
+                }
+                parser.opcode = b;
+                parser.expectedPayloadLen = opcodePayloadLen(b);
+                parser.payloadBuf.clear();
+                if (parser.expectedPayloadLen == 0) {
+                    parser.state = ParseState::READING_CRC;
+                    parser.crcBytesRead = 0;
+                } else {
+                    parser.state = ParseState::READING_PAYLOAD;
+                }
+                break;
+            case ParseState::READING_PAYLOAD:
+                parser.payloadBuf.push_back(b);
+                if (parser.payloadBuf.size() >= parser.expectedPayloadLen) {
+                    parser.state = ParseState::READING_CRC;
+                    parser.crcBytesRead = 0;
+                }
+                break;
+            case ParseState::READING_CRC:
+                parser.crcBytes[parser.crcBytesRead++] = b;
+                if (parser.crcBytesRead == 2) {
+                    const uint16_t got = (static_cast<uint16_t>(parser.crcBytes[0]) << 8) | static_cast<uint16_t>(parser.crcBytes[1]);
+                    // CRC covers opcode + payload; fold the two spans into a
+                    // running CRC to avoid a per-frame copy on the UART event task.
+                    uint16_t expected = crc16(&parser.opcode, 1);
+                    expected = crc16Update(expected, parser.payloadBuf.data(),
+                                           parser.payloadBuf.size());
+                    if (got == expected && binaryFrameHandler) {
+                        // Move, don't copy: resetParser()'s clear() is valid on
+                        // the moved-from buffer.
+                        Frame f{parser.opcode, std::move(parser.payloadBuf)};
+                        binaryFrameHandler(f);
+                    }
+                    resetParser();
+                }
+                break;
+        }
+    }
+}

--- a/test/test_core/serial-frame-parser-tests.hpp
+++ b/test/test_core/serial-frame-parser-tests.hpp
@@ -1,0 +1,225 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "device/serial-frame-parser.hpp"
+#include "utility-tests.hpp"
+#include "utils/simple-timer.hpp"
+#include "wireless/crc16.hpp"
+
+#include <cstdint>
+#include <vector>
+
+class SerialFrameParserTests : public testing::Test {
+public:
+    /// Installs a fake clock so timeout behavior is deterministic.
+    void SetUp() override {
+        fakeClock = new FakePlatformClock();
+        SimpleTimer::setPlatformClock(fakeClock);
+        fakeClock->setTime(1000);
+    }
+
+    /// Restores the real platform clock.
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        delete fakeClock;
+    }
+
+    /// Build a valid binary frame for a given opcode + payload; appends the CRC-16
+    /// computed over (opcode + payload). The 0xAA 0x55 preamble is prepended.
+    /// Built by hand rather than via encodeFramed so the tests cross-check the
+    /// encoder and parser against an independent construction.
+    std::vector<uint8_t> buildFrame(uint8_t opcode, const std::vector<uint8_t>& payload) {
+        std::vector<uint8_t> crcInput;
+        crcInput.push_back(opcode);
+        crcInput.insert(crcInput.end(), payload.begin(), payload.end());
+        const uint16_t c = crc16(crcInput.data(), crcInput.size());
+
+        std::vector<uint8_t> out;
+        out.push_back(0xAA);
+        out.push_back(0x55);
+        out.push_back(opcode);
+        out.insert(out.end(), payload.begin(), payload.end());
+        out.push_back(static_cast<uint8_t>((c >> 8) & 0xFF));
+        out.push_back(static_cast<uint8_t>(c & 0xFF));
+        return out;
+    }
+
+    /// HELLO payload: source mac[6] + deviceType[1] + headMac[6] + confirmed[1].
+    std::vector<uint8_t> helloPayload(uint8_t firstMacByte = 0x10) {
+        std::vector<uint8_t> p = {firstMacByte, 0x20, 0x30, 0x40, 0x50, 0x60,  // source
+                                  0x01,                                        // deviceType
+                                  0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,          // headMac
+                                  0x00};                                       // confirmed
+        EXPECT_EQ(p.size(), HELLO_PAYLOAD_LEN);
+        return p;
+    }
+
+    /// Feeds the whole byte vector to the parser in one burst.
+    void feed(const std::vector<uint8_t>& bytes) {
+        parser.feed(bytes.data(), bytes.size());
+    }
+
+    SerialFrameParser parser;
+    FakePlatformClock* fakeClock = nullptr;
+};
+
+TEST_F(SerialFrameParserTests, validBinaryFrameRoutesToFrameHandler) {
+    int frameCount = 0;
+    Frame got;
+    parser.setBinaryFrameHandler([&](const Frame& f) { got = f; ++frameCount; });
+
+    std::vector<uint8_t> frame = buildFrame(OP_HELLO, helloPayload());
+    feed(frame);
+
+    ASSERT_EQ(frameCount, 1);
+    EXPECT_EQ(got.opcode, OP_HELLO);
+    ASSERT_EQ(got.payload.size(), HELLO_PAYLOAD_LEN);
+    EXPECT_EQ(got.payload[0], 0x10);
+    EXPECT_EQ(got.payload[13], 0x00);
+}
+
+TEST_F(SerialFrameParserTests, encodeFramedRoundTripsThroughParser) {
+    // The encoder is the parser's inverse: a frame produced by encodeFramed
+    // must parse back to the identical opcode + payload.
+    int frameCount = 0;
+    Frame got;
+    parser.setBinaryFrameHandler([&](const Frame& f) { got = f; ++frameCount; });
+
+    std::vector<uint8_t> payload = helloPayload(0xA7);
+    std::vector<uint8_t> frame = encodeFramed(OP_HELLO, payload);
+    feed(frame);
+
+    ASSERT_EQ(frameCount, 1);
+    EXPECT_EQ(got.opcode, OP_HELLO);
+    EXPECT_EQ(got.payload, payload);
+}
+
+TEST_F(SerialFrameParserTests, badCrcDropsFrame) {
+    int frameCount = 0;
+    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+
+    // Full-length frame so the parser consumes everything and actually reaches
+    // the CRC comparison. A short payload would end mid-CRC-read and drop the
+    // frame regardless of whether CRC checking works, making this a vacuous
+    // test of the rejection path.
+    std::vector<uint8_t> frame = buildFrame(OP_HELLO, helloPayload());
+    frame[frame.size() - 2] ^= 0xFF;
+    frame[frame.size() - 1] ^= 0xFF;
+    feed(frame);
+
+    EXPECT_EQ(frameCount, 0);
+
+    // The parser must have resynced, not swallowed the next frame: a valid frame
+    // immediately after the bad one still parses.
+    feed(buildFrame(OP_HELLO, helloPayload()));
+    EXPECT_EQ(frameCount, 1);
+}
+
+TEST_F(SerialFrameParserTests, unknownOpcodeDrops) {
+    int frameCount = 0;
+    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+
+    // 0x99 is not an opcode; neither is 0x01 (the fork's BEACON, not ported).
+    feed({0xAA, 0x55, 0x99, 0x01, 0x02, 0x03, 0x04});
+    feed({0xAA, 0x55, 0x01, 0x01, 0x02, 0x03, 0x04});
+    EXPECT_EQ(frameCount, 0);
+
+    // After resync, a valid frame should still parse cleanly.
+    feed(buildFrame(OP_HELLO, helloPayload()));
+    EXPECT_EQ(frameCount, 1);
+}
+
+TEST_F(SerialFrameParserTests, fragmentedFrameAssembles) {
+    int frameCount = 0;
+    Frame got;
+    parser.setBinaryFrameHandler([&](const Frame& f) { got = f; ++frameCount; });
+
+    std::vector<uint8_t> frame = buildFrame(OP_HELLO, helloPayload(0x01));
+    for (uint8_t b : frame) {
+        uint8_t single = b;
+        parser.feed(&single, 1);
+    }
+
+    ASSERT_EQ(frameCount, 1);
+    EXPECT_EQ(got.opcode, OP_HELLO);
+    ASSERT_EQ(got.payload.size(), HELLO_PAYLOAD_LEN);
+    EXPECT_EQ(got.payload[0], 0x01);
+    EXPECT_EQ(got.payload[5], 0x60);
+}
+
+TEST_F(SerialFrameParserTests, midFrameTimeoutResets) {
+    int frameCount = 0;
+    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+
+    // Inject just the preamble + opcode + partial payload, then stall.
+    feed({0xAA, 0x55, OP_HELLO, 0xDE, 0xAD, 0xBE});
+    EXPECT_EQ(frameCount, 0);
+
+    // Advance the clock past the 50ms timeout. The parser checks the mid-frame
+    // timeout at the start of the next feed(), so the partial frame is cleared
+    // before the fresh frame below is consumed.
+    fakeClock->advance(60);
+
+    feed(buildFrame(OP_HELLO, helloPayload()));
+    EXPECT_EQ(frameCount, 1);
+}
+
+TEST_F(SerialFrameParserTests, requestResetClearsPartialFrameAtNextFeed) {
+    // The cross-thread reset used when a jack is declared dead: mid-frame state
+    // from the dying connection must not corrupt the next device to plug in.
+    int frameCount = 0;
+    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+
+    // Partial frame in flight, then a reset requested from "another thread".
+    feed({0xAA, 0x55, OP_HELLO, 0x01, 0x02, 0x03});
+    parser.requestReset();
+
+    // Without the reset these bytes would land mid-payload of the stale frame;
+    // with it, the fresh frame parses cleanly at the next feed.
+    feed(buildFrame(OP_HELLO, helloPayload()));
+    EXPECT_EQ(frameCount, 1);
+}
+
+TEST_F(SerialFrameParserTests, garbageThenValidFrameResyncs) {
+    int frameCount = 0;
+    Frame got;
+    parser.setBinaryFrameHandler([&](const Frame& f) { got = f; ++frameCount; });
+
+    // Leading line noise with no preamble must be discarded, and the parser must
+    // resync on the next 0xAA 0x55 rather than swallowing the following frame.
+    feed({0x12, 0x34, 0xFF, 0x00, 0x55});
+    feed(buildFrame(OP_HELLO, helloPayload(0xA1)));
+
+    ASSERT_EQ(frameCount, 1);
+    EXPECT_EQ(got.opcode, OP_HELLO);
+    EXPECT_EQ(got.payload[0], 0xA1);
+}
+
+TEST_F(SerialFrameParserTests, doubleAAResyncsToPreamble) {
+    int frameCount = 0;
+    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+
+    // A stray extra 0xAA before the real preamble: GotAA on another 0xAA must
+    // stay in GotAA so 0xAA 0xAA 0x55 still opens a frame rather than aborting.
+    std::vector<uint8_t> valid = buildFrame(OP_HELLO, helloPayload());
+    std::vector<uint8_t> withExtraAA;
+    withExtraAA.push_back(0xAA);
+    withExtraAA.insert(withExtraAA.end(), valid.begin(), valid.end());
+    feed(withExtraAA);
+
+    EXPECT_EQ(frameCount, 1);
+}
+
+TEST_F(SerialFrameParserTests, splitPreambleAcrossFeeds) {
+    int frameCount = 0;
+    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+
+    // The 0xAA and 0x55 of the preamble arrive in separate feed() calls; the
+    // GotAA state must survive across reads.
+    std::vector<uint8_t> valid = buildFrame(OP_HELLO, helloPayload());
+    feed({valid[0]});                                              // 0xAA
+    feed(std::vector<uint8_t>(valid.begin() + 1, valid.end()));    // 0x55 + body
+
+    EXPECT_EQ(frameCount, 1);
+}

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -20,6 +20,7 @@
 #include "chain-duel-multi-device-fixture.hpp"
 #include "shootout-manager-tests.hpp"
 #include "match-manager-concurrent.hpp"
+#include "serial-frame-parser-tests.hpp"
 
 #if defined(ARDUINO)
 #include <Arduino.h>


### PR DESCRIPTION
Ports `SerialFrameParser` (+ `crc16.hpp`, verbatim) from `tire-fire/reliable-duel-delivery` and extracts `encodeFramed` out of the fork's BEACON codec into the parser's own files. Scope is #149; independent of the transport PRs (#175).

**Deviations from "port cleanly" — worth reviewing hardest:**

- **HELLO is the sole opcode.** The fork's BEACON opcode and `peer-graph-codec` are not ported (rejected design). The opcode table collapses to `kOpHello`, and anything else — including the fork's old `0x01` BEACON — drops and resyncs (tested).
- **Framing constants re-homed.** Preamble bytes, `kOpHello`, and the HELLO payload length lived in the codec header; they now live with the parser, which is the other half of the same wire contract.
- **`kHelloPayloadLen = 14`** — the redesigned HELLO (source[6] + deviceType[1] + headMac[6] + confirmed[1]), not the fork's 9-byte userId variant. The packed `HelloPayload` struct itself is #153's scope; the parser only needs the length to frame it. If #153 changes the field set, this constant moves with it.
- **Two tests the fork didn't have:** an `encodeFramed`→parser round-trip (encoder and parser are cross-checked against an independent hand-built frame), and a `requestReset()` test — the cross-thread reset is required by #161's edge-case guards and was previously untested.

**Fragile spots:** the mid-frame timeout clamp in `checkTimeout()` (backwards-clock underflow guard — mirrors the same guard pattern the RDC rewrite specifies) and the GotAA-stays-on-0xAA resync subtlety in `feed()`.

Verification: 273/273 native tests (10 parser tests: framing, CRC rejection with resync, unknown-opcode drop incl. old BEACON, fragmentation, mid-frame timeout, cross-thread reset, garbage resync, double-preamble, split-preamble).
