### PR TITLE
transport: DirectPeerTable with ESP-NOW slot lifecycle (#150)

### DIFF
--- a/lib/core/include/wireless/direct-peer-table.hpp
+++ b/lib/core/include/wireless/direct-peer-table.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <optional>
+
+#include "device/drivers/serial-wrapper.hpp"
+#include "device/device-type.hpp"
+
+class WirelessManager;
+
+struct DirectPeer {
+    std::array<uint8_t, 6> macAddr;
+    SerialIdentifier sid;
+    DeviceType deviceType;
+    uint16_t userId = 0xFFFF;  // 4-digit player code; 0xFFFF = not yet registered
+};
+
+// Tracks the direct cable peer on each jack and owns the ESP-NOW peer slot
+// lifecycle for them: a peer's slot is registered when it first appears on
+// either jack and released only when its MAC is absent from BOTH jacks — a
+// two-device ring has the same MAC on both jacks, and releasing the slot on a
+// one-cable disconnect would silently break wireless for the still-connected
+// device. The 20-slot ESP-NOW table is finite; leaking one entry per neighbor
+// that silent-dies over a multi-hour event eventually rejects new peers.
+class DirectPeerTable {
+public:
+    /// Inert until initialize() provides the radio.
+    DirectPeerTable();
+    /// Nulls the injected radio pointer; the table owns nothing.
+    ~DirectPeerTable();
+
+    /// Injects the radio used for ESP-NOW slot registration; nullptr in unit
+    /// tests disables slot management and the self-MAC check.
+    void initialize(WirelessManager* wirelessManager);
+
+    /// Fired on a direct-peer presence transition on a jack: previous=nullopt on
+    /// connect, current=nullopt on disconnect. macPeers is already mutated when
+    /// this runs (slot written on connect, erased on disconnect), so a handler
+    /// re-querying getMacPeer observes the post-transition state. macPeers is the
+    /// single source of truth for these edges; the RDC reacts rather than polling.
+    using PeerChangeCallback =
+        std::function<void(SerialIdentifier jack,
+                           std::optional<DirectPeer> previous,
+                           std::optional<DirectPeer> current)>;
+
+    /// Registers the transition observer (see PeerChangeCallback).
+    void setPeerChangeCallback(PeerChangeCallback cb) {
+        peerChangeCallback = std::move(cb);
+    }
+
+    /// Registers a direct peer on a jack and its ESP-NOW slot (skipped when the
+    /// same MAC is already live on the other jack). Returns false if the peer's
+    /// MAC equals our own (self-loopback or spoofing); the peer is not stored
+    /// and the caller must not adopt it. Fires the PeerChangeCallback as a
+    /// connect only when the jack was previously empty; replacing a live jack's
+    /// peer (an A->B swap with no intervening drop) surfaces as
+    /// disconnect-then-connect.
+    bool setMacPeer(SerialIdentifier jack, DirectPeer peer);
+
+    /// Clears a jack's peer, fires the disconnect transition, and releases the
+    /// ESP-NOW slot unless the same MAC is still live on the other jack.
+    void removeMacPeer(SerialIdentifier jack);
+
+    /// The peer on a jack, or nullptr when the jack is empty.
+    const DirectPeer* getMacPeer(SerialIdentifier jack) const;
+
+    /// True when this MAC is the live peer on either jack.
+    bool isDirectPeer(const uint8_t* macAddress) const;
+
+private:
+    // Releases the ESP-NOW peer slot unless the MAC is still live on the
+    // other jack (two-device ring shares one MAC on both jacks).
+    void releaseSlotIfUnused(const uint8_t* macAddress);
+
+    WirelessManager* wirelessManager = nullptr;
+
+    std::map<SerialIdentifier, DirectPeer> macPeers;
+    PeerChangeCallback peerChangeCallback;
+};

--- a/lib/core/src/wireless/direct-peer-table.cpp
+++ b/lib/core/src/wireless/direct-peer-table.cpp
@@ -1,0 +1,99 @@
+#include "wireless/direct-peer-table.hpp"
+
+#include <cstring>
+
+#include "device/drivers/logger.hpp"
+#include "device/wireless-manager.hpp"
+#include "wireless/mac-functions.hpp"
+
+namespace {
+constexpr const char* DPT_TAG = "DPT";
+}
+
+DirectPeerTable::DirectPeerTable() {}
+
+DirectPeerTable::~DirectPeerTable() {
+    wirelessManager = nullptr;
+}
+
+void DirectPeerTable::initialize(WirelessManager* wirelessManager) {
+    this->wirelessManager = wirelessManager;
+}
+
+bool DirectPeerTable::setMacPeer(SerialIdentifier jack, DirectPeer peer) {
+    // Reject self-MAC: a peer claiming our own MAC (self-loopback or a neighbor
+    // spoofing it) must never register as a direct peer; violates spec
+    // invariant DirectPeerIsNeverSelf.
+    if (wirelessManager != nullptr) {
+        const uint8_t* selfMac = wirelessManager->getMacAddress();
+        if (selfMac != nullptr && memcmp(peer.macAddr.data(), selfMac, 6) == 0) {
+            return false;
+        }
+    }
+    std::map<SerialIdentifier, DirectPeer>::iterator it = macPeers.find(jack);
+    const bool wasEmpty = (it == macPeers.end());
+    const bool changed = (wasEmpty || it->second.macAddr != peer.macAddr);
+    if (changed) {
+        LOG_W(DPT_TAG, "setMacPeer jack=%c mac=%s sid=%d type=%d",
+              jack == SerialIdentifier::INPUT_JACK ? 'I' : 'O',
+              MacToString(peer.macAddr.data()),
+              (int)peer.sid, (int)peer.deviceType);
+    }
+    // A different MAC on an occupied jack is a swap (old peer left, new one
+    // plugged in within the silent-link window): surface it as
+    // disconnect-then-connect so subscribers never see the dying entry, and
+    // release the old peer's ESP-NOW slot exactly as a real disconnect would.
+    if (changed && !wasEmpty) {
+        DirectPeer previous = it->second;
+        macPeers.erase(it);
+        if (peerChangeCallback) {
+            peerChangeCallback(jack, previous, std::nullopt);
+        }
+        releaseSlotIfUnused(previous.macAddr.data());
+    }
+    // Register the ESP-NOW slot before storing: isDirectPeer still reflects the
+    // pre-connect state here, so a MAC already live on the other jack (the
+    // two-device ring) is not double-registered.
+    if (changed && wirelessManager != nullptr && !isDirectPeer(peer.macAddr.data())) {
+        wirelessManager->addEspNowPeer(peer.macAddr.data());
+    }
+    macPeers[jack] = peer;
+    if (changed && peerChangeCallback) {
+        peerChangeCallback(jack, std::nullopt, peer);
+    }
+    return true;
+}
+
+void DirectPeerTable::removeMacPeer(SerialIdentifier jack) {
+    std::map<SerialIdentifier, DirectPeer>::iterator it = macPeers.find(jack);
+    if (it == macPeers.end()) return;
+    DirectPeer previous = it->second;
+    macPeers.erase(it);
+    if (peerChangeCallback) {
+        peerChangeCallback(jack, previous, std::nullopt);
+    }
+    releaseSlotIfUnused(previous.macAddr.data());
+}
+
+const DirectPeer* DirectPeerTable::getMacPeer(SerialIdentifier jack) const {
+    std::map<SerialIdentifier, DirectPeer>::const_iterator it = macPeers.find(jack);
+    if (it == macPeers.end()) return nullptr;
+    return &it->second;
+}
+
+bool DirectPeerTable::isDirectPeer(const uint8_t* macAddress) const {
+    if (macAddress == nullptr) return false;
+    for (const std::pair<const SerialIdentifier, DirectPeer>& entry : macPeers) {
+        if (memcmp(entry.second.macAddr.data(), macAddress, 6) == 0) return true;
+    }
+    return false;
+}
+
+void DirectPeerTable::releaseSlotIfUnused(const uint8_t* macAddress) {
+    // Only release the ESP-NOW slot when the MAC is gone from BOTH jacks: a
+    // two-device ring carries the same neighbor on both, and dropping one
+    // cable must not break the radio path the other still uses.
+    if (wirelessManager == nullptr) return;
+    if (isDirectPeer(macAddress)) return;
+    wirelessManager->removeEspNowPeer(macAddress);
+}

--- a/test/test_core/direct-peer-table-tests.hpp
+++ b/test/test_core/direct-peer-table-tests.hpp
@@ -1,0 +1,176 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "device-mock.hpp"
+#include "wireless/direct-peer-table.hpp"
+
+#include <optional>
+#include <vector>
+
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+/// A DirectPeer with the given MAC, PDN device type, and jack id.
+inline DirectPeer makeDirectPeer(const uint8_t* mac, SerialIdentifier sid) {
+    DirectPeer p;
+    std::copy(mac, mac + 6, p.macAddr.begin());
+    p.sid = sid;
+    p.deviceType = DeviceType::PDN;
+    return p;
+}
+
+class DirectPeerTableTests : public testing::Test {
+public:
+    /// Wires the table to a WirelessManager over mocked radio comms.
+    void SetUp() override {
+        ON_CALL(peerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+        wirelessManager = new WirelessManager(&peerComms, &httpClient);
+        table.initialize(wirelessManager);
+    }
+
+    /// Releases the manager; the table holds no owned resources.
+    void TearDown() override {
+        delete wirelessManager;
+        wirelessManager = nullptr;
+    }
+
+    NiceMock<MockPeerComms> peerComms;
+    MockHttpClient httpClient;
+    WirelessManager* wirelessManager = nullptr;
+    DirectPeerTable table;
+};
+
+TEST_F(DirectPeerTableTests, getMacPeerReturnsNullWhenNotSet) {
+    EXPECT_EQ(table.getMacPeer(SerialIdentifier::OUTPUT_JACK), nullptr);
+    EXPECT_EQ(table.getMacPeer(SerialIdentifier::INPUT_JACK), nullptr);
+}
+
+TEST_F(DirectPeerTableTests, getMacPeerReturnsCorrectMac) {
+    uint8_t mac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    table.setMacPeer(SerialIdentifier::OUTPUT_JACK, makeDirectPeer(mac, SerialIdentifier::OUTPUT_JACK));
+
+    const DirectPeer* result = table.getMacPeer(SerialIdentifier::OUTPUT_JACK);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result->macAddr[0], 0x11);
+    EXPECT_EQ(result->macAddr[5], 0x66);
+
+    EXPECT_EQ(table.getMacPeer(SerialIdentifier::INPUT_JACK), nullptr);
+}
+
+TEST_F(DirectPeerTableTests, removeMacPeerClearsEntry) {
+    uint8_t mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    table.setMacPeer(SerialIdentifier::INPUT_JACK, makeDirectPeer(mac, SerialIdentifier::INPUT_JACK));
+    ASSERT_NE(table.getMacPeer(SerialIdentifier::INPUT_JACK), nullptr);
+
+    table.removeMacPeer(SerialIdentifier::INPUT_JACK);
+    EXPECT_EQ(table.getMacPeer(SerialIdentifier::INPUT_JACK), nullptr);
+}
+
+TEST_F(DirectPeerTableTests, setMacPeerRegistersEspNowSlot) {
+    uint8_t mac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+    EXPECT_CALL(peerComms, addEspNowPeer(_)).Times(1);
+    table.setMacPeer(SerialIdentifier::INPUT_JACK, makeDirectPeer(mac, SerialIdentifier::INPUT_JACK));
+}
+
+TEST_F(DirectPeerTableTests, sameMacOnSecondJackDoesNotReRegister) {
+    // A two-device ring presents one neighbor MAC on both jacks; the second
+    // jack's connect must not register the ESP-NOW slot twice.
+    uint8_t mac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+    EXPECT_CALL(peerComms, addEspNowPeer(_)).Times(1);
+    table.setMacPeer(SerialIdentifier::INPUT_JACK, makeDirectPeer(mac, SerialIdentifier::INPUT_JACK));
+    table.setMacPeer(SerialIdentifier::OUTPUT_JACK, makeDirectPeer(mac, SerialIdentifier::OUTPUT_JACK));
+}
+
+TEST_F(DirectPeerTableTests, removeReleasesSlotWhenMacAbsentElsewhere) {
+    uint8_t mac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+    table.setMacPeer(SerialIdentifier::INPUT_JACK, makeDirectPeer(mac, SerialIdentifier::INPUT_JACK));
+
+    EXPECT_CALL(peerComms, removeEspNowPeer(_)).Times(1);
+    table.removeMacPeer(SerialIdentifier::INPUT_JACK);
+}
+
+TEST_F(DirectPeerTableTests, twoDeviceRingKeepsSlotUntilBothJacksClear) {
+    // The dereg guard: same MAC on both jacks (two-device ring). Dropping one
+    // cable must NOT release the ESP-NOW slot the other jack still uses;
+    // dropping the second releases it exactly once.
+    uint8_t mac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+    table.setMacPeer(SerialIdentifier::INPUT_JACK, makeDirectPeer(mac, SerialIdentifier::INPUT_JACK));
+    table.setMacPeer(SerialIdentifier::OUTPUT_JACK, makeDirectPeer(mac, SerialIdentifier::OUTPUT_JACK));
+
+    EXPECT_CALL(peerComms, removeEspNowPeer(_)).Times(0);
+    table.removeMacPeer(SerialIdentifier::INPUT_JACK);
+    ::testing::Mock::VerifyAndClearExpectations(&peerComms);
+
+    EXPECT_CALL(peerComms, removeEspNowPeer(_)).Times(1);
+    table.removeMacPeer(SerialIdentifier::OUTPUT_JACK);
+}
+
+TEST_F(DirectPeerTableTests, selfMacIsRejected) {
+    // Self-loopback (TRS echo) or a spoofed neighbor claiming our MAC must not
+    // become a direct peer.
+    static uint8_t selfMac[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01};
+    ON_CALL(peerComms, getMacAddress()).WillByDefault(Return(selfMac));
+
+    EXPECT_CALL(peerComms, addEspNowPeer(_)).Times(0);
+    EXPECT_FALSE(table.setMacPeer(SerialIdentifier::INPUT_JACK,
+                                  makeDirectPeer(selfMac, SerialIdentifier::INPUT_JACK)));
+    EXPECT_EQ(table.getMacPeer(SerialIdentifier::INPUT_JACK), nullptr);
+}
+
+TEST_F(DirectPeerTableTests, callbackFiresConnectAndDisconnectWithPostMutationState) {
+    uint8_t mac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+    int connects = 0;
+    int disconnects = 0;
+    table.setPeerChangeCallback(
+        [&](SerialIdentifier jack, std::optional<DirectPeer> previous,
+            std::optional<DirectPeer> current) {
+            if (current.has_value()) {
+                ++connects;
+                // macPeers is mutated before the callback: the entry is visible.
+                EXPECT_NE(table.getMacPeer(jack), nullptr);
+            } else {
+                ++disconnects;
+                EXPECT_EQ(previous->macAddr[0], 0x01);
+                // Post-transition state: the dying entry is already gone.
+                EXPECT_EQ(table.getMacPeer(jack), nullptr);
+            }
+        });
+
+    table.setMacPeer(SerialIdentifier::INPUT_JACK, makeDirectPeer(mac, SerialIdentifier::INPUT_JACK));
+    EXPECT_EQ(connects, 1);
+    EXPECT_EQ(disconnects, 0);
+
+    // Re-setting the same MAC on the same jack is not a transition.
+    table.setMacPeer(SerialIdentifier::INPUT_JACK, makeDirectPeer(mac, SerialIdentifier::INPUT_JACK));
+    EXPECT_EQ(connects, 1);
+
+    table.removeMacPeer(SerialIdentifier::INPUT_JACK);
+    EXPECT_EQ(disconnects, 1);
+}
+
+TEST_F(DirectPeerTableTests, swapSurfacesAsDisconnectThenConnect) {
+    // A different MAC on an occupied jack (old peer left, new one plugged in
+    // within the silent-link window) must fire disconnect(old) then
+    // connect(new), and swap the ESP-NOW slots accordingly.
+    uint8_t macA[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x0A};
+    uint8_t macB[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x0B};
+    std::vector<uint8_t> transitions;  // 0 = disconnect, 1 = connect
+    table.setMacPeer(SerialIdentifier::INPUT_JACK, makeDirectPeer(macA, SerialIdentifier::INPUT_JACK));
+    table.setPeerChangeCallback(
+        [&](SerialIdentifier, std::optional<DirectPeer> previous,
+            std::optional<DirectPeer> current) {
+            transitions.push_back(current.has_value() ? 1 : 0);
+            if (!current.has_value()) EXPECT_EQ(previous->macAddr[5], 0x0A);
+            if (current.has_value()) EXPECT_EQ(current->macAddr[5], 0x0B);
+        });
+
+    EXPECT_CALL(peerComms, removeEspNowPeer(_)).Times(1);  // macA released
+    EXPECT_CALL(peerComms, addEspNowPeer(_)).Times(1);     // macB registered
+    table.setMacPeer(SerialIdentifier::INPUT_JACK, makeDirectPeer(macB, SerialIdentifier::INPUT_JACK));
+
+    ASSERT_EQ(transitions.size(), 2u);
+    EXPECT_EQ(transitions[0], 0);
+    EXPECT_EQ(transitions[1], 1);
+}

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -22,6 +22,7 @@
 #include "match-manager-concurrent.hpp"
 #include "serial-frame-parser-tests.hpp"
 #include "reliable-channel-tests.hpp"
+#include "direct-peer-table-tests.hpp"
 
 #if defined(ARDUINO)
 #include <Arduino.h>
@@ -433,8 +434,6 @@ TEST_F(DeviceTestSuite, inactiveAppLoopCountUnchanged) {
     // Switch away
     device->setActiveApp(APP_TWO);
 
-
-    
     // Run loops on app two — app one should not receive any
     device->loop();
     device->loop();


### PR DESCRIPTION
Ports `DirectPeerTable` from `tire-fire/reliable-duel-delivery` for #150, with one deliberate scope move the issue text asks for: **the ESP-NOW slot lifecycle now lives inside the table** instead of the RDC caller. On the fork, the table only tracked peers and fired callbacks; the register/release logic (and the both-jacks guard) sat in `RemoteDeviceCoordinator::onPeerTableChange`. Moving it down means the guard is enforced wherever the table is used, not wherever a caller remembers to.

**The load-bearing behavior to review:**

- **Both-jacks dereg guard** (`releaseSlotIfUnused`): a slot is released only when the MAC is absent from *both* jacks. A two-device ring carries the same neighbor MAC on both jacks — releasing on a one-cable disconnect silently breaks the radio path the other jack still uses. Conversely, never releasing leaks one of 20 slots per silent-dying neighbor over a multi-hour event.
- **Double-registration guard**: a MAC already live on the other jack isn't re-registered (registration happens before the table stores the new entry, so `isDirectPeer` still reflects pre-connect state — that ordering is the subtle line).
- **Swap semantics preserved from the fork**: a different MAC on an occupied jack surfaces as disconnect(old)-then-connect(new), releases old slot and registers the new — subscribers never observe the dying entry.
- Self-MAC rejection (TRS loopback/spoof) is verbatim fork behavior.

Callback contract is unchanged: mutate-then-notify, previous/current optionals, no transition on same-MAC re-set.

Verification: 273/273 native tests, 10 new — including the two-device-ring keep-then-release sequence, the double-reg guard, swap ordering, and post-mutation state visibility inside callbacks. Style-conformant per the new guide from the first commit.
