### PR TITLE
esp-now: remove multi-packet clustering subsystem (#146)

### DIFF
--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -33,8 +33,6 @@ struct DataPktHdr
     //Total packet length including header
     uint8_t pktLen;
     PktType packetType;
-    uint8_t numPktsInCluster;
-    uint8_t idxInCluster;
 } __attribute__((packed));
 
 struct ChainConfirmPayload

--- a/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
+++ b/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <queue>
 #include <unordered_map>
+#include <limits>
 #include <Arduino.h>
 #include <WiFi.h>
 #include <esp_now.h>
@@ -23,7 +24,13 @@ constexpr uint8_t PEER_BROADCAST_ADDR[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 // Max application payload per frame. ESP-NOW v2.0 (IDF 5.x, all-S3 targets)
 // carries up to 1470 bytes in a single frame, so every packet type fits in
 // one send — no multi-frame clustering.
-constexpr size_t MAX_PKT_DATA_SIZE = ESP_NOW_MAX_DATA_LEN_V2 - sizeof(DataPktHdr);
+// The payload ceiling is whatever DataPktHdr::pktLen can hold (it stores the
+// total packet length), minus the header. ESP-NOW v2 frames are far larger,
+// but the length field is the real ceiling: a payload above this would overflow
+// pktLen and deliver a corrupt short buffer. Derived from the field's type so
+// it follows automatically if pktLen ever widens.
+constexpr size_t MAX_PKT_DATA_SIZE =
+    std::numeric_limits<decltype(DataPktHdr::pktLen)>::max() - sizeof(DataPktHdr);
 
 //Singleton class that handles communication over ESP-NOW protocol.
 class EspNowManager : public PeerCommsDriverInterface

--- a/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
+++ b/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
@@ -20,7 +20,10 @@
 //Use this mac address in order to reach all nearby devices
 constexpr uint8_t PEER_BROADCAST_ADDR[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
-constexpr size_t MAX_PKT_DATA_SIZE = ESP_NOW_MAX_DATA_LEN - sizeof(DataPktHdr);
+// Max application payload per frame. ESP-NOW v2.0 (IDF 5.x, all-S3 targets)
+// carries up to 1470 bytes in a single frame, so every packet type fits in
+// one send — no multi-frame clustering.
+constexpr size_t MAX_PKT_DATA_SIZE = ESP_NOW_MAX_DATA_LEN_V2 - sizeof(DataPktHdr);
 
 //Singleton class that handles communication over ESP-NOW protocol.
 class EspNowManager : public PeerCommsDriverInterface
@@ -147,77 +150,35 @@ public:
     // Queues up data for sending, may not send right away
     /// Queues data for sending; may not send right away.
     int sendData(const uint8_t* dst, PktType packetType, const uint8_t* data, const size_t length) override {
-        if(length > (255 * MAX_PKT_DATA_SIZE))
-        {
+        if (length > MAX_PKT_DATA_SIZE) {
             LOG_W("ENC", "ESP-NOW: Tried to send too large of buffer: %u of max %u\n",
-                length, 
-                255 * MAX_PKT_DATA_SIZE);
+                  length,
+                  MAX_PKT_DATA_SIZE);
             return -1;
         }
 
-        //Calculate the total number of ESP_NOW_MAX_DATA_LEN (250) byte packets we'll 
-        //need to send the whole buffer
-        uint8_t numInCluster = length / MAX_PKT_DATA_SIZE + 
-                               (length % MAX_PKT_DATA_SIZE == 0 ? 0 : 1);
-        
-        //Allocate entire send buffer up front so we don't fail an allocation part way through
-        //the cluster
-        //We'll use alloca for tracking the buffers while we set them up since this should
-        //require a very small amount of memory making the risk of stack overflow very small
-        //This will also be much faster than malloc/free which would be wasteful for such a
-        //small allocation
-        auto sendBuffers = static_cast<uint8_t**>(alloca(sizeof(uint8_t*) * numInCluster));
-        size_t bytesLeft = length;
-        for(int i = 0; i < numInCluster; ++i)
-        {
-            size_t thisBuffer = std::min(bytesLeft, MAX_PKT_DATA_SIZE);
-            sendBuffers[i] = (uint8_t*)ps_malloc(sizeof(DataPktHdr) + thisBuffer);
-            if(!sendBuffers[i])
-            {
-                //free anything we already allocated
-                for(int j = 0; j < i; ++j)
-                    free(sendBuffers[j]);
-
-                //TODO: Return better error code once we have them
-                LOG_E("ENC", "Failed to allocate buffers for ESP-NOW send queue");
-                LOG_E("ENC", "Needed to allocate a total of %lu bytes\n", length);
-                return -1;
-            }
-            bytesLeft -= thisBuffer;
+        // One frame carries the whole payload (ESP-NOW v2.0). Build header +
+        // data in a single buffer and queue it.
+        uint8_t* buf = (uint8_t*)ps_malloc(sizeof(DataPktHdr) + length);
+        if (!buf) {
+            LOG_E("ENC", "Failed to allocate %lu byte buffer for ESP-NOW send\n",
+                  sizeof(DataPktHdr) + length);
+            return -1;
         }
+
+        DataPktHdr* hdr = reinterpret_cast<DataPktHdr*>(buf);
+        hdr->pktLen = sizeof(DataPktHdr) + length;
+        hdr->packetType = packetType;
+        memcpy(buf + sizeof(DataPktHdr), data, length);
+
+        DataSendBuffer buffer;
+        memcpy(buffer.dstMac, dst, ESP_NOW_ETH_ALEN);
+        buffer.ptr = buf;
+        buffer.len = hdr->pktLen;
 
         xSemaphoreTake(sendMutex, portMAX_DELAY);
         bool willNeedToStartSend = sendQueue.empty();
-
-        //Build up each packet
-        bytesLeft = length;
-        for(int pktIdx = 0; pktIdx < numInCluster; ++pktIdx)
-        {
-            size_t thisBuffer = std::min(bytesLeft, MAX_PKT_DATA_SIZE);
-#if DEBUG_PRINT_ESP_NOW
-            ESP_LOGD("ENC", "ESPNOW SendData pktIdx: %i thisBuffer: %u\n", pktIdx, thisBuffer);
-#endif
-
-            //Each packet needs a header, build it directly in the send buffer
-            auto* hdr = reinterpret_cast<DataPktHdr*>(sendBuffers[pktIdx]);
-            hdr->idxInCluster = pktIdx;
-            hdr->numPktsInCluster = numInCluster;
-            hdr->pktLen = sizeof(DataPktHdr) + thisBuffer;
-            hdr->packetType = packetType;
-
-            //Copy the actual data into the send buffer following the header
-            size_t dataOffset = pktIdx * MAX_PKT_DATA_SIZE;
-            memcpy(sendBuffers[pktIdx] + sizeof(DataPktHdr), data + dataOffset, thisBuffer);
-
-            //Now add it to the send queue
-            DataSendBuffer buffer;
-            memcpy(buffer.dstMac, dst, ESP_NOW_ETH_ALEN);
-            buffer.ptr = sendBuffers[pktIdx];
-            buffer.len = hdr->pktLen;
-            sendQueue.push(buffer);
-
-            bytesLeft -= thisBuffer;
-        }
+        sendQueue.push(buffer);
         xSemaphoreGive(sendMutex);
 
         if(willNeedToStartSend)
@@ -300,13 +261,6 @@ private:
         size_t len;
     };
 
-    struct DataRecvBuffer
-    {
-        uint8_t* data;
-        unsigned long mostRecentRecvPktTime;
-        uint8_t expectedNextIdx;
-    };
-
     explicit EspNowManager(const std::string& name)
         : PeerCommsDriverInterface(name)
         , pktHandlerCallbacks((int)PktType::kNumPacketTypes, std::pair<PacketCallback, void*>(nullptr, nullptr))
@@ -385,96 +339,12 @@ private:
         ESP_LOGD("ENC", "Packet Type: %i\n", pktHdr->packetType);
 #endif
 
-        if(pktHdr->numPktsInCluster > 1) {
-            manager->handleMultiPacketCluster(esp_now_info->src_addr, data, pktHdr);
-        } else {
-            manager->handleSinglePacket(esp_now_info->src_addr, data, pktHdr);
-        }
+        manager->handleSinglePacket(esp_now_info->src_addr, data, pktHdr);
     }
 
     // Helper methods for packet reception
     void handleSinglePacket(const uint8_t* mac_addr, const uint8_t* data, const DataPktHdr* pktHdr) {
         HandlePktCallback(pktHdr->packetType, mac_addr, data + sizeof(DataPktHdr), pktHdr->pktLen - sizeof(DataPktHdr));
-    }
-
-    void handleMultiPacketCluster(const uint8_t* mac_addr, const uint8_t* data, const DataPktHdr* pktHdr) {
-        uint64_t macAddr64 = MacToUInt64(mac_addr);
-        
-        if(pktHdr->idxInCluster == 0) {
-            handleFirstPacketInCluster(macAddr64, pktHdr);
-        }
-        
-        handleSubsequentPacket(mac_addr, data, pktHdr, macAddr64);
-    }
-
-    void handleFirstPacketInCluster(uint64_t macAddr64, const DataPktHdr* pktHdr) {
-        // If there's an existing cluster for this mac address, release it
-        // as that means we lost a packet somewhere
-        auto existingBuffer = recvBuffers.find(macAddr64);
-        if (existingBuffer != recvBuffers.end()) {
-            free(existingBuffer->second.data);
-            recvBuffers.erase(existingBuffer);
-        }
-
-        DataRecvBuffer newBuffer;
-        newBuffer.data = (uint8_t*)ps_malloc(pktHdr->numPktsInCluster * MAX_PKT_DATA_SIZE);
-        newBuffer.expectedNextIdx = 1;
-        recvBuffers[macAddr64] = newBuffer;
-    }
-
-    void handleSubsequentPacket(const uint8_t* mac_addr, const uint8_t* data, const DataPktHdr* pktHdr, uint64_t macAddr64) {
-        auto existingBuffer = recvBuffers.find(macAddr64);
-
-        // If no buffer exists, we missed the start packet
-        if (existingBuffer == recvBuffers.end()) {
-            LOG_W("ENC", "No recv buffer for mid cluster pkt. We must have missed first pkt.");
-            return;
-        }
-
-        DataRecvBuffer& recvBuffer = existingBuffer->second;
-        
-        if(!validatePacketSequence(pktHdr, recvBuffer, existingBuffer)) {
-            return;
-        }
-
-        copyPacketData(data, pktHdr, recvBuffer);
-        ++existingBuffer->second.expectedNextIdx;
-        
-        if(isClusterComplete(existingBuffer->second, pktHdr)) {
-            finalizeCluster(mac_addr, pktHdr, recvBuffer, existingBuffer);
-        }
-    }
-
-    bool validatePacketSequence(const DataPktHdr* pktHdr, DataRecvBuffer& recvBuffer, 
-                                std::unordered_map<uint64_t, DataRecvBuffer>::iterator& existingBuffer) {
-        if(pktHdr->idxInCluster != recvBuffer.expectedNextIdx) {
-            LOG_W("ENC", "Received pkt %u when expecting %u. Must have missed a packet in cluster.\n",
-                  recvBuffer.expectedNextIdx, pktHdr->idxInCluster);
-            free(recvBuffer.data);
-            recvBuffers.erase(existingBuffer);
-            return false;
-        }
-        return true;
-    }
-
-    void copyPacketData(const uint8_t* data, const DataPktHdr* pktHdr, DataRecvBuffer& recvBuffer) {
-        size_t bufferOffset = pktHdr->idxInCluster * MAX_PKT_DATA_SIZE;
-        memcpy(recvBuffer.data + bufferOffset, data + sizeof(DataPktHdr), pktHdr->pktLen - sizeof(DataPktHdr));
-    }
-
-    bool isClusterComplete(const DataRecvBuffer& recvBuffer, const DataPktHdr* pktHdr) {
-        return recvBuffer.expectedNextIdx == pktHdr->numPktsInCluster;
-    }
-
-    void finalizeCluster(const uint8_t* mac_addr, const DataPktHdr* pktHdr, DataRecvBuffer& recvBuffer,
-                         std::unordered_map<uint64_t, DataRecvBuffer>::iterator& existingBuffer) {
-        size_t totalClusterSize = (pktHdr->numPktsInCluster - 1) * MAX_PKT_DATA_SIZE;
-        totalClusterSize += pktHdr->pktLen - sizeof(DataPktHdr);
-        
-        HandlePktCallback(pktHdr->packetType, mac_addr, recvBuffer.data, totalClusterSize);
-        
-        free(recvBuffer.data);
-        recvBuffers.erase(existingBuffer);
     }
 
     static void EspNowSendCallback(const esp_now_send_info_t *esp_now_info, esp_now_send_status_t status) {
@@ -516,9 +386,8 @@ private:
         DataSendBuffer buffer = sendQueue.front();
         xSemaphoreGive(sendMutex);
 
-        //If this is the first packet in cluster, make sure the peer is registered
-        DataPktHdr* hdr = reinterpret_cast<DataPktHdr*>(buffer.ptr);
-        if(hdr->idxInCluster == 0 && (memcmp(buffer.dstMac, PEER_BROADCAST_ADDR, ESP_NOW_ETH_ALEN) != 0))
+        // Make sure a unicast peer is registered before sending to it.
+        if (memcmp(buffer.dstMac, PEER_BROADCAST_ADDR, ESP_NOW_ETH_ALEN) != 0)
             EnsurePeerIsRegistered(buffer.dstMac);
 
         esp_err_t err;
@@ -674,9 +543,6 @@ private:
 
     //Packet send queue
     std::queue<DataSendBuffer> sendQueue;
-
-    //Receive buffer tracking for multi-packet clusters
-    std::unordered_map<uint64_t, DataRecvBuffer> recvBuffers;
 
     // Storage for rssi, filled from each ESP-NOW receive callback (rx_ctrl)
     std::unordered_map<uint64_t, int> rssiTracker;


### PR DESCRIPTION
Deletes the multi-packet clustering subsystem from the ESP-NOW driver (discussion #143, Finding 5). All targets are ESP32-S3 on IDF 5.5.4 with ESP-NOW v2.0 (1470-byte frames); every packet type — the largest being a head-transfer or full bracket, ~110 bytes — fits in a single frame, so the split/reassemble machinery was dead code.

**Stacked on #179 (#147)** — both edit the driver, and #146 rewrites the same `sendData`/recv paths #147 touched. Review/merge #147 first; this diff is clean on top of it.

**What goes:**
- `DataPktHdr` shrinks to `{pktLen, packetType}` (drops `numPktsInCluster`, `idxInCluster`) — the one edit outside the driver, in the shared `peer-comms-types.hpp`, but part of the same removal.
- `sendData` collapses from an alloca'd per-cluster loop to a single header+payload buffer.
- Deleted the whole receive-side reassembly: `handleMultiPacketCluster`, `handleFirstPacketInCluster`, `handleSubsequentPacket`, `validatePacketSequence`, `copyPacketData`, `isClusterComplete`, `finalizeCluster`, plus `DataRecvBuffer` and the `recvBuffers` map. The recv callback now dispatches straight to `handleSinglePacket`.
- `MAX_PKT_DATA_SIZE` rebased on `ESP_NOW_MAX_DATA_LEN_V2` (1470) instead of the v1.0 250.
- The `SendFrontPkt` "first packet in cluster" peer-registration guard becomes a plain unicast check (there are no clusters).

**Scope guard:** the send-size limit is now one frame (`MAX_PKT_DATA_SIZE`) rather than `255 * MAX_PKT_DATA_SIZE`. Any caller trying to send >1470−2 bytes gets a rejection instead of silent fragmentation — intended; the payload survey in #143 shows nothing comes close.

Net −136 lines. Verification: esp32-s3 release firmware compiles; 277/277 native tests (native driver has no `DataPktHdr`/cluster coupling, confirmed).
