### PR TITLE
tooling: bring in compiledb / flash-and-monitor / clangd scripts (#174)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ callgrind*
 
 .VSCodeCounter/
 .clangd/
+
+# Python bytecode cache
+__pycache__/
+*.pyc

--- a/platformio.ini
+++ b/platformio.ini
@@ -42,7 +42,9 @@ lib_deps =
 ; Usage: pio run -e <env> -t multi_flash
 ; See scripts/multi_flash_target.py and scripts/flash_multi.py for details.
 ; Pass --erase at runtime via: $env:MULTI_FLASH_ARGS="--erase"; pio run -e <env> -t multi_flash
-extra_scripts = scripts/multi_flash_target.py
+extra_scripts =
+    scripts/multi_flash_target.py
+    scripts/auto_compiledb.py
 custom_multi_flash_args =
 
 ; Debug build
@@ -105,7 +107,9 @@ lib_deps =
     ArduinoJson@^7.4.2
     WiFi
 
-extra_scripts = scripts/multi_flash_target.py
+extra_scripts =
+    scripts/multi_flash_target.py
+    scripts/auto_compiledb.py
 custom_multi_flash_args =
 
 ; FDN debug build
@@ -146,6 +150,7 @@ build_type = test
 test_framework = googletest
 test_build_src = yes
 test_filter = test_core
+extra_scripts = scripts/auto_compiledb.py
 
 build_flags =
     -std=c++17
@@ -272,6 +277,7 @@ build_unflags = -Werror
 [env:native_cli]
 platform = native
 build_type = release
+extra_scripts = scripts/auto_compiledb.py
 
 build_flags =
     -std=c++17
@@ -304,6 +310,7 @@ build_type = test
 test_framework = googletest
 test_build_src = yes
 test_filter = test_cli
+extra_scripts = scripts/auto_compiledb.py
 
 build_flags =
     -std=c++17

--- a/scripts/auto_compiledb.py
+++ b/scripts/auto_compiledb.py
@@ -1,0 +1,59 @@
+# PlatformIO extra_script: keeps compile_commands.json fresh for clangd.
+#
+# Why: PlatformIO only writes compile_commands.json when you pass -t compiledb,
+# so on every normal `pio run` / `pio test` the file goes stale relative to
+# files added or renamed since the last manual refresh. Clangd then reports
+# diagnostics against a phantom snapshot of the tree.
+#
+# What it does:
+#   - For env:native_cli: registers the SCons CompilationDatabase builder as a
+#     default target, so every native_cli build refreshes
+#     $PROJECT_DIR/compile_commands.json inline (~0.5s overhead). This env is
+#     the canonical indexing source because it includes cli-main.cpp and the
+#     cli/* sources that other native envs exclude.
+#   - For every other env (esp32, native_cli_test, native, native_perf, etc):
+#     spawns `pio run -e native_cli -t compiledb` in the background at script
+#     LOAD time (not as a post-build action). This way the refresh fires even
+#     on no-op `pio test` invocations where SCons doesn't rebuild anything;
+#     AddPostAction is tied to target rebuilds and would silently skip those.
+#     Xtensa flags and headers aren't useful to clangd on a Linux dev machine,
+#     so we never let ESP32 entries reach the root file.
+
+Import("env")  # noqa: F821  (PlatformIO injects this)
+
+import subprocess
+import sys
+
+
+_CANONICAL_ENV = "native_cli"
+
+
+def _register_inline_compiledb(env):
+    env.Tool("compilation_db")
+    cdb = env.CompilationDatabase("$PROJECT_DIR/compile_commands.json")
+    env.AlwaysBuild(cdb)
+    env.Default(cdb)
+
+
+def _spawn_canonical_refresh(env):
+    project_dir = env.subst("$PROJECT_DIR")
+    cmd = [sys.executable, "-m", "platformio", "run",
+           "-e", _CANONICAL_ENV, "-t", "compiledb", "-s"]
+    try:
+        subprocess.Popen(
+            cmd,
+            cwd=project_dir,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError:
+        pass
+
+
+env_name = env.subst("$PIOENV")
+
+if env_name == _CANONICAL_ENV:
+    _register_inline_compiledb(env)
+else:
+    _spawn_canonical_refresh(env)

--- a/scripts/flash_and_monitor.py
+++ b/scripts/flash_and_monitor.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+Flash all connected ESP32-S3 devices with the release_verbose firmware, then
+stream serial logs from all of them concurrently to per-device files in
+/tmp/pdn-logs/devN.log.
+
+Usage:
+  scripts/flash_and_monitor.py            # flash + monitor indefinitely
+  scripts/flash_and_monitor.py --duration 60   # monitor 60s then exit
+  scripts/flash_and_monitor.py --no-flash      # skip flashing, just monitor
+  scripts/flash_and_monitor.py --env esp32-s3_pdn_debug   # different env
+  scripts/flash_and_monitor.py --tail-grep "JACKDEAD|HELLO"   # only print matching lines
+
+Defaults to the esp32-s3_pdn_release_verbose pio environment. Devices are
+discovered as /dev/ttyACM* ports. Flash is sequential (pio holds a lock per
+build dir, and the upload tool's --upload-port goes one at a time anyway).
+Monitor runs reading-side, one thread per port, via pyserial. Lines are
+prefixed with [devN] and time-of-host so concurrent streams are
+interleaved-friendly.
+
+Stop with Ctrl-C; pending writes are flushed.
+"""
+
+import argparse
+import glob
+import os
+import re
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+PIO_ENV_DEFAULT = "esp32-s3_pdn_release_verbose"
+PIO_BIN = "/usr/bin/pio"
+PYSERIAL_PYTHON = "/home/tirefire/.platformio/penv/bin/python"
+LOG_DIR = "/tmp/pdn-logs"
+
+_print_lock = threading.Lock()
+_stop = threading.Event()
+
+
+def emit(prefix, line):
+    with _print_lock:
+        sys.stdout.write(f"[{prefix}] {line}\n")
+        sys.stdout.flush()
+
+
+def discover_ports():
+    ports = sorted(glob.glob("/dev/ttyACM*"))
+    return ports
+
+
+def build_firmware(env):
+    emit("BUILD", f"pio run -e {env}")
+    r = subprocess.run([PIO_BIN, "run", "-e", env],
+                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                       text=True)
+    if r.returncode != 0:
+        sys.stderr.write(r.stdout)
+        emit("BUILD", "FAILED")
+        sys.exit(r.returncode)
+    last = [l for l in r.stdout.splitlines() if "SUCCESS" in l or "FAILED" in l]
+    for l in last[-3:]:
+        emit("BUILD", l.strip())
+
+
+def flash_one(env, port):
+    emit("FLASH", f"{port} starting")
+    r = subprocess.run(
+        [PIO_BIN, "run", "-e", env, "-t", "upload", "--upload-port", port],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    last_line = ""
+    for l in r.stdout.splitlines():
+        if "SUCCESS" in l or "FAILED" in l:
+            last_line = l.strip()
+    emit("FLASH", f"{port} {last_line or ('rc=' + str(r.returncode))}")
+    return r.returncode == 0
+
+
+def flash_all(env, ports):
+    # multi_flash flashes all devices concurrently (~30s vs ~2min sequential);
+    # it can fail on an older pio target or esptool missing from its python.
+    emit("FLASH", f"multi_flash all ({len(ports)} devices)")
+    r = subprocess.run(
+        [PIO_BIN, "run", "-e", env, "-t", "multi_flash"],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    success_line = ""
+    for l in r.stdout.splitlines():
+        if "succeeded" in l.lower() or "SUCCESS" in l:
+            success_line = l.strip()
+    if r.returncode == 0:
+        emit("FLASH", f"multi_flash OK: {success_line}")
+        return True
+    emit("FLASH", "multi_flash failed, falling back to sequential")
+    sys.stderr.write(r.stdout)
+    ok = True
+    for p in ports:
+        if not flash_one(env, p):
+            ok = False
+    return ok
+
+
+def reader_thread(port, idx, duration, tail_filter):
+    # pyserial lives in the platformio venv; import inside the thread so the
+    # script itself doesn't need pyserial on system Python.
+    sys.path.insert(0, "/home/tirefire/.platformio/penv/lib/python3.13/site-packages")
+    sys.path.insert(0, "/home/tirefire/.platformio/penv/lib/python3.12/site-packages")
+    sys.path.insert(0, "/home/tirefire/.platformio/penv/lib/python3.11/site-packages")
+    try:
+        import serial  # noqa: E402
+    except ImportError:
+        run_reader_subprocess(port, idx, duration, tail_filter)
+        return
+
+    try:
+        s = serial.Serial(port, 115200, timeout=1)
+    except Exception as e:
+        emit(f"dev{idx}", f"OPEN FAILED: {e}")
+        return
+
+    os.makedirs(LOG_DIR, exist_ok=True)
+    log_path = f"{LOG_DIR}/dev{idx}.log"
+    f = open(log_path, "wb")
+    emit(f"dev{idx}", f"streaming {port} -> {log_path}")
+
+    end_at = (time.time() + duration) if duration else None
+    pat = re.compile(tail_filter) if tail_filter else None
+    line_buf = b""
+    try:
+        while not _stop.is_set():
+            if end_at and time.time() >= end_at:
+                break
+            data = s.read(4096)
+            if not data:
+                continue
+            f.write(data)
+            f.flush()
+            line_buf += data
+            # Emit per newline so prints stay readable.
+            while b"\n" in line_buf:
+                line, line_buf = line_buf.split(b"\n", 1)
+                text = line.decode("utf-8", errors="replace").rstrip()
+                if not text:
+                    continue
+                if pat and not pat.search(text):
+                    continue
+                emit(f"dev{idx}", text)
+    finally:
+        f.close()
+        try:
+            s.close()
+        except Exception:
+            pass
+
+
+def run_reader_subprocess(port, idx, duration, tail_filter):
+    # Spawn the platformio venv python so pyserial is available.
+    code = (
+        "import sys, time, re, serial\n"
+        f"s = serial.Serial({port!r}, 115200, timeout=1)\n"
+        f"end = time.time() + {duration if duration else 0}\n"
+        f"pat = re.compile({tail_filter!r}) if {tail_filter!r} else None\n"
+        f"f = open({(LOG_DIR + '/dev' + str(idx) + '.log')!r}, 'wb')\n"
+        "buf = b''\n"
+        "while True:\n"
+        "  if end and time.time() >= end: break\n"
+        "  d = s.read(4096)\n"
+        "  if not d: continue\n"
+        "  f.write(d); f.flush()\n"
+        "  buf += d\n"
+        "  while b'\\n' in buf:\n"
+        "    line, buf = buf.split(b'\\n', 1)\n"
+        "    t = line.decode('utf-8', errors='replace').rstrip()\n"
+        "    if not t: continue\n"
+        "    if pat and not pat.search(t): continue\n"
+        f"    print('[dev{idx}]', t, flush=True)\n"
+    )
+    subprocess.run([PYSERIAL_PYTHON, "-c", code])
+
+
+def install_signal_handlers():
+    def handler(sig, frame):
+        emit("MAIN", "stopping (signal)")
+        _stop.set()
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--env", default=PIO_ENV_DEFAULT,
+                    help="platformio env name (default: esp32-s3_pdn_release_verbose)")
+    ap.add_argument("--duration", type=int, default=0,
+                    help="seconds to monitor (0 = until Ctrl-C)")
+    ap.add_argument("--no-flash", action="store_true",
+                    help="skip building/flashing, only monitor")
+    ap.add_argument("--no-build", action="store_true",
+                    help="skip building (use last firmware.bin); still flashes")
+    ap.add_argument("--tail-grep", default="",
+                    help="only print lines matching this regex (still writes full log)")
+    args = ap.parse_args()
+
+    install_signal_handlers()
+
+    ports = discover_ports()
+    if not ports:
+        emit("MAIN", "no /dev/ttyACM* devices found")
+        return 1
+    emit("MAIN", f"ports: {ports}")
+
+    if not args.no_flash:
+        if not args.no_build:
+            build_firmware(args.env)
+        if not flash_all(args.env, ports):
+            emit("MAIN", "flash failed; aborting before monitor")
+            return 1
+
+    os.makedirs(LOG_DIR, exist_ok=True)
+    # Truncate prior logs so each run starts clean.
+    for i in range(len(ports)):
+        try:
+            open(f"{LOG_DIR}/dev{i}.log", "wb").close()
+        except Exception:
+            pass
+
+    threads = []
+    for i, p in enumerate(ports):
+        t = threading.Thread(
+            target=reader_thread,
+            args=(p, i, args.duration, args.tail_grep),
+            daemon=True,
+        )
+        t.start()
+        threads.append(t)
+
+    if args.duration:
+        end = time.time() + args.duration
+        while time.time() < end and not _stop.is_set():
+            time.sleep(0.5)
+        _stop.set()
+    else:
+        try:
+            while not _stop.is_set():
+                time.sleep(0.5)
+        except KeyboardInterrupt:
+            _stop.set()
+
+    for t in threads:
+        t.join(timeout=2)
+    emit("MAIN", f"logs in {LOG_DIR}/dev[0-{len(ports)-1}].log")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/flash_and_monitor.py
+++ b/scripts/flash_and_monitor.py
@@ -191,14 +191,6 @@ def main():
             emit("MAIN", "flash failed; aborting before monitor")
             return 1
 
-    os.makedirs(LOG_DIR, exist_ok=True)
-    # Truncate prior logs so each run starts clean.
-    for i in range(len(ports)):
-        try:
-            open(f"{LOG_DIR}/dev{i}.log", "wb").close()
-        except Exception:
-            pass
-
     threads = []
     for i, p in enumerate(ports):
         t = threading.Thread(
@@ -215,11 +207,8 @@ def main():
             time.sleep(0.5)
         _stop.set()
     else:
-        try:
-            while not _stop.is_set():
-                time.sleep(0.5)
-        except KeyboardInterrupt:
-            _stop.set()
+        while not _stop.is_set():
+            time.sleep(0.5)
 
     for t in threads:
         t.join(timeout=2)

--- a/scripts/flash_and_monitor.py
+++ b/scripts/flash_and_monitor.py
@@ -36,6 +36,17 @@ PIO_BIN = "/usr/bin/pio"
 PYSERIAL_PYTHON = "/home/tirefire/.platformio/penv/bin/python"
 LOG_DIR = "/tmp/pdn-logs"
 
+# pyserial lives in the platformio venv, not necessarily on the python running
+# this script. If it's missing here, re-exec the whole script once under the
+# venv python so every reader thread can just use `serial` in-process.
+try:
+    import serial  # noqa: F401
+except ImportError:
+    if os.path.realpath(sys.executable) == os.path.realpath(PYSERIAL_PYTHON):
+        raise  # already the venv python and still no pyserial: nothing to do
+    os.execv(PYSERIAL_PYTHON,
+             [PYSERIAL_PYTHON, os.path.abspath(__file__), *sys.argv[1:]])
+
 _print_lock = threading.Lock()
 _stop = threading.Event()
 
@@ -102,17 +113,6 @@ def flash_all(env, ports):
 
 
 def reader_thread(port, idx, duration, tail_filter):
-    # pyserial lives in the platformio venv; import inside the thread so the
-    # script itself doesn't need pyserial on system Python.
-    sys.path.insert(0, "/home/tirefire/.platformio/penv/lib/python3.13/site-packages")
-    sys.path.insert(0, "/home/tirefire/.platformio/penv/lib/python3.12/site-packages")
-    sys.path.insert(0, "/home/tirefire/.platformio/penv/lib/python3.11/site-packages")
-    try:
-        import serial  # noqa: E402
-    except ImportError:
-        run_reader_subprocess(port, idx, duration, tail_filter)
-        return
-
     try:
         s = serial.Serial(port, 115200, timeout=1)
     except Exception as e:
@@ -152,31 +152,6 @@ def reader_thread(port, idx, duration, tail_filter):
             s.close()
         except Exception:
             pass
-
-
-def run_reader_subprocess(port, idx, duration, tail_filter):
-    # Spawn the platformio venv python so pyserial is available.
-    code = (
-        "import sys, time, re, serial\n"
-        f"s = serial.Serial({port!r}, 115200, timeout=1)\n"
-        f"end = time.time() + {duration if duration else 0}\n"
-        f"pat = re.compile({tail_filter!r}) if {tail_filter!r} else None\n"
-        f"f = open({(LOG_DIR + '/dev' + str(idx) + '.log')!r}, 'wb')\n"
-        "buf = b''\n"
-        "while True:\n"
-        "  if end and time.time() >= end: break\n"
-        "  d = s.read(4096)\n"
-        "  if not d: continue\n"
-        "  f.write(d); f.flush()\n"
-        "  buf += d\n"
-        "  while b'\\n' in buf:\n"
-        "    line, buf = buf.split(b'\\n', 1)\n"
-        "    t = line.decode('utf-8', errors='replace').rstrip()\n"
-        "    if not t: continue\n"
-        "    if pat and not pat.search(t): continue\n"
-        f"    print('[dev{idx}]', t, flush=True)\n"
-    )
-    subprocess.run([PYSERIAL_PYTHON, "-c", code])
 
 
 def install_signal_handlers():

--- a/scripts/refresh_clangd.sh
+++ b/scripts/refresh_clangd.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Refresh clangd's view of the project. Run this whenever code state changes
+# outside of a `pio run`/`pio test` invocation (e.g. after an Agent completes
+# or after direct file edits). PlatformIO's own auto_compiledb.py covers pio
+# invocations; this script covers the gap.
+#
+# What it does:
+#   1. Regenerates compile_commands.json from native_cli env (canonical).
+#   2. Touches the file to force mtime bump, so clangd's inotify watcher
+#      definitely picks up a change even when content is identical.
+#
+# A lockfile prevents concurrent runs from racing each other. If another
+# instance is already refreshing, this one exits immediately.
+
+set -u
+PROJECT_DIR="/home/tirefire/pdn"
+LOCKFILE="$PROJECT_DIR/.pio/.compiledb_refresh.lock"
+
+mkdir -p "$(dirname "$LOCKFILE")"
+exec 9>"$LOCKFILE"
+if ! flock -n 9; then
+    exit 0
+fi
+
+cd "$PROJECT_DIR" || exit 0
+pio run -e native_cli -t compiledb -s >/dev/null 2>&1
+touch "$PROJECT_DIR/compile_commands.json"


### PR DESCRIPTION
Brings in the three dev-tooling scripts named in #174 from `reliable-duel-delivery`, and wires the one that needs it.

- **`scripts/auto_compiledb.py`** — a PlatformIO `extra_script` that keeps `compile_commands.json` fresh for clangd (PIO only writes it on `-t compiledb` otherwise). Wired into `extra_scripts` for both hardware bases (`esp32-s3_base`, `esp32-s3_fdn_base`, alongside the existing `multi_flash_target.py`) and the three native envs (`native`, `native_cli`, `native_cli_test`) — matching how the fork used it. `native_cli` is the canonical source; other envs kick a background refresh. Without the platformio.ini wiring the script is inert, so it's included here.
- **`scripts/flash_and_monitor.py`** — flash-all-connected-S3s + monitor helper. Defaults to `esp32-s3_pdn_release_verbose` (post-migration env name, already correct on this branch — no drift).
- **`scripts/refresh_clangd.sh`** — regenerates `compile_commands.json` from `native_cli` and nudges clangd; for use after code changes made outside a `pio run`/`pio test`.

Not brought in: `extract_images.py` (not in scope).

Verification: `native` and `esp32-s3_pdn_release` both build clean with the new wiring; `compile_commands.json` refreshes on native build; 277/277 tests; all three scripts pass syntax checks.


Also adds `__pycache__/` + `*.pyc` to `.gitignore` — introducing Python scripts otherwise leaves bytecode cache dirs as untracked cruft.
