### PR TITLE
rdc: define and stub RDC public API header (#154)

### DIFF
--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <vector>
 #include "device/serial-manager.hpp"
 #include "utils/simple-timer.hpp"
 #include "wireless/handshake-wireless-manager.hpp"
@@ -13,21 +14,44 @@ class Device;
 class HandshakeApp;
 
 enum class PortStatus {
-    DISCONNECTED = 0, // No Connection. Handshake is in Idle state.
-    CONNECTING = 1, // Port is NOT connected && NOT in handshake idle state.
-    CONNECTED = 2, // Port is connected to exactly 1 peer.
-    DAISY_CHAINED = 3, // Port is connected to more than 1 peer.
+    DISCONNECTED = 0,  // No Connection. Handshake is in Idle state.
+    CONNECTING = 1,    // Port is NOT connected && NOT in handshake idle state.
+    CONNECTED = 2,     // Port is connected to a peer.
 };
 
-    struct PortState {
-        SerialIdentifier port;
-        PortStatus status;
-        std::vector<std::array<uint8_t, 6>> peerMacAddresses;
+// This device's position in the physical chain, derived from jack state:
+// head has no in-peer, a child has one, a ring is a chain whose ends met.
+// Device-level (not per-port): whether a connection makes this device a head
+// or child is a chain concern surfaced here, never a PortStatus.
+enum class ChainRole {
+    STANDALONE = 0,
+    HEAD = 1,
+    CHILD = 2,
+    RING = 3,
+};
+
+struct PortState {
+    SerialIdentifier port;
+    PortStatus status;
+    std::vector<std::array<uint8_t, 6>> peerMacAddresses;
 };
 
 class RemoteDeviceCoordinator {
 public:
+    /// Fires on a per-jack connect (true) / disconnect (false) transition.
+    using JackChangeCallback = std::function<void(SerialIdentifier jack, bool connected)>;
+    /// Fires when this device's ChainRole changes.
+    using ChainRoleChangeCallback = std::function<void(ChainRole role)>;
+    /// Head-only: fires when the chain member roster changes; read the new
+    /// roster via getChainMembers().
+    using MembershipChangeCallback = std::function<void()>;
+    /// Head-only: fires when the ring fully closes. This is the shootout
+    /// coordinator claim point.
+    using RingClosedCallback = std::function<void()>;
+
+    /// Inert until initialize().
     RemoteDeviceCoordinator();
+    /// Tears down the per-port handshake apps.
     ~RemoteDeviceCoordinator();
 
     /**
@@ -45,7 +69,10 @@ public:
      */
     void sync(Device* PDN);
 
+    /// Connection state of one jack (device-level chain facts live in
+    /// getChainRole(), not here).
     virtual PortStatus getPortStatus(SerialIdentifier port);
+    /// Status plus the peer MACs reachable via the port.
     PortState getPortState(SerialIdentifier port);
 
     /**
@@ -54,13 +81,54 @@ public:
      */
     virtual const uint8_t* getPeerMac(SerialIdentifier port) const;
 
+    /// The direct peer's hardware kind (PDN/FDN) for the given port.
     virtual DeviceType getPeerDeviceType(SerialIdentifier port) const;
 
-    // Returns true iff `mac` matches the direct peer on either jack.
+    /// The direct peer's 4-digit player id for the given port; 0xFFFF when
+    /// unregistered or no peer. STUB until the context exchange lands (#157):
+    /// always 0xFFFF.
+    virtual uint16_t getPeerUserId(SerialIdentifier port) const { return 0xFFFF; }
+
+    /// Returns true iff `mac` matches the direct peer on either jack.
     virtual bool isDirectPeer(const uint8_t* mac) const;
 
-    // Reachable via either jack (direct peer or daisy-chained).
+    /// Reachable via either jack (direct peer or daisy-chained).
     virtual bool canReachPeer(const uint8_t* mac) const;
+
+    // ---- Chain-level surface (#154). Stubs until the connection-state
+    // machines land (#155-#159): they return the standalone defaults so the
+    // game layer can compile and wire against the final shape now. ----
+
+    /// This device's chain role. STUB: always STANDALONE.
+    virtual ChainRole getChainRole() const { return ChainRole::STANDALONE; }
+
+    /// The chain head's MAC, or nullptr when this device is the head or
+    /// standalone. STUB: always nullptr.
+    virtual const uint8_t* getHeadMac() const { return nullptr; }
+
+    /// Head-only chain member roster; empty for a child or standalone device.
+    /// STUB: always empty.
+    virtual std::vector<std::array<uint8_t, 6>> getChainMembers() const { return {}; }
+
+    /// Registers the per-jack connect/disconnect observer.
+    void setOnJackChange(JackChangeCallback callback) {
+        jackChangeCallback = std::move(callback);
+    }
+
+    /// Registers the chain-role transition observer.
+    void setOnChainRoleChange(ChainRoleChangeCallback callback) {
+        chainRoleChangeCallback = std::move(callback);
+    }
+
+    /// Registers the head-only roster observer.
+    void setOnMembershipChange(MembershipChangeCallback callback) {
+        membershipChangeCallback = std::move(callback);
+    }
+
+    /// Registers the head-only ring-closure observer.
+    void setOnRingClosed(RingClosedCallback callback) {
+        ringClosedCallback = std::move(callback);
+    }
 
     /**
      * Called when a chain announcement is received from a direct peer.
@@ -72,19 +140,25 @@ public:
         SerialIdentifier port,
         const std::vector<std::array<uint8_t, 6>>& announcedPeers);
 
+    /// Registers the legacy any-chain-change observer.
     void setChainChangeCallback(std::function<void()> callback);
 
-    // Direct peer drops only; daisy-chained drops arrive via chain announcements.
+    /// Direct peer drops only; daisy-chained drops arrive via chain announcements.
     void setPeerLostCallback(std::function<void(const uint8_t*)> callback);
 
+    /// Decodes and applies an inbound kChainAnnouncement packet.
     void processChainAnnouncementPacket(const uint8_t* fromMac, const uint8_t* data, size_t dataLen);
 
     using AnnouncementEmitCallback = std::function<void(const uint8_t* toMac, uint8_t announcementId, const std::vector<std::array<uint8_t, 6>>& peers)>;
+    /// Registers the outbound chain-announcement sender.
     void setAnnouncementEmitCallback(AnnouncementEmitCallback callback);
 
+    /// Decodes and applies an inbound kChainAnnouncementAck packet.
     void processChainAnnouncementAckPacket(const uint8_t* fromMac, const uint8_t* data, size_t dataLen);
 
+    /// Registers the MAC as an ESP-NOW peer slot.
     void registerPeer(const uint8_t* macAddress);
+    /// Releases the MAC's ESP-NOW peer slot.
     void unregisterPeer(const uint8_t* macAddress);
 
     // Retry / reliability observability. Cumulative since boot. For hardware
@@ -98,6 +172,7 @@ public:
         uint32_t ackLatencyMsSum = 0;
         uint32_t ackCount = 0;
     };
+    /// Cumulative chain-announcement retry counters (see RetryStats).
     RetryStats getRetryStats() const { return retryStats_; }
 
 private:
@@ -146,6 +221,12 @@ private:
     std::function<void()> chainChangeCallback_;
     std::function<void(const uint8_t*)> peerLostCallback_;
     AnnouncementEmitCallback announcementEmitCallback_;
+
+    // New-surface observers (#154); fired by the RDC internals as #155-#159 land.
+    JackChangeCallback jackChangeCallback;
+    ChainRoleChangeCallback chainRoleChangeCallback;
+    MembershipChangeCallback membershipChangeCallback;
+    RingClosedCallback ringClosedCallback;
 
     HandshakeWirelessManager handshakeWirelessManager;
 

--- a/lib/core/include/state/connect-state.hpp
+++ b/lib/core/include/state/connect-state.hpp
@@ -23,12 +23,9 @@ public:
 
     /// True when every jack this state requires reports CONNECTED.
     bool isConnected() {
-        auto connected = [this](SerialIdentifier jack) {
-            return remoteDeviceCoordinator->getPortStatus(jack) == PortStatus::CONNECTED;
-        };
-        return (isPrimaryRequired() && connected(SerialIdentifier::OUTPUT_JACK)) ||
-               (isAuxRequired() && connected(SerialIdentifier::INPUT_JACK)) ||
-               (isSecondaryRequired() && connected(SerialIdentifier::INPUT_JACK_SECONDARY));
+        return (isPrimaryRequired() && isJackConnected(SerialIdentifier::OUTPUT_JACK)) ||
+               (isAuxRequired() && isJackConnected(SerialIdentifier::INPUT_JACK)) ||
+               (isSecondaryRequired() && isJackConnected(SerialIdentifier::INPUT_JACK_SECONDARY));
     }
 
     /// isConnected() has been false for the full debounce window.
@@ -46,6 +43,11 @@ protected:
     virtual bool isSecondaryRequired() { return false; }
 
 private:
+    /// True when the given jack's port status is CONNECTED.
+    bool isJackConnected(SerialIdentifier jack) const {
+        return remoteDeviceCoordinator->getPortStatus(jack) == PortStatus::CONNECTED;
+    }
+
     static constexpr unsigned long kDisconnectDebounceMs = 500;
     DebouncedCondition disconnectDebounce_;
 };

--- a/lib/core/include/state/connect-state.hpp
+++ b/lib/core/include/state/connect-state.hpp
@@ -7,27 +7,31 @@
 template<typename DeviceT>
 class ConnectState : public TypedState<DeviceT> {
 public:
+    /// Binds the state to the coordinator whose jack statuses it watches.
     ConnectState(RemoteDeviceCoordinator* remoteDeviceCoordinator, int stateId)
         : TypedState<DeviceT>(stateId), remoteDeviceCoordinator(remoteDeviceCoordinator) {}
 
+    /// Non-owning; just drops the coordinator pointer.
     virtual ~ConnectState() {
         remoteDeviceCoordinator = nullptr;
     }
 
+    /// The direct peer's hardware kind on the given port.
     const DeviceType getPeerDeviceType(SerialIdentifier port) const {
         return remoteDeviceCoordinator->getPeerDeviceType(port);
     }
 
+    /// True when every jack this state requires reports CONNECTED.
     bool isConnected() {
-        auto connectedOrChain = [this](SerialIdentifier jack) {
-            PortStatus s = remoteDeviceCoordinator->getPortStatus(jack);
-            return s == PortStatus::CONNECTED || s == PortStatus::DAISY_CHAINED;
+        auto connected = [this](SerialIdentifier jack) {
+            return remoteDeviceCoordinator->getPortStatus(jack) == PortStatus::CONNECTED;
         };
-        return (isPrimaryRequired()   && connectedOrChain(SerialIdentifier::OUTPUT_JACK)) ||
-               (isAuxRequired()       && connectedOrChain(SerialIdentifier::INPUT_JACK)) ||
-               (isSecondaryRequired() && connectedOrChain(SerialIdentifier::INPUT_JACK_SECONDARY));
+        return (isPrimaryRequired() && connected(SerialIdentifier::OUTPUT_JACK)) ||
+               (isAuxRequired() && connected(SerialIdentifier::INPUT_JACK)) ||
+               (isSecondaryRequired() && connected(SerialIdentifier::INPUT_JACK_SECONDARY));
     }
 
+    /// isConnected() has been false for the full debounce window.
     bool isPersistentlyDisconnected() {
         return disconnectDebounce_.heldFor(!isConnected(), kDisconnectDebounceMs);
     }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -244,13 +244,9 @@ size_t RemoteDeviceCoordinator::portIndex(SerialIdentifier port) const {
 }
 
 PortStatus RemoteDeviceCoordinator::getPortStatus(SerialIdentifier port) {
-    PortStatus statusByState = mapHandshakeStateToStatus(port);
-
-    if (statusByState == PortStatus::CONNECTED && !daisyChainedByPort_[portIndex(port)].empty()) {
-        return PortStatus::DAISY_CHAINED;
-    }
-
-    return statusByState;
+    // Daisy-chained peers no longer upgrade the status: a port is CONNECTED or
+    // it isn't. Chain position is a device-level fact (getChainRole()).
+    return mapHandshakeStateToStatus(port);
 }
 
 PortState RemoteDeviceCoordinator::getPortState(SerialIdentifier port) {

--- a/test/test_core/rdc-tests.hpp
+++ b/test/test_core/rdc-tests.hpp
@@ -21,6 +21,7 @@ using ::testing::NiceMock;
 
 class RDCTests : public testing::Test {
 public:
+    /// Fake clock + mocked radio with captured per-PktType handlers; RDC initialized.
     void SetUp() override {
         fakeClock = new FakePlatformClock();
         SimpleTimer::setPlatformClock(fakeClock);
@@ -47,11 +48,13 @@ public:
         rdc.initialize(device.wirelessManager, device.serialManager, &device);
     }
 
+    /// Restores the real clock.
     void TearDown() override {
         SimpleTimer::setPlatformClock(nullptr);
         delete fakeClock;
     }
 
+    /// Injects a raw handshake packet as if received on the jack opposite senderJack.
     void deliverPacketViaRDC(int command, SerialIdentifier senderJack, int deviceType = 0) {
         SerialIdentifier receivingJack = (senderJack == SerialIdentifier::OUTPUT_JACK)
             ? SerialIdentifier::INPUT_JACK : SerialIdentifier::OUTPUT_JACK;
@@ -465,7 +468,9 @@ inline void rdcDisconnectWipesDaisyChainedPeers(RDCTests* suite) {
         directPeerMac, SerialIdentifier::OUTPUT_JACK, announcedPeers);
 
     ASSERT_EQ(suite->rdc.getPortState(SerialIdentifier::OUTPUT_JACK).peerMacAddresses.size(), 3u);
-    ASSERT_EQ(suite->rdc.getPortStatus(SerialIdentifier::OUTPUT_JACK), PortStatus::DAISY_CHAINED);
+    // Daisy peers no longer upgrade the port status (chain position is
+    // device-level via getChainRole()); the port stays plain CONNECTED.
+    ASSERT_EQ(suite->rdc.getPortStatus(SerialIdentifier::OUTPUT_JACK), PortStatus::CONNECTED);
 
     // Heartbeat monitor timeout expires → handshake drops → port disconnects
     suite->fakeClock->advance(2100);


### PR DESCRIPTION
Defines the new `RemoteDeviceCoordinator` public surface as a header with stubbed chain-level methods (#154). The point is to unblock the game-layer work (#163, #165) and the RDC internals (#155) to proceed in parallel against the final API shape, before any of the connection-state machinery exists.

**New chain-level surface** (stubs returning standalone defaults until #155–#159 fill them in):
- `getChainRole()` → new `ChainRole` enum {STANDALONE, HEAD, CHILD, RING}
- `getHeadMac()` (nullptr when head/standalone), `getChainMembers()` (head-only roster), `getPeerUserId(jack)`
- callbacks: `setOnJackChange`, `setOnChainRoleChange`, `setOnMembershipChange`, `setOnRingClosed` (the last is the shootout coordinator-claim point)

**Removals the design calls for:**
- `PortStatus::DAISY_CHAINED` is gone — chain position is a device-level fact (`getChainRole()`), never a port-level status. `getPortStatus` no longer upgrades to it, and `ConnectState::isConnected()` drops the daisy arm (a jack is CONNECTED or not). The one rdc-test that asserted DAISY_CHAINED now asserts plain CONNECTED, with a comment on why.
- No `ChampionResolver` / `OpponentRoleResolver` injection points — those were a PR-era construct that never existed on this base, so this is a "don't introduce them" rather than a deletion.

**Compile strategy** (the one thing worth scrutinizing): the stubs are additive on top of the existing HandshakeApp-era RDC, so the whole firmware keeps building today. The old surface and impl stay until #160 tears them out. That keeps the tree green while the game layer builds against the new methods now.

Verification: 277/277 native tests (incl. the reworked daisy→connected rdc-test), style-clean. Rebased onto the current `comms-rewrite` tip.
