### PR TITLE
transport: trim dead surface + config theater from primitives

### DIFF
--- a/lib/core/include/wireless/reliable-channel.hpp
+++ b/lib/core/include/wireless/reliable-channel.hpp
@@ -48,20 +48,6 @@ public:
     /// Silently drops every pending send to this MAC (no abandon callback).
     void cancel(const uint8_t* mac);
 
-    /// Counts peers with at least one in-flight entry on this channel.
-    size_t pendingCount(const std::vector<std::array<uint8_t, 6>>& peers) const {
-        size_t n = 0;
-        for (const std::array<uint8_t, 6>& p : peers)
-            if (isPending(p.data())) ++n;
-        return n;
-    }
-
-    /// Silently drops every pending send to each peer in the set.
-    void cancel(const std::vector<std::array<uint8_t, 6>>& peers) {
-        for (const std::array<uint8_t, 6>& p : peers)
-            cancel(p.data());
-    }
-
     /// Typed subclass deserializes bytes into its payload type and dispatches
     /// to its onReceive callback. Returns true if delivered.
     virtual bool deliverBytes(const uint8_t* fromMac, const uint8_t* data, size_t len) = 0;
@@ -70,8 +56,6 @@ protected:
     uint8_t nextSeqId();
     // nullptr in probe-style unit tests; every use is null-tolerant.
     WirelessManager* getWirelessManager() const { return wirelessManager; }
-    // Own MAC, for self-exclusion in multi-target sends; nullptr without a manager.
-    const uint8_t* selfMac() const;
     void sendOnceBytes(const uint8_t* mac, const uint8_t* data, size_t len);
     // Defined in the .cpp so the logger stays out of this template header.
     static void logLengthMismatch(PktType type, size_t got, size_t want);
@@ -128,17 +112,6 @@ public:
         sendOnceBytes(mac, reinterpret_cast<const uint8_t*>(&p), sizeof(P));
     }
 
-    /// Broadcast the same payload reliably to a peer set, skipping self. Each
-    /// target gets its own seqId just as a single-target send would.
-    void sendReliable(const std::vector<std::array<uint8_t, 6>>& peers, P p) {
-        broadcast(peers, [&](const uint8_t* mac) { sendReliable(mac, p); });
-    }
-
-    /// Broadcast the same payload fire-and-forget to a peer set, skipping self.
-    void sendOnce(const std::vector<std::array<uint8_t, 6>>& peers, P p) {
-        broadcast(peers, [&](const uint8_t* mac) { sendOnce(mac, p); });
-    }
-
     /// Decode + dispatch one inbound packet: ack first (a retransmit means our
     /// prior ack was lost), then dedup, then the onReceive callback.
     bool deliver(const uint8_t* fromMac, const uint8_t* data, size_t len) {
@@ -166,14 +139,5 @@ public:
     void onReceive(OnReceive cb) { onReceiveCallback = std::move(cb); }
 
 private:
-    template <typename SendToTarget>
-    void broadcast(const std::vector<std::array<uint8_t, 6>>& peers, SendToTarget sendToTarget) {
-        const uint8_t* self = selfMac();
-        for (const std::array<uint8_t, 6>& target : peers) {
-            if (self && std::memcmp(target.data(), self, 6) == 0) continue;
-            sendToTarget(target.data());
-        }
-    }
-
     OnReceive onReceiveCallback;
 };

--- a/lib/core/include/wireless/resender.hpp
+++ b/lib/core/include/wireless/resender.hpp
@@ -32,16 +32,6 @@ struct ResenderRetryPolicy {
         unsigned shift = retryNum > 16 ? 16u : retryNum;
         return initialTimeoutMs << shift;
     }
-
-    /// Time from the first transmission until the last retransmit leaves the
-    /// radio; after this window a reliable send can no longer reach the peer
-    /// (abandonment fires one further backoff later).
-    constexpr unsigned long totalBudgetMs() const {
-        unsigned long total = 0;
-        for (uint8_t i = 0; i < maxRetries; ++i)
-            total += backoffMs(i);
-        return total;
-    }
 };
 
 class Resender {

--- a/lib/core/include/wireless/resender.hpp
+++ b/lib/core/include/wireless/resender.hpp
@@ -18,22 +18,6 @@ class WirelessManager;
 // retain their own retry slots. sync() must be called every loop tick to drive
 // retransmits.
 
-// One retry policy for every channel; Resender::RETRY_POLICY is the single
-// instance. (Namespace scope because a nested struct's default member
-// initializers can't be evaluated inside the enclosing class definition.)
-struct ResenderRetryPolicy {
-    unsigned long initialTimeoutMs = 100;
-    uint8_t maxRetries = 3;
-
-    /// Exponential backoff for the given retry number: 100, 200, 400 ...
-    constexpr unsigned long backoffMs(uint8_t retryNum) const {
-        // unsigned long is 32-bit on the ESP32; an unclamped shift from a
-        // caller-set maxRetries would be UB past ~25 doublings.
-        unsigned shift = retryNum > 16 ? 16u : retryNum;
-        return initialTimeoutMs << shift;
-    }
-};
-
 class Resender {
 public:
     // How a send relates to other in-flight sends to the same peer on the same
@@ -45,8 +29,17 @@ public:
     enum class SendMode { SUPERSEDE_PER_TARGET,
                           KEEP_DISTINCT };
 
-    using RetryPolicy = ResenderRetryPolicy;
-    static constexpr RetryPolicy RETRY_POLICY{};
+    // Retry tuning, shared by every channel: first retransmit after 100ms,
+    // doubling each retry, capped at 3 retries.
+    static constexpr unsigned long INITIAL_TIMEOUT_MS = 100;
+    static constexpr uint8_t MAX_RETRIES = 3;
+
+    /// Exponential backoff for the given retry number: 100, 200, 400 ...
+    static constexpr unsigned long backoffMs(uint8_t retryNum) {
+        // Clamp the shift so raising MAX_RETRIES past ~25 can't hit shift UB
+        // (unsigned long is 32-bit on the ESP32).
+        return INITIAL_TIMEOUT_MS << (retryNum > 16 ? 16u : retryNum);
+    }
 
     /// Fires once per pending entry that exhausts its retry budget. Invoked
     /// from sync() AFTER all retransmits have been processed and the

--- a/lib/core/src/wireless/reliable-channel.cpp
+++ b/lib/core/src/wireless/reliable-channel.cpp
@@ -47,11 +47,6 @@ uint8_t ReliableChannelBase::nextSeqId() {
     return lastSentSeqId;
 }
 
-const uint8_t* ReliableChannelBase::selfMac() const {
-    WirelessManager* wm = getWirelessManager();
-    return wm ? wm->getMacAddress() : nullptr;
-}
-
 bool ReliableChannelBase::isDuplicateReliableRx(const uint8_t* fromMac, uint8_t seqId) {
     if (seqId == 0 || fromMac == nullptr) return false;
     for (RxSeqRecord& r : rxSeq) {

--- a/lib/core/src/wireless/reliable-channel.cpp
+++ b/lib/core/src/wireless/reliable-channel.cpp
@@ -24,9 +24,7 @@ ReliableChannelBase::ReliableChannelBase(WirelessManager* wirelessManager,
     , onAbandon(std::move(onAbandon)) {}
 
 void ReliableChannelBase::onAck(uint8_t seqId, const uint8_t* fromMac) {
-    if (resender) {
-        resender->onAck(packetType, seqId, fromMac);
-    }
+    resender->onAck(packetType, seqId, fromMac);
 }
 
 void ReliableChannelBase::onResenderAbandon(uint8_t seqId, const uint8_t* targetMac) {
@@ -34,11 +32,11 @@ void ReliableChannelBase::onResenderAbandon(uint8_t seqId, const uint8_t* target
 }
 
 bool ReliableChannelBase::isPending(const uint8_t* mac) const {
-    return resender && resender->isPending(packetType, mac);
+    return resender->isPending(packetType, mac);
 }
 
 void ReliableChannelBase::cancel(const uint8_t* mac) {
-    if (resender) resender->cancel(packetType, mac);
+    resender->cancel(packetType, mac);
 }
 
 uint8_t ReliableChannelBase::nextSeqId() {

--- a/lib/core/src/wireless/resender.cpp
+++ b/lib/core/src/wireless/resender.cpp
@@ -43,7 +43,7 @@ void Resender::send(const uint8_t* target, PktType type, uint8_t seqId,
     p.seqId = seqId;
     p.payload.assign(payload, payload + len);
     p.retries = 0;
-    p.timer.setTimer(RETRY_POLICY.backoffMs(0));
+    p.timer.setTimer(backoffMs(0));
     pending.push_back(std::move(p));
 
     transmit(pending.back());
@@ -97,7 +97,7 @@ void Resender::sync() {
             continue;
         }
 
-        if (p.retries >= RETRY_POLICY.maxRetries) {
+        if (p.retries >= MAX_RETRIES) {
             LOG_E(RSND_TAG, "abandon type=%u seq=%u to=%02X%02X",
                   (unsigned)p.type, p.seqId, p.target[4], p.target[5]);
             abandoned.push_back({p.type, p.seqId, p.target});
@@ -113,7 +113,7 @@ void Resender::sync() {
         // Re-arm either way. A send that never reached the radio leaves retries
         // unchanged, so a packet that was not actually transmitted keeps being
         // retried rather than being abandoned against an exhausted budget.
-        p.timer.setTimer(RETRY_POLICY.backoffMs(p.retries));
+        p.timer.setTimer(backoffMs(p.retries));
         ++i;
     }
 


### PR DESCRIPTION
Trims dead/accidental complexity from the transport primitives (#148 follow-up). All behavior-preserving — 277/277 throughout. Three commits, each a distinct cut:

**1. Dead surface removal** — nothing calls these, including the intended game-layer consumers (which hand-roll single-MAC `cancel(t.data())` loops rather than the vector forms):
- `ReliableChannel` peer-vector overloads `sendReliable(peers)`, `sendOnce(peers)`, `cancel(peers)`, `pendingCount(peers)`
- their only helper, the private `broadcast()` template
- `selfMac()` — existed solely for `broadcast`'s self-exclusion
- `ResenderRetryPolicy::totalBudgetMs()` — zero callers anywhere

**2. `RetryPolicy` struct → constants** — there was exactly one default-constructed `static constexpr RETRY_POLICY{}` and nothing ever set a field, so the struct dressed three fixed values as configurable. Folded `initialTimeoutMs`/`maxRetries`/`backoffMs` into `Resender` as `INITIAL_TIMEOUT_MS` / `MAX_RETRIES` / a static `backoffMs()`. Values byte-identical; the shift clamp stays (now guarding a future `MAX_RETRIES` bump rather than a phantom caller-set field).

**3. Impossible-state guards** — `onAck`/`isPending`/`cancel` guarded `resender` for null, but it's a constructor-set member every construction passes real (transport and all tests). Dropped the three guards.

Left intact deliberately: the retry/backoff state machine, ack-before-dedup, the single-MAC send/cancel path, and the `onAbandon` guard (calling an empty `std::function` crashes — that one guards a real failure mode). The `wirelessManager`-nullable test seam is untouched here; collapsing it would reshape several proven #148 tests, so it's held for a separate look.
