### PR TITLE
rdc: HelloPayload wire format + SerialFrameParser integration (#153)

### DIFF
--- a/lib/core/include/device/serial-frame-parser.hpp
+++ b/lib/core/include/device/serial-frame-parser.hpp
@@ -14,25 +14,34 @@
 constexpr uint8_t FRAME_PREAMBLE_0 = 0xAA;
 constexpr uint8_t FRAME_PREAMBLE_1 = 0x55;
 constexpr uint8_t OP_HELLO = 0x00;
-// Payload bytes after the opcode, before the CRC: source mac[6] +
-// deviceType[1] + headMac[6] + confirmed[1]. The packed HelloPayload struct
-// that owns this layout arrives with the HELLO wire-format work; the parser
-// only needs the length to frame it.
+// Payload bytes after the opcode, before the CRC. Owned by the packed
+// HelloPayload struct below; the constant lets the parser frame the payload
+// without depending on the struct in switch tables.
 constexpr size_t HELLO_PAYLOAD_LEN = 14;
 
-// Wraps a payload in the framed wire format: preamble, opcode, payload,
+// The sole serial payload, exchanged jack-to-jack on every HELLO frame.
+// Packed to a fixed 14-byte wire layout: the parser memcpys the raw payload
+// straight into this struct, so the field order and packing ARE the wire
+// contract.
+struct HelloPayload {
+    uint8_t source[6];   // this device's WiFi MAC
+    uint8_t deviceType;  // DeviceType value; discriminates ConnectionContext deser
+    uint8_t headMac[6];  // chain head MAC, all-zero if head/standalone; hop-propagated
+    uint8_t confirmed;   // 1 once head context exchange completes, else 0
+} __attribute__((packed));
+
+static_assert(sizeof(HelloPayload) == HELLO_PAYLOAD_LEN,
+              "HelloPayload must match the 14-byte HELLO wire layout");
+
+// Wraps a raw payload in the framed wire format: preamble, opcode, payload,
 // CRC-16 over (opcode + payload). The inverse of SerialFrameParser.
 std::vector<uint8_t> encodeFramed(uint8_t opcode, const std::vector<uint8_t>& payload);
 
-// A validated binary frame surfaced to downstream consumers (RDC's serial
-// ingest, bound via setBinaryFrameHandler). payload holds the raw bytes
-// between the opcode and the CRC.
-struct Frame {
-    uint8_t opcode;
-    std::vector<uint8_t> payload;
-};
+// Serializes a HelloPayload into a HELLO frame. Convenience over the raw
+// encodeFramed for the only payload type serial actually carries.
+std::vector<uint8_t> encodeFramed(const HelloPayload& hello);
 
-using BinaryFrameHandler = std::function<void(const Frame&)>;
+using HelloFrameHandler = std::function<void(const HelloPayload&)>;
 
 // Parses one jack's serial byte stream into framed binary frames
 // (preamble 0xAA 0x55 + opcode + payload + CRC-16). One instance per jack.
@@ -52,8 +61,8 @@ public:
     /// the start of the next feed(), keeping parser state single-owner.
     void requestReset() { resetRequested.store(true); }
 
-    /// Registers the validated-frame consumer.
-    void setBinaryFrameHandler(BinaryFrameHandler cb) { binaryFrameHandler = std::move(cb); }
+    /// Registers the consumer for CRC-valid HELLO frames, decoded to HelloPayload.
+    void setHelloFrameHandler(HelloFrameHandler cb) { helloFrameHandler = std::move(cb); }
 
 private:
     enum class ParseState {
@@ -81,7 +90,7 @@ private:
 
     std::atomic<bool> resetRequested{false};
 
-    BinaryFrameHandler binaryFrameHandler;
+    HelloFrameHandler helloFrameHandler;
 
     // Wall-clock window after which a mid-frame parser resets to scan-for-sync.
     static constexpr unsigned long PARSER_TIMEOUT_MS = 50;

--- a/lib/core/src/device/serial-frame-parser.cpp
+++ b/lib/core/src/device/serial-frame-parser.cpp
@@ -3,6 +3,7 @@
 #include "utils/simple-timer.hpp"
 #include "wireless/crc16.hpp"
 
+#include <cstring>
 #include <limits>
 #include <utility>
 
@@ -26,6 +27,11 @@ std::vector<uint8_t> encodeFramed(uint8_t opcode, const std::vector<uint8_t>& pa
     frame.push_back(static_cast<uint8_t>(crc >> 8));
     frame.push_back(static_cast<uint8_t>(crc & 0xFF));
     return frame;
+}
+
+std::vector<uint8_t> encodeFramed(const HelloPayload& hello) {
+    const uint8_t* bytes = reinterpret_cast<const uint8_t*>(&hello);
+    return encodeFramed(OP_HELLO, std::vector<uint8_t>(bytes, bytes + sizeof(hello)));
 }
 
 unsigned long SerialFrameParser::nowMs() {
@@ -129,11 +135,13 @@ void SerialFrameParser::feed(const uint8_t* data, size_t len) {
                     uint16_t expected = crc16(&parser.opcode, 1);
                     expected = crc16Update(expected, parser.payloadBuf.data(),
                                            parser.payloadBuf.size());
-                    if (got == expected && binaryFrameHandler) {
-                        // Move, don't copy: resetParser()'s clear() is valid on
-                        // the moved-from buffer.
-                        Frame f{parser.opcode, std::move(parser.payloadBuf)};
-                        binaryFrameHandler(f);
+                    if (got == expected && helloFrameHandler &&
+                        parser.payloadBuf.size() == sizeof(HelloPayload)) {
+                        // The packed struct mirrors the wire byte-for-byte, so
+                        // the validated payload copies straight in.
+                        HelloPayload hello;
+                        std::memcpy(&hello, parser.payloadBuf.data(), sizeof(hello));
+                        helloFrameHandler(hello);
                     }
                     resetParser();
                 }

--- a/test/test_core/serial-frame-parser-tests.hpp
+++ b/test/test_core/serial-frame-parser-tests.hpp
@@ -45,7 +45,7 @@ public:
         return out;
     }
 
-    /// HELLO payload: source mac[6] + deviceType[1] + headMac[6] + confirmed[1].
+    /// HELLO payload bytes: source mac[6] + deviceType[1] + headMac[6] + confirmed[1].
     std::vector<uint8_t> helloPayload(uint8_t firstMacByte = 0x10) {
         std::vector<uint8_t> p = {firstMacByte, 0x20, 0x30, 0x40, 0x50, 0x60,  // source
                                   0x01,                                        // deviceType
@@ -64,40 +64,90 @@ public:
     FakePlatformClock* fakeClock = nullptr;
 };
 
-TEST_F(SerialFrameParserTests, validBinaryFrameRoutesToFrameHandler) {
+TEST_F(SerialFrameParserTests, validFrameDecodesToHelloPayload) {
     int frameCount = 0;
-    Frame got;
-    parser.setBinaryFrameHandler([&](const Frame& f) { got = f; ++frameCount; });
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; ++frameCount; });
 
-    std::vector<uint8_t> frame = buildFrame(OP_HELLO, helloPayload());
+    feed(buildFrame(OP_HELLO, helloPayload()));
+
+    ASSERT_EQ(frameCount, 1);
+    EXPECT_EQ(got.source[0], 0x10);
+    EXPECT_EQ(got.source[5], 0x60);
+    EXPECT_EQ(got.deviceType, 0x01);
+    EXPECT_EQ(got.headMac[0], 0xAA);
+    EXPECT_EQ(got.headMac[5], 0xFF);
+    EXPECT_EQ(got.confirmed, 0x00);
+}
+
+TEST_F(SerialFrameParserTests, decodeMapsEveryWireByteToItsField) {
+    // Independent of buildFrame/encodeFramed: a hand-laid frame whose CRC is the
+    // precomputed CRC-16/XMODEM of (opcode + payload). Pins the exact byte->field
+    // mapping so a reordered or repacked struct fails here, not silently on the wire.
+    // Layout: preamble 0xAA 0x55, OP_HELLO 0x00, source[6]=11..66, deviceType=01,
+    // headMac[6]=DE AD BE EF 00 01, confirmed=01, then CRC 0xDC48.
+    const std::vector<uint8_t> frame = {0xAA, 0x55, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x01,
+                                        0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x01, 0xDC, 0x48};
+
+    int frameCount = 0;
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; ++frameCount; });
     feed(frame);
 
     ASSERT_EQ(frameCount, 1);
-    EXPECT_EQ(got.opcode, OP_HELLO);
-    ASSERT_EQ(got.payload.size(), HELLO_PAYLOAD_LEN);
-    EXPECT_EQ(got.payload[0], 0x10);
-    EXPECT_EQ(got.payload[13], 0x00);
+    const uint8_t expectedSource[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    const uint8_t expectedHead[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01};
+    for (int i = 0; i < 6; ++i) {
+        EXPECT_EQ(got.source[i], expectedSource[i]);
+        EXPECT_EQ(got.headMac[i], expectedHead[i]);
+    }
+    EXPECT_EQ(got.deviceType, 0x01);
+    EXPECT_EQ(got.confirmed, 0x01);
+}
+
+TEST_F(SerialFrameParserTests, encodeFramedEmitsExactFrameBytes) {
+    // The typed encoder must produce the identical bytes the hand oracle above
+    // expects: preamble + opcode + packed payload + precomputed CRC.
+    HelloPayload hello{};
+    const uint8_t source[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    const uint8_t head[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01};
+    for (int i = 0; i < 6; ++i) {
+        hello.source[i] = source[i];
+        hello.headMac[i] = head[i];
+    }
+    hello.deviceType = 0x01;
+    hello.confirmed = 0x01;
+
+    // Same bytes the decode oracle above pins: preamble, OP_HELLO, payload, CRC 0xDC48.
+    const std::vector<uint8_t> expected = {0xAA, 0x55, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x01,
+                                           0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x01, 0xDC, 0x48};
+    EXPECT_EQ(encodeFramed(hello), expected);
 }
 
 TEST_F(SerialFrameParserTests, encodeFramedRoundTripsThroughParser) {
-    // The encoder is the parser's inverse: a frame produced by encodeFramed
-    // must parse back to the identical opcode + payload.
+    // The typed encoder is the parser's inverse: a HelloPayload framed by
+    // encodeFramed must decode back to the identical field values.
     int frameCount = 0;
-    Frame got;
-    parser.setBinaryFrameHandler([&](const Frame& f) { got = f; ++frameCount; });
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; ++frameCount; });
 
-    std::vector<uint8_t> payload = helloPayload(0xA7);
-    std::vector<uint8_t> frame = encodeFramed(OP_HELLO, payload);
-    feed(frame);
+    HelloPayload sent{};
+    sent.source[0] = 0xA7;
+    sent.deviceType = 0x02;
+    sent.headMac[3] = 0x99;
+    sent.confirmed = 0x01;
+    feed(encodeFramed(sent));
 
     ASSERT_EQ(frameCount, 1);
-    EXPECT_EQ(got.opcode, OP_HELLO);
-    EXPECT_EQ(got.payload, payload);
+    EXPECT_EQ(got.source[0], 0xA7);
+    EXPECT_EQ(got.deviceType, 0x02);
+    EXPECT_EQ(got.headMac[3], 0x99);
+    EXPECT_EQ(got.confirmed, 0x01);
 }
 
 TEST_F(SerialFrameParserTests, badCrcDropsFrame) {
     int frameCount = 0;
-    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
 
     // Full-length frame so the parser consumes everything and actually reaches
     // the CRC comparison. A short payload would end mid-CRC-read and drop the
@@ -118,7 +168,7 @@ TEST_F(SerialFrameParserTests, badCrcDropsFrame) {
 
 TEST_F(SerialFrameParserTests, unknownOpcodeDrops) {
     int frameCount = 0;
-    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
 
     // 0x99 is not an opcode; neither is 0x01 (the fork's BEACON, not ported).
     feed({0xAA, 0x55, 0x99, 0x01, 0x02, 0x03, 0x04});
@@ -132,8 +182,8 @@ TEST_F(SerialFrameParserTests, unknownOpcodeDrops) {
 
 TEST_F(SerialFrameParserTests, fragmentedFrameAssembles) {
     int frameCount = 0;
-    Frame got;
-    parser.setBinaryFrameHandler([&](const Frame& f) { got = f; ++frameCount; });
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; ++frameCount; });
 
     std::vector<uint8_t> frame = buildFrame(OP_HELLO, helloPayload(0x01));
     for (uint8_t b : frame) {
@@ -142,15 +192,13 @@ TEST_F(SerialFrameParserTests, fragmentedFrameAssembles) {
     }
 
     ASSERT_EQ(frameCount, 1);
-    EXPECT_EQ(got.opcode, OP_HELLO);
-    ASSERT_EQ(got.payload.size(), HELLO_PAYLOAD_LEN);
-    EXPECT_EQ(got.payload[0], 0x01);
-    EXPECT_EQ(got.payload[5], 0x60);
+    EXPECT_EQ(got.source[0], 0x01);
+    EXPECT_EQ(got.source[5], 0x60);
 }
 
 TEST_F(SerialFrameParserTests, midFrameTimeoutResets) {
     int frameCount = 0;
-    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
 
     // Inject just the preamble + opcode + partial payload, then stall.
     feed({0xAA, 0x55, OP_HELLO, 0xDE, 0xAD, 0xBE});
@@ -169,7 +217,7 @@ TEST_F(SerialFrameParserTests, requestResetClearsPartialFrameAtNextFeed) {
     // The cross-thread reset used when a jack is declared dead: mid-frame state
     // from the dying connection must not corrupt the next device to plug in.
     int frameCount = 0;
-    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
 
     // Partial frame in flight, then a reset requested from "another thread".
     feed({0xAA, 0x55, OP_HELLO, 0x01, 0x02, 0x03});
@@ -183,8 +231,8 @@ TEST_F(SerialFrameParserTests, requestResetClearsPartialFrameAtNextFeed) {
 
 TEST_F(SerialFrameParserTests, garbageThenValidFrameResyncs) {
     int frameCount = 0;
-    Frame got;
-    parser.setBinaryFrameHandler([&](const Frame& f) { got = f; ++frameCount; });
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; ++frameCount; });
 
     // Leading line noise with no preamble must be discarded, and the parser must
     // resync on the next 0xAA 0x55 rather than swallowing the following frame.
@@ -192,13 +240,12 @@ TEST_F(SerialFrameParserTests, garbageThenValidFrameResyncs) {
     feed(buildFrame(OP_HELLO, helloPayload(0xA1)));
 
     ASSERT_EQ(frameCount, 1);
-    EXPECT_EQ(got.opcode, OP_HELLO);
-    EXPECT_EQ(got.payload[0], 0xA1);
+    EXPECT_EQ(got.source[0], 0xA1);
 }
 
 TEST_F(SerialFrameParserTests, doubleAAResyncsToPreamble) {
     int frameCount = 0;
-    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
 
     // A stray extra 0xAA before the real preamble: GotAA on another 0xAA must
     // stay in GotAA so 0xAA 0xAA 0x55 still opens a frame rather than aborting.
@@ -213,7 +260,7 @@ TEST_F(SerialFrameParserTests, doubleAAResyncsToPreamble) {
 
 TEST_F(SerialFrameParserTests, splitPreambleAcrossFeeds) {
     int frameCount = 0;
-    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
 
     // The 0xAA and 0x55 of the preamble arrive in separate feed() calls; the
     // GotAA state must survive across reads.


### PR DESCRIPTION
Closes #153. Defines the `HelloPayload` wire struct and makes it the sole serial payload type in `SerialFrameParser` — the concrete wire contract the RDC work (#155+) builds on. Also covers Finding 7 (serial payload encoding unification).

- `HelloPayload` (14 bytes, packed): `source[6]`, `deviceType`, `headMac[6]`, `confirmed`, with a `static_assert` tying `sizeof` to `HELLO_PAYLOAD_LEN` so the field layout *is* the wire format. `deviceType` and `confirmed` are carried through for the RDC internals that read them; they're API-ahead-of-consumers, not dead.
- `encodeFramed(const HelloPayload&)` serializes via reinterpret_cast + memcpy (peer-comms-types pattern) and reuses the existing generic framing primitive.
- The parser's output is unified onto one typed handler (`HelloFrameHandler`); on a CRC-valid HELLO frame it memcpys the 14 bytes into a `HelloPayload` and fires it. The proven CRC/resync/timeout state machine is untouched.

**Tests:** an independent oracle — `decodeMapsEveryWireByteToItsField` and `encodeFramedEmitsExactFrameBytes` pin a hand-computed CRC-16/XMODEM (`0xDC48`), so they validate the wire bytes independently rather than mirroring the implementation. 299/299 native; clang-format / check_style / clang-tidy clean.

**Two reviewed-and-kept judgment calls** (flagged by the self-review, deliberately not changed):
- The `payloadBuf.size() == sizeof(HelloPayload)` check before the memcpy is provably always-true under the single-opcode design, but kept as defense-in-depth on externally-fed serial bytes (a future second opcode could break the invariant).
- The generic `encodeFramed(uint8_t, vector)` overload is currently only called by the typed overload, but kept public as the shared framing seam.

_Implemented and self-reviewed via an automated task→PR pipeline (implement → ripoff-bandaids / ponytail-review / code-review → verify → auto-apply-safe / gate-risky → lint gate); the two items above are its gated findings, resolved by hand._
