### PR TITLE
esp-now: hardware ACK as delivery signal; remove kAck (#152)

### DIFF
--- a/lib/core/include/device/drivers/peer-comms-interface.hpp
+++ b/lib/core/include/device/drivers/peer-comms-interface.hpp
@@ -12,11 +12,19 @@ enum class PeerCommsState {
 class PeerCommsInterface {
 public:
     using PacketCallback = std::function<void(const uint8_t* src, const uint8_t* data, const size_t length, void* ctx)>;
+    // Fired once per outbound packet when the radio reports its MAC-layer
+    // result. `dst`/`data`/`length` mirror the send; `success` is the
+    // SEND_SUCCESS/FAIL verdict. Drives the reliable transport's ack in place
+    // of a round-trip ack packet. Default no-op so drivers without a send
+    // callback (or that don't need one) need not implement it.
+    using SendStatusCallback = std::function<void(const uint8_t* dst, const uint8_t* data, const size_t length, bool success, void* ctx)>;
 
     virtual ~PeerCommsInterface() = default;
     virtual int sendData(const uint8_t* dst, PktType packetType, const uint8_t* data, const size_t length) = 0;
     virtual void setPacketHandler(PktType packetType, PacketCallback callback, void* ctx) = 0;
     virtual void clearPacketHandler(PktType packetType) = 0;
+    virtual void setSendStatusHandler(PktType packetType, SendStatusCallback callback, void* ctx) { (void)packetType; (void)callback; (void)ctx; }
+    virtual void clearSendStatusHandler(PktType packetType) { (void)packetType; }
     virtual const uint8_t* getGlobalBroadcastAddress() = 0;
     virtual uint8_t* getMacAddress() = 0;
     virtual void removePeer(uint8_t* macAddr) = 0;

--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -19,14 +19,8 @@ enum class PktType : uint8_t {
     kShootoutCommandAck = 12,
     kSymbolMatchCommand = 13,
     kFdnConnect = 14,
-    ACK = 15,
     kNumPacketTypes  // Not a real packet type, DO NOT USE
 };
-
-struct AckPayload {
-    uint8_t originalType;
-    uint8_t seqId;
-} __attribute__((packed));
 
 struct DataPktHdr
 {

--- a/lib/core/include/device/wireless-manager.hpp
+++ b/lib/core/include/device/wireless-manager.hpp
@@ -214,6 +214,13 @@ public:
     }
 
     /**
+     * Clear the send-status handler for a specific packet type.
+     */
+    void clearEspNowSendStatusHandler(PktType packetType) {
+        peerComms->clearSendStatusHandler(packetType);
+    }
+
+    /**
      * Register a MAC as an ESP-NOW peer, making it eligible for unicast sends.
      */
     int addEspNowPeer(const uint8_t* mac) {

--- a/lib/core/include/device/wireless-manager.hpp
+++ b/lib/core/include/device/wireless-manager.hpp
@@ -196,6 +196,15 @@ public:
     void setEspNowPacketHandler(PktType packetType, PeerCommsInterface::PacketCallback callback, void* ctx) {
         peerComms->setPacketHandler(packetType, callback, ctx);
     }
+
+    /**
+     * Set the radio send-result handler for a packet type. Fires per outbound
+     * packet with the MAC-layer SEND_SUCCESS/FAIL verdict; drives the reliable
+     * transport's ack in place of a round-trip ack packet.
+     */
+    void setEspNowSendStatusHandler(PktType packetType, PeerCommsInterface::SendStatusCallback callback, void* ctx) {
+        peerComms->setSendStatusHandler(packetType, callback, ctx);
+    }
     
     /**
      * Clear packet handler for a specific packet type.

--- a/lib/core/include/wireless/reliable-channel.hpp
+++ b/lib/core/include/wireless/reliable-channel.hpp
@@ -52,6 +52,12 @@ public:
     /// to its onReceive callback. Returns true if delivered.
     virtual bool deliverBytes(const uint8_t* fromMac, const uint8_t* data, size_t len) = 0;
 
+    /// Radio send-result for one of this channel's outbound packets. The typed
+    /// subclass reads the stamped seqId back from `data` and, on success,
+    /// clears the pending entry (replacing the old ack round-trip).
+    virtual void onSendResult(const uint8_t* toMac, const uint8_t* data,
+                              size_t len, bool success) = 0;
+
     /// sizeof the payload struct this channel is typed on. The transport uses
     /// it to tell a same-type re-claim from a different-payload collision on
     /// the same PktType.
@@ -121,19 +127,20 @@ public:
         sendOnceBytes(mac, reinterpret_cast<const uint8_t*>(&p), sizeof(P));
     }
 
-    /// Decode + dispatch one inbound packet: ack first (a retransmit means our
-    /// prior ack was lost), then dedup, then the onReceive callback.
+    /// Decode + dispatch one inbound packet: dedup, then the onReceive
+    /// callback. No ack is emitted; the sender's Resender is cleared by its own
+    /// radio SEND_SUCCESS, not a round-trip. Dedup still matters because a
+    /// sender that missed SEND_SUCCESS retransmits, and the duplicate must be
+    /// suppressed here.
     bool deliver(const uint8_t* fromMac, const uint8_t* data, size_t len) {
         if (len != sizeof(P)) {
-            // Drop without acking: a corrupt/truncated ESP-NOW frame (no CRC on
-            // this path) would otherwise be retransmitted to abandonment with no
-            // trace. Log so it's diagnosable rather than silent.
+            // A corrupt/truncated ESP-NOW frame (no CRC on this path); log so
+            // it's diagnosable rather than silently dropped.
             logLengthMismatch(packetType, len, sizeof(P));
             return false;
         }
         P p;
         std::memcpy(&p, data, sizeof(P));
-        Resender::sendAck(getWirelessManager(), fromMac, packetType, p.seqId);
         if (isDuplicateReliableRx(fromMac, p.seqId)) return true;
         if (onReceiveCallback) onReceiveCallback(fromMac, p);
         return true;
@@ -142,6 +149,20 @@ public:
     /// Untyped entry point used by the transport's rx routing.
     bool deliverBytes(const uint8_t* fromMac, const uint8_t* data, size_t len) override {
         return deliver(fromMac, data, len);
+    }
+
+    /// Radio send-result for one of this channel's outbound packets, routed
+    /// from the driver's send callback via the transport. `data` is the exact
+    /// payload handed to the radio, so the stamped seqId reads straight back
+    /// out. SEND_SUCCESS clears the pending entry (the peer's MAC acked it);
+    /// SEND_FAIL is ignored and left to the backoff timer.
+    void onSendResult(const uint8_t* toMac, const uint8_t* data, size_t len,
+                      bool success) override {
+        if (!success || len != sizeof(P)) return;
+        P p;
+        std::memcpy(&p, data, sizeof(P));
+        if (p.seqId == 0) return;  // fire-and-forget, no pending entry to clear
+        resender->onAck(packetType, p.seqId, toMac);
     }
 
     /// This channel's payload struct size, for the transport's claim guard.

--- a/lib/core/include/wireless/reliable-transport.hpp
+++ b/lib/core/include/wireless/reliable-transport.hpp
@@ -65,8 +65,13 @@ public:
         return raw;
     }
 
-    /// Routes the inbound AckPayload to the owning channel, if any.
-    void onAckPacket(const uint8_t* from, const uint8_t* data, size_t len);
+    /// Routes a radio send-result (SEND_SUCCESS/FAIL for one outbound packet)
+    /// to the channel claiming its PktType. On success the channel reads the
+    /// stamped seqId back out of `data` and clears its pending entry; this is
+    /// what replaces the old ack round-trip. Public so unit tests can drive it
+    /// directly without a radio.
+    void onSendResult(PktType type, const uint8_t* toMac,
+                      const uint8_t* data, size_t len, bool success);
 
     /// Dispatches an inbound data packet to the channel claiming its PktType.
     /// Returns false if no channel is registered.

--- a/lib/core/include/wireless/resender.hpp
+++ b/lib/core/include/wireless/resender.hpp
@@ -54,10 +54,6 @@ public:
     /// Pending entries own their payload copies; nothing external to release.
     ~Resender() = default;
 
-    /// Send the shared ack wire format for a reliably-received packet.
-    static void sendAck(WirelessManager* wm, const uint8_t* toMac,
-                        PktType originalType, uint8_t seqId);
-
     /// Registers the once-per-abandoned-entry callback (see AbandonCallback).
     void setAbandonCallback(AbandonCallback cb) {
         abandonCallback = std::move(cb);
@@ -72,6 +68,12 @@ public:
               SendMode mode = SendMode::SUPERSEDE_PER_TARGET);
 
     /// Clears the matching pending entry. Returns true when one matched.
+    /// Driven by the radio SEND_SUCCESS callback (the peer's MAC ack), which
+    /// replaces the old application-level ACK round-trip. A SEND_FAIL is
+    /// deliberately ignored: the existing backoff timer retransmits on timeout,
+    /// which avoids burning the whole retry budget on a briefly-absent peer.
+    /// (SEND_FAIL as a fast-retry accelerant is left as a follow-up; its
+    /// interaction with backoff is unsettled.)
     bool onAck(PktType type, uint8_t seqId, const uint8_t* fromMac);
 
     /// Silent drop; use when the target is known unreachable. No abandon callback.

--- a/lib/core/src/wireless/reliable-transport.cpp
+++ b/lib/core/src/wireless/reliable-transport.cpp
@@ -24,7 +24,15 @@ ReliableTransport::~ReliableTransport() {
         entry.second = nullptr;
     }
     registry.clear();
+    // Unregister the driver callbacks before freeing their ctx cells: each
+    // ReceiveBinding is the void* ctx held by the driver's per-type receive and
+    // send-status handlers, so a packet arriving after this dtor would otherwise
+    // dispatch into freed memory.
     for (ReceiveBinding*& binding : receiveBindings) {
+        if (wirelessManager != nullptr) {
+            wirelessManager->clearEspNowPacketHandler(binding->type);
+            wirelessManager->clearEspNowSendStatusHandler(binding->type);
+        }
         delete binding;
         binding = nullptr;
     }

--- a/lib/core/src/wireless/reliable-transport.cpp
+++ b/lib/core/src/wireless/reliable-transport.cpp
@@ -16,15 +16,6 @@ ReliableTransport::ReliableTransport(WirelessManager* wm)
         [this](PktType type, uint8_t seqId, const uint8_t* targetMac) {
             onResenderAbandon(type, seqId, targetMac);
         });
-    if (wirelessManager != nullptr) {
-        wirelessManager->setEspNowPacketHandler(
-            PktType::ACK,
-            [](const uint8_t* src, const uint8_t* data, const size_t len,
-               void* ctx) {
-                static_cast<ReliableTransport*>(ctx)->onAckPacket(src, data, len);
-            },
-            this);
-    }
 }
 
 ReliableTransport::~ReliableTransport() {
@@ -44,6 +35,7 @@ void ReliableTransport::ensurePacketCallback(PktType type) {
     // Only ever called on a channel's first claim of `type` (channel() returns
     // early on a re-claim), so the binding is always new — no dedup needed.
     receiveBindings.push_back(new ReceiveBinding{this, type});
+    ReceiveBinding* binding = receiveBindings.back();
     if (wirelessManager == nullptr) return;
     wirelessManager->setEspNowPacketHandler(
         type,
@@ -52,18 +44,23 @@ void ReliableTransport::ensurePacketCallback(PktType type) {
             ReceiveBinding* b = static_cast<ReceiveBinding*>(ctx);
             b->transport->deliverIncoming(b->type, src, data, len);
         },
-        receiveBindings.back());
+        binding);
+    wirelessManager->setEspNowSendStatusHandler(
+        type,
+        [](const uint8_t* dst, const uint8_t* data, const size_t len,
+           bool success, void* ctx) {
+            ReceiveBinding* b = static_cast<ReceiveBinding*>(ctx);
+            b->transport->onSendResult(b->type, dst, data, len, success);
+        },
+        binding);
 }
 
-void ReliableTransport::onAckPacket(const uint8_t* from,
-                                    const uint8_t* data, size_t len) {
-    if (len < sizeof(AckPayload)) return;
-    AckPayload ack;
-    std::memcpy(&ack, data, sizeof(ack));
-    PktType origType = static_cast<PktType>(ack.originalType);
-    std::map<PktType, ReliableChannelBase*>::iterator it = registry.find(origType);
+void ReliableTransport::onSendResult(PktType type, const uint8_t* toMac,
+                                     const uint8_t* data, size_t len,
+                                     bool success) {
+    std::map<PktType, ReliableChannelBase*>::iterator it = registry.find(type);
     if (it == registry.end()) return;
-    it->second->onAck(ack.seqId, from);
+    it->second->onSendResult(toMac, data, len, success);
 }
 
 bool ReliableTransport::deliverIncoming(PktType type, const uint8_t* fromMac,

--- a/lib/core/src/wireless/resender.cpp
+++ b/lib/core/src/wireless/resender.cpp
@@ -7,17 +7,6 @@ namespace {
 constexpr const char* RSND_TAG = "RSND";
 }
 
-void Resender::sendAck(WirelessManager* wm, const uint8_t* toMac,
-                       PktType originalType, uint8_t seqId) {
-    if (wm == nullptr || toMac == nullptr) return;
-    // seqId=0 is the fire-and-forget sentinel; no sender-side pending entry
-    // exists for the ack to match, so emitting one wastes airtime.
-    if (seqId == 0) return;
-    AckPayload payload{static_cast<uint8_t>(originalType), seqId};
-    wm->sendEspNowData(toMac, PktType::ACK,
-                       reinterpret_cast<const uint8_t*>(&payload), sizeof(payload));
-}
-
 void Resender::send(const uint8_t* target, PktType type, uint8_t seqId,
                     const uint8_t* payload, size_t len, SendMode mode) {
     if (target == nullptr) return;

--- a/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
+++ b/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
@@ -81,6 +81,21 @@ public:
             }
             pending.pop();
         }
+
+        std::queue<DeferredSendResult> sendResults;
+        xSemaphoreTake(sendResultMutex, portMAX_DELAY);
+        std::swap(sendResults, sendResultQueue);
+        xSemaphoreGive(sendResultMutex);
+
+        while (!sendResults.empty()) {
+            auto& r = sendResults.front();
+            SendStatusCallback cb = sendStatusHandlers_[(int)r.type].first;
+            if (cb) {
+                cb(r.dstMac, r.data.data(), r.data.size(), r.success,
+                   sendStatusHandlers_[(int)r.type].second);
+            }
+            sendResults.pop();
+        }
     }
 
     /// Brings the radio into ESP-NOW mode: STA, auto-reconnect off, PS_NONE,
@@ -214,6 +229,19 @@ public:
         pktHandlerCallbacks[(int)packetType].first = nullptr;
     }
 
+    /// Radio send-result handler, one per PktType. Fired from exec() (deferred
+    /// to the main loop) when the send callback reports SEND_SUCCESS or a final
+    /// SEND_FAIL for a packet of this type. Drives the reliable-transport ack.
+    void setSendStatusHandler(PktType packetType, SendStatusCallback callback, void* ctx) override {
+        sendStatusHandlers_[(int)packetType].first = callback;
+        sendStatusHandlers_[(int)packetType].second = ctx;
+    }
+
+    /// Removes the send-result handler for a packet type.
+    void clearSendStatusHandler(PktType packetType) override {
+        sendStatusHandlers_[(int)packetType].first = nullptr;
+    }
+
     // Called by DriverManager at startup - we don't initialize ESP-NOW here
     // because WiFi must be set up first. Actual init happens in connect().
     /// Driver-interface initialization hook; radio setup happens in connect().
@@ -261,6 +289,16 @@ private:
         std::vector<uint8_t> data;
     };
 
+    // A send callback result queued off the WiFi-task callback for the main
+    // loop to dispatch. `data` is the payload (past the DataPktHdr) of the
+    // packet that was sent, so the reliable channel can read its seqId back out.
+    struct DeferredSendResult {
+        PktType type;
+        uint8_t dstMac[6];
+        std::vector<uint8_t> data;
+        bool success;
+    };
+
     struct DataSendBuffer
     {
         uint8_t dstMac[6];
@@ -271,10 +309,12 @@ private:
     explicit EspNowManager(const std::string& name)
         : PeerCommsDriverInterface(name)
         , pktHandlerCallbacks((int)PktType::kNumPacketTypes, std::pair<PacketCallback, void*>(nullptr, nullptr))
+        , sendStatusHandlers_((int)PktType::kNumPacketTypes, std::pair<SendStatusCallback, void*>(nullptr, nullptr))
         , maxRetries(5)
         , curRetries(0)
         , recvMutex(xSemaphoreCreateMutex())
         , sendMutex(xSemaphoreCreateMutex()) {
+        sendResultMutex = xSemaphoreCreateMutex();
         // ESP-NOW initialization happens in connect() -> initializeEspNow()
         // after WiFi has been set up. RSSI is read directly from each receive
         // callback (esp_now_recv_info_t::rx_ctrl), so no promiscuous mode.
@@ -366,6 +406,7 @@ private:
         // enums share values (ESP_NOW_SEND_SUCCESS == WIFI_SEND_SUCCESS).
         if (esp_now_info->tx_status == WIFI_SEND_SUCCESS) {
             LOG_D("ENC", "Send SUCCESS");
+            manager->deferSendResult(true);
             manager->MoveToNextSendPkt();
         } else {
             if (manager->curRetries < manager->maxRetries) {
@@ -375,6 +416,7 @@ private:
             } else {
                 LOG_E("ENC", "Send FAILED - giving up after %d retries",
                       manager->maxRetries);
+                manager->deferSendResult(false);
                 manager->MoveToNextSendPkt();
             }
         }
@@ -429,6 +471,32 @@ private:
         curRetries = 0;
     }
 
+    // Snapshot the just-finished send (still at sendQueue.front()) onto the
+    // deferred queue for exec() to dispatch on the main loop. Call BEFORE
+    // MoveToNextSendPkt, which frees the front buffer. Broadcast/unsequenced
+    // sends are queued too; the reliable channel drops them (no seqId match).
+    void deferSendResult(bool success) {
+        DeferredSendResult res;
+        bool have = false;
+        xSemaphoreTake(sendMutex, portMAX_DELAY);
+        if (!sendQueue.empty()) {
+            const DataSendBuffer& buf = sendQueue.front();
+            const DataPktHdr* hdr = reinterpret_cast<const DataPktHdr*>(buf.ptr);
+            res.type = hdr->packetType;
+            memcpy(res.dstMac, buf.dstMac, 6);
+            const uint8_t* payload = buf.ptr + sizeof(DataPktHdr);
+            size_t payloadLen = buf.len > sizeof(DataPktHdr) ? buf.len - sizeof(DataPktHdr) : 0;
+            res.data.assign(payload, payload + payloadLen);
+            res.success = success;
+            have = true;
+        }
+        xSemaphoreGive(sendMutex);
+        if (!have) return;
+        xSemaphoreTake(sendResultMutex, portMAX_DELAY);
+        sendResultQueue.push(std::move(res));
+        xSemaphoreGive(sendResultMutex);
+    }
+
     void clearSendQueue() {
         xSemaphoreTake(sendMutex, portMAX_DELAY);
         while (!sendQueue.empty()) {
@@ -478,6 +546,8 @@ private:
 
     //Storage for packet handler callbacks and their user args
     std::vector<std::pair<PacketCallback, void*>> pktHandlerCallbacks;
+    // Send-result handlers, one per PktType, mirroring pktHandlerCallbacks.
+    std::vector<std::pair<SendStatusCallback, void*>> sendStatusHandlers_;
 
     void HandlePktCallback(const PktType packetType, const uint8_t* srcMacAddr, const uint8_t* pktData, const size_t pktLen) {
         if((int)packetType >= (int)PktType::kNumPacketTypes)
@@ -550,6 +620,12 @@ private:
 
     //Packet send queue
     std::queue<DataSendBuffer> sendQueue;
+
+    // Deferred send-result queue: the WiFi-task send callback snapshots each
+    // finished send here; exec() drains it on the main loop so the reliable
+    // transport ack never races Resender::sync().
+    SemaphoreHandle_t sendResultMutex;
+    std::queue<DeferredSendResult> sendResultQueue;
 
     // Storage for rssi, filled from each ESP-NOW receive callback (rx_ctrl)
     std::unordered_map<uint64_t, int> rssiTracker;

--- a/test/test_core/reliable-channel-tests.hpp
+++ b/test/test_core/reliable-channel-tests.hpp
@@ -17,6 +17,8 @@ public:
     bool deliverBytes(const uint8_t*, const uint8_t*, size_t) override { return false; }
     /// Untyped probe: no payload struct, so report 0.
     size_t payloadSize() const override { return 0; }
+    /// No-op: this probe exercises only the base's seqId/dedup helpers.
+    void onSendResult(const uint8_t*, const uint8_t*, size_t, bool) override {}
 };
 
 TEST(ReliableChannelBaseTest, nextSeqIdWrapsAfter255) {

--- a/test/test_core/reliable-transport-tests.hpp
+++ b/test/test_core/reliable-transport-tests.hpp
@@ -94,8 +94,12 @@ TEST(ReliableTransportTest, sendReliableTriggersAck) {
     ASSERT_NE(seq, 0);
     ASSERT_TRUE(ch->isPending(target));
 
-    AckPayload ack{static_cast<uint8_t>(PktType::kChainGameEvent), seq};
-    transport.onAckPacket(target, reinterpret_cast<const uint8_t*>(&ack), sizeof(ack));
+    // Radio SEND_SUCCESS for the packet we sent clears the pending entry. The
+    // channel reads the stamped seqId back out of the echoed payload bytes.
+    TransportTestPayload sentEcho{};
+    sentEcho.seqId = seq;
+    transport.onSendResult(PktType::kChainGameEvent, target,
+                           reinterpret_cast<const uint8_t*>(&sentEcho), sizeof(sentEcho), true);
     ASSERT_FALSE(ch->isPending(target));
     ASSERT_FALSE(abandoned);
 
@@ -231,8 +235,10 @@ TEST(ReliableTransportTest, ackRoutesByPktType) {
     ASSERT_TRUE(chA->isPending(target));
     ASSERT_TRUE(chB->isPending(target));
 
-    AckPayload ack{static_cast<uint8_t>(PktType::kShootoutCommand), seqA};
-    transport.onAckPacket(target, reinterpret_cast<const uint8_t*>(&ack), sizeof(ack));
+    TransportTestPayload sentEcho{};
+    sentEcho.seqId = seqA;
+    transport.onSendResult(PktType::kShootoutCommand, target,
+                           reinterpret_cast<const uint8_t*>(&sentEcho), sizeof(sentEcho), true);
 
     ASSERT_FALSE(chA->isPending(target));
     ASSERT_TRUE(chB->isPending(target));
@@ -273,8 +279,10 @@ TEST(ReliableTransportTest, droppedNonFinalSlotStillRetransmits) {
 
     // Peer acks the two later slots; s1 stays pending.
     for (uint8_t seq : {s2, s3}) {
-        AckPayload ack{static_cast<uint8_t>(PktType::kShootoutCommand), seq};
-        transport.onAckPacket(target, reinterpret_cast<const uint8_t*>(&ack), sizeof(ack));
+        TransportTestPayload sentEcho{};
+        sentEcho.seqId = seq;
+        transport.onSendResult(PktType::kShootoutCommand, target,
+                               reinterpret_cast<const uint8_t*>(&sentEcho), sizeof(sentEcho), true);
     }
     ASSERT_TRUE(ch->isPending(target));  // s1 survived the later sends
 

--- a/test/test_core/reliable-transport-tests.hpp
+++ b/test/test_core/reliable-transport-tests.hpp
@@ -115,6 +115,64 @@ TEST(ReliableTransportTest, sendReliableTriggersAck) {
     ASSERT_EQ(deliveredP.cmd, 99);
 }
 
+TEST(ReliableTransportTest, sendFailLeavesPendingForBackoffRetry) {
+    ::testing::NiceMock<MockPeerComms> mockComms;
+    WirelessManager wm(&mockComms, nullptr);
+    ReliableTransport transport(&wm);
+
+    ReliableChannel<TransportTestPayload>* ch = transport.channel<TransportTestPayload>(
+        PktType::kChainGameEvent,
+        [](uint8_t, const uint8_t*) {});
+
+    using ::testing::_;
+    using ::testing::Return;
+    EXPECT_CALL(mockComms, sendData(_, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(Return(1));
+
+    uint8_t target[6] = {1, 2, 3, 4, 5, 6};
+    TransportTestPayload p{};
+    uint8_t seq = ch->sendReliable(target, p);
+    ASSERT_TRUE(ch->isPending(target));
+
+    // A SEND_FAIL must NOT clear the pending entry: loss is left to the backoff
+    // timer, so the entry stays armed for retransmit.
+    TransportTestPayload sentEcho{};
+    sentEcho.seqId = seq;
+    transport.onSendResult(PktType::kChainGameEvent, target,
+                           reinterpret_cast<const uint8_t*>(&sentEcho), sizeof(sentEcho), false);
+    EXPECT_TRUE(ch->isPending(target));
+}
+
+TEST(ReliableTransportTest, sendResultSeqIdZeroDoesNotAck) {
+    ::testing::NiceMock<MockPeerComms> mockComms;
+    WirelessManager wm(&mockComms, nullptr);
+    ReliableTransport transport(&wm);
+
+    ReliableChannel<TransportTestPayload>* ch = transport.channel<TransportTestPayload>(
+        PktType::kChainGameEvent,
+        [](uint8_t, const uint8_t*) {});
+
+    using ::testing::_;
+    using ::testing::Return;
+    EXPECT_CALL(mockComms, sendData(_, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(Return(1));
+
+    uint8_t target[6] = {1, 2, 3, 4, 5, 6};
+    TransportTestPayload p{};
+    ch->sendReliable(target, p);  // stamps a nonzero seqId
+    ASSERT_TRUE(ch->isPending(target));
+
+    // A fire-and-forget send-result (seqId 0) has no sender-side pending entry
+    // to match, so it must not clear the live reliable pending entry.
+    TransportTestPayload fireAndForget{};
+    fireAndForget.seqId = 0;
+    transport.onSendResult(PktType::kChainGameEvent, target,
+                           reinterpret_cast<const uint8_t*>(&fireAndForget), sizeof(fireAndForget), true);
+    EXPECT_TRUE(ch->isPending(target));
+}
+
 TEST(ReliableTransportTest, abandonAfterMaxRetries) {
     ::testing::NiceMock<MockPeerComms> mockComms;
     WirelessManager wm(&mockComms, nullptr);


### PR DESCRIPTION
Closes #152 (the remove-kAck half). Drives the reliable transport's ack off the ESP-NOW `SEND_SUCCESS` callback and deletes the `PktType::ACK` round-trip.

## Where to look

- **`esp-now-driver.hpp`** is the part that needs the most eyes. IDF's send callback only gives mac+status, so the driver snapshots the just-sent packet (`deferSendResult`) and drains it in `exec()` on the main loop. That deferral is deliberate: the callback runs on the WiFi task, and dispatching the ack inline would race `Resender::sync()` on the main loop. The correlation assumes the callback maps to `sendQueue.front()`, which holds because the driver sends serially.
- **`reliable-channel.hpp` `onSendResult`** reads the stamped seqId back out of the echoed outbound bytes, so it works for both SUPERSEDE and KEEP_DISTINCT channels.

## Deliberate choices worth a look

- **`SEND_FAIL` is ignored**, not turned into a fast retry. Rapid fails to a briefly-absent peer would otherwise burn the whole retry budget in milliseconds and abandon instantly. The existing backoff timer still handles loss. The fast-retry accelerant is left as a follow-up (its backoff interaction is unsettled).
- Semantics caveat stands: `SEND_SUCCESS` is a MAC-layer ack, not app-delivery. This is safe now only because nothing consumes the shared transport yet; the consumer decides whether it needs more (per the deep-research on #152).

## Validation

- Native suite green (297/297); the transport ack tests now drive `onSendResult` instead of injecting an ACK packet.
- ESP32 firmware compiles.
- **Not** runtime-validated: native can't exercise the driver, and I haven't run hardware. The deferred send-result path under real send-callback timing needs a bench check before anything relies on it.