### PR TITLE
rdc: per-jack HELLO connectivity, emission, and connectivity task (#155)

### DIFF
--- a/lib/core/include/device/drivers/serial-wrapper.hpp
+++ b/lib/core/include/device/drivers/serial-wrapper.hpp
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <functional>
 
 using SerialStringCallback = std::function<void(std::string)>;
+using SerialByteCallback = std::function<void(uint8_t)>;
 
 enum class SerialIdentifier {
     OUTPUT_JACK = 0,
@@ -28,4 +30,9 @@ class HWSerialWrapper {
     virtual void println(const std::string& msg) = 0;
     virtual void flush() = 0;
     virtual void setStringCallback(const SerialStringCallback& callback) = 0;
+    /// When a byte callback is set, exec() routes each RX byte to it and does NOT
+    /// assemble strings on this jack; a null byte callback leaves the legacy
+    /// string path untouched. HELLO framing and delimited strings share one RX
+    /// pump and are mutually exclusive per jack.
+    virtual void setByteCallback(const SerialByteCallback& callback) = 0;
 };

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -12,7 +12,7 @@
 
 // Per-jack HELLO link state machine (#155). One instance per jack, driven by the
 // RDC. Three states — Idle / Connecting / Connected — on the project's StateMachine
-// framework, replacing the enum the first cut used.
+// framework.
 //
 // Liveness (lastHelloMs) is inherently cross-state: every HELLO refreshes the
 // watchdog in Connecting and Connected alike, so it lives on this shared context,

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -1,0 +1,169 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <utility>
+
+#include "state/state-machine.hpp"
+#include "device/serial-manager.hpp"
+#include "device/serial-frame-parser.hpp"
+
+// Per-jack HELLO link state machine (#155). One instance per jack, driven by the
+// RDC. Three states — Idle / Connecting / Connected — on the project's StateMachine
+// framework, replacing the enum the first cut used.
+//
+// Liveness (lastHelloMs) is inherently cross-state: every HELLO refreshes the
+// watchdog in Connecting and Connected alike, so it lives on this shared context,
+// not on any one State. The per-transition triggers stay where the framework wants
+// them — private flags on the state that owns the edge, set by the machine's event
+// inputs and read by the transition predicates.
+
+enum HelloLinkStateId {
+    HELLO_LINK_MACHINE = 89,
+    HELLO_LINK_IDLE = 90,
+    HELLO_LINK_CONNECTING = 91,
+    HELLO_LINK_CONNECTED = 92,
+};
+
+struct HelloLinkContext {
+    SerialIdentifier jack{};
+    std::function<unsigned long()> nowMs;
+    std::function<void(SerialIdentifier)> onContextRequest;   // OUT jack only
+    std::function<void(SerialIdentifier, bool)> onJackChange;  // connect / disconnect
+    std::function<void()> resetParser;                         // on link death
+
+    unsigned long silentLinkMs = 100;
+    unsigned long contextTimeoutMs = 500;
+
+    unsigned long lastHelloMs = 0;
+    std::array<uint8_t, 6> peerMac{};  // source MAC last heard; consumed by #157
+
+    // Silent-link gap with the unsigned-underflow clamp: the UART task can stamp
+    // lastHelloMs just after now is read, so now - lastHelloMs would wrap to ~UINT_MAX.
+    unsigned long sinceHello() const {
+        const unsigned long now = nowMs();
+        return now >= lastHelloMs ? now - lastHelloMs : 0;
+    }
+};
+
+class HelloIdleState : public State {
+public:
+    explicit HelloIdleState(HelloLinkContext* context) : State(HELLO_LINK_IDLE), context(context) {}
+
+    void onStateMounted(Device*) override { transitionToConnectingState = false; }
+
+    void arm() { transitionToConnectingState = true; }
+    bool transitionToConnecting() { return transitionToConnectingState; }
+
+private:
+    HelloLinkContext* context = nullptr;
+    bool transitionToConnectingState = false;
+};
+
+class HelloConnectingState : public State {
+public:
+    explicit HelloConnectingState(HelloLinkContext* context)
+        : State(HELLO_LINK_CONNECTING), context(context) {}
+
+    void onStateMounted(Device*) override {
+        connectingSinceMs = context->nowMs();
+        transitionToConnectedState = false;
+        // Output-jack-initiates: only the OUT jack requests the context exchange.
+        if (context->jack == SerialIdentifier::OUTPUT_JACK && context->onContextRequest) {
+            context->onContextRequest(context->jack);
+        }
+    }
+
+    void markContextComplete() { transitionToConnectedState = true; }
+    bool transitionToConnected() { return transitionToConnectedState; }
+
+    // No HELLO within the silent-link window, or a context exchange that never
+    // completes, drops the link back to Idle.
+    bool transitionToIdle() {
+        const unsigned long now = context->nowMs();
+        const unsigned long connecting =
+            now >= connectingSinceMs ? now - connectingSinceMs : 0;
+        return context->sinceHello() > context->silentLinkMs ||
+               connecting > context->contextTimeoutMs;
+    }
+
+private:
+    HelloLinkContext* context = nullptr;
+    unsigned long connectingSinceMs = 0;
+    bool transitionToConnectedState = false;
+};
+
+class HelloConnectedState : public State {
+public:
+    explicit HelloConnectedState(HelloLinkContext* context)
+        : State(HELLO_LINK_CONNECTED), context(context) {}
+
+    void onStateMounted(Device*) override {
+        if (context->onJackChange) context->onJackChange(context->jack, true);
+    }
+
+    // Leaving Connected means the link died: fire the disconnect and reset the
+    // parser so a half-read frame from the dying peer cannot merge into the next
+    // device that plugs in.
+    void onStateDismounted(Device*) override {
+        if (context->onJackChange) context->onJackChange(context->jack, false);
+        if (context->resetParser) context->resetParser();
+    }
+
+    bool transitionToIdle() { return context->sinceHello() > context->silentLinkMs; }
+
+private:
+    HelloLinkContext* context = nullptr;
+};
+
+class HelloLinkMachine : public StateMachine {
+public:
+    explicit HelloLinkMachine(HelloLinkContext context)
+        : StateMachine(HELLO_LINK_MACHINE), context(std::move(context)) {}
+
+    void populateStateMap() override {
+        auto* idle = new HelloIdleState(&context);
+        auto* connecting = new HelloConnectingState(&context);
+        auto* connected = new HelloConnectedState(&context);
+
+        idle->addTransition(new StateTransition(
+            [idle] { return idle->transitionToConnecting(); }, connecting));
+        connecting->addTransition(new StateTransition(
+            [connecting] { return connecting->transitionToConnected(); }, connected));
+        connecting->addTransition(new StateTransition(
+            [connecting] { return connecting->transitionToIdle(); }, idle));
+        connected->addTransition(new StateTransition(
+            [connected] { return connected->transitionToIdle(); }, idle));
+
+        stateMap.push_back(idle);  // index 0 = initial state
+        stateMap.push_back(connecting);
+        stateMap.push_back(connected);
+    }
+
+    // A HELLO stamps liveness on every state; it only opens a new link while Idle.
+    // The self-echo / all-zero reject happens upstream in the RDC (it owns selfMac).
+    void onHelloReceived(const HelloPayload& hello) {
+        context.lastHelloMs = context.nowMs();
+        memcpy(context.peerMac.data(), hello.source, 6);
+        if (currentState && currentState->getStateId() == HELLO_LINK_IDLE) {
+            static_cast<HelloIdleState*>(currentState)->arm();
+        }
+    }
+
+    // #157 drives this when the context exchange completes; only meaningful while
+    // Connecting (mirrors the enum's state guard).
+    void onContextExchangeComplete() {
+        if (currentState && currentState->getStateId() == HELLO_LINK_CONNECTING) {
+            static_cast<HelloConnectingState*>(currentState)->markContextComplete();
+        }
+    }
+
+    int currentStateId() const {
+        return currentState ? currentState->getStateId() : HELLO_LINK_IDLE;
+    }
+
+private:
+    HelloLinkContext context;
+};

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <optional>
@@ -158,6 +159,12 @@ public:
     /// on a separate FreeRTOS task while the main loop owns everything else.
     void emitHello();
 
+#ifndef NATIVE_BUILD
+    /// FreeRTOS task body: emit at HELLO_CADENCE_MS until the destructor requests
+    /// a stop, then self-delete. A member so it can read the stop flags directly.
+    void connectivityTaskBody();
+#endif
+
     /// #157 drives this once the context exchange completes: CONNECTING->CONNECTED
     /// and fires the jack-connect observer.
     void onContextExchangeComplete(SerialIdentifier jack);
@@ -303,6 +310,11 @@ private:
     DeviceType selfDeviceType = DeviceType::UNKNOWN;
 #ifndef NATIVE_BUILD
     TaskHandle_t connectivityTaskHandle = nullptr;
+    // Cooperative stop: the destructor sets stopRequested and waits for the task
+    // to observe it and self-delete (setting exited), rather than a cross-core
+    // vTaskDelete that could truncate an in-flight emit or strand the UART lock.
+    std::atomic<bool> connectivityTaskStopRequested{false};
+    std::atomic<bool> connectivityTaskExited{false};
     static constexpr uint32_t kConnectivityTaskStack = 4096;
     static constexpr unsigned kConnectivityTaskPriority = 1;
 #endif

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -300,6 +300,7 @@ private:
         HelloLinkState state = HelloLinkState::IDLE;
         unsigned long lastHelloMs = 0;
         unsigned long connectingSinceMs = 0;
+        std::array<uint8_t, 6> peerMac{};  // source MAC last heard on this jack
         SerialFrameParser parser;  // non-copyable; default-constructed in place
     };
     std::array<JackHelloLink, kNumPorts> helloByPort_;

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -291,8 +291,6 @@ private:
     // ---- HELLO connectivity internals (#155) ----
     struct JackHelloLink {
         HelloLinkState state = HelloLinkState::IDLE;
-        std::array<uint8_t, 6> sourceMac{};
-        bool hasSource = false;
         unsigned long lastHelloMs = 0;
         unsigned long connectingSinceMs = 0;
         SerialFrameParser parser;  // non-copyable; default-constructed in place

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -19,6 +19,7 @@
 
 class Device;
 class HandshakeApp;
+class HelloLinkMachine;
 
 enum class PortStatus {
     DISCONNECTED = 0,  // No Connection. Handshake is in Idle state.
@@ -151,7 +152,7 @@ public:
     void enableHelloConnectivity();
 
     /// Native/test hook: suppress the FreeRTOS emit-task spawn so the caller
-    /// drives emitHello()/serviceConnectivity() directly on one thread.
+    /// drives emitHello() and the per-jack link machines (via sync()) on one thread.
     void setExternalConnectivityTask(bool external) { externalConnectivityTask = external; }
 
     /// The connectivity task's sole action: emit one HELLO frame on every jack.
@@ -297,11 +298,8 @@ private:
 
     // ---- HELLO connectivity internals (#155) ----
     struct JackHelloLink {
-        HelloLinkState state = HelloLinkState::IDLE;
-        unsigned long lastHelloMs = 0;
-        unsigned long connectingSinceMs = 0;
-        std::array<uint8_t, 6> peerMac{};  // source MAC last heard on this jack
         SerialFrameParser parser;  // non-copyable; default-constructed in place
+        HelloLinkMachine* machine = nullptr;  // per-jack link SM; owned, deleted in dtor
     };
     std::array<JackHelloLink, kNumPorts> helloByPort_;
     bool helloConnectivityEnabled = false;
@@ -323,8 +321,6 @@ private:
     HWSerialWrapper* jackWrapper(SerialIdentifier port) const;
     bool isHelloJack(SerialIdentifier port) const;
     void onHelloReceived(SerialIdentifier jack, const HelloPayload& hello);
-    void serviceConnectivity();
-    void resetHelloLink(JackHelloLink& link);
     PortStatus mapHelloLinkToStatus(SerialIdentifier port) const;
     static unsigned long nowMs();
 };

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -6,9 +6,15 @@
 #include <optional>
 #include <vector>
 #include "device/serial-manager.hpp"
+#include "device/serial-frame-parser.hpp"
 #include "utils/simple-timer.hpp"
 #include "wireless/handshake-wireless-manager.hpp"
 #include "device/device-type.hpp"
+
+#ifndef NATIVE_BUILD
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#endif
 
 class Device;
 class HandshakeApp;
@@ -114,6 +120,50 @@ public:
     void setOnJackChange(JackChangeCallback callback) {
         jackChangeCallback = std::move(callback);
     }
+
+    // ---- Per-jack HELLO connectivity (#155) ----
+    // HELLO is the serial discovery/liveness beacon that replaces the string
+    // handshake (deleted by #160). Each jack runs an independent link SM fed by
+    // the real exec()-driven RX byte pump. Off by default: production stays on
+    // the handshake until the context exchange (#157) and device chain SM (#156)
+    // land, since nothing drives CONNECTING->CONNECTED before then.
+
+    static constexpr unsigned long HELLO_CADENCE_MS = 20;
+    static constexpr unsigned long HELLO_SILENT_LINK_MS = 100;
+    // A link stuck mid-context-exchange past this falls back to IDLE (#157).
+    static constexpr unsigned long CONTEXT_EXCHANGE_TIMEOUT_MS = 500;
+
+    enum class HelloLinkState { IDLE,
+                                CONNECTING,
+                                CONNECTED };
+
+    // Fires on the OUT jack when a new HELLO source appears: the output jack
+    // initiates the context request (#157 placeholder). The IN jacks never do.
+    using ContextRequestCallback = std::function<void(SerialIdentifier jack)>;
+    /// Registers the output-jack context-request initiator (#157 placeholder).
+    void setOnContextRequest(ContextRequestCallback callback) {
+        contextRequestCallback = std::move(callback);
+    }
+
+    /// Wires byte callbacks + parsers on every present jack, quiesces the
+    /// handshake, and (unless external) spawns the emit task. Idempotent.
+    void enableHelloConnectivity();
+
+    /// Native/test hook: suppress the FreeRTOS emit-task spawn so the caller
+    /// drives emitHello()/serviceConnectivity() directly on one thread.
+    void setExternalConnectivityTask(bool external) { externalConnectivityTask = external; }
+
+    /// The connectivity task's sole action: emit one HELLO frame on every jack.
+    /// TX only — touches no SM state and fires no callback, so it is safe to run
+    /// on a separate FreeRTOS task while the main loop owns everything else.
+    void emitHello();
+
+    /// #157 drives this once the context exchange completes: CONNECTING->CONNECTED
+    /// and fires the jack-connect observer.
+    void onContextExchangeComplete(SerialIdentifier jack);
+
+    /// This jack's HELLO link state (observability / tests).
+    HelloLinkState getHelloLinkState(SerialIdentifier jack) const;
 
     /// Registers the chain-role transition observer.
     void setOnChainRoleChange(ChainRoleChangeCallback callback) {
@@ -237,4 +287,33 @@ private:
     // Returns the list of ports that have active handshake apps.
     std::vector<SerialIdentifier> activePorts() const;
     HandshakeApp* handshakeAppForPort(SerialIdentifier port) const;
+
+    // ---- HELLO connectivity internals (#155) ----
+    struct JackHelloLink {
+        HelloLinkState state = HelloLinkState::IDLE;
+        std::array<uint8_t, 6> sourceMac{};
+        bool hasSource = false;
+        unsigned long lastHelloMs = 0;
+        unsigned long connectingSinceMs = 0;
+        SerialFrameParser parser;  // non-copyable; default-constructed in place
+    };
+    std::array<JackHelloLink, kNumPorts> helloByPort_;
+    bool helloConnectivityEnabled = false;
+    bool externalConnectivityTask = false;
+    ContextRequestCallback contextRequestCallback;
+    std::array<uint8_t, 6> selfMac_{};
+    DeviceType selfDeviceType = DeviceType::UNKNOWN;
+#ifndef NATIVE_BUILD
+    TaskHandle_t connectivityTaskHandle = nullptr;
+    static constexpr uint32_t kConnectivityTaskStack = 4096;
+    static constexpr unsigned kConnectivityTaskPriority = 1;
+#endif
+
+    HWSerialWrapper* jackWrapper(SerialIdentifier port) const;
+    bool isHelloJack(SerialIdentifier port) const;
+    void onHelloReceived(SerialIdentifier jack, const HelloPayload& hello);
+    void serviceConnectivity();
+    void resetHelloLink(JackHelloLink& link);
+    PortStatus mapHelloLinkToStatus(SerialIdentifier port) const;
+    static unsigned long nowMs();
 };

--- a/lib/core/include/device/serial-frame-parser.hpp
+++ b/lib/core/include/device/serial-frame-parser.hpp
@@ -14,25 +14,34 @@
 constexpr uint8_t FRAME_PREAMBLE_0 = 0xAA;
 constexpr uint8_t FRAME_PREAMBLE_1 = 0x55;
 constexpr uint8_t OP_HELLO = 0x00;
-// Payload bytes after the opcode, before the CRC: source mac[6] +
-// deviceType[1] + headMac[6] + confirmed[1]. The packed HelloPayload struct
-// that owns this layout arrives with the HELLO wire-format work; the parser
-// only needs the length to frame it.
+// Payload bytes after the opcode, before the CRC. Owned by the packed
+// HelloPayload struct below; the constant lets the parser frame the payload
+// without depending on the struct in switch tables.
 constexpr size_t HELLO_PAYLOAD_LEN = 14;
 
-// Wraps a payload in the framed wire format: preamble, opcode, payload,
+// The sole serial payload, exchanged jack-to-jack on every HELLO frame.
+// Packed to a fixed 14-byte wire layout: the parser memcpys the raw payload
+// straight into this struct, so the field order and packing ARE the wire
+// contract.
+struct HelloPayload {
+    uint8_t source[6];   // this device's WiFi MAC
+    uint8_t deviceType;  // DeviceType value; discriminates ConnectionContext deser
+    uint8_t headMac[6];  // chain head MAC, all-zero if head/standalone; hop-propagated
+    uint8_t confirmed;   // 1 once head context exchange completes, else 0
+} __attribute__((packed));
+
+static_assert(sizeof(HelloPayload) == HELLO_PAYLOAD_LEN,
+              "HelloPayload must match the 14-byte HELLO wire layout");
+
+// Wraps a raw payload in the framed wire format: preamble, opcode, payload,
 // CRC-16 over (opcode + payload). The inverse of SerialFrameParser.
 std::vector<uint8_t> encodeFramed(uint8_t opcode, const std::vector<uint8_t>& payload);
 
-// A validated binary frame surfaced to downstream consumers (RDC's serial
-// ingest, bound via setBinaryFrameHandler). payload holds the raw bytes
-// between the opcode and the CRC.
-struct Frame {
-    uint8_t opcode;
-    std::vector<uint8_t> payload;
-};
+// Serializes a HelloPayload into a HELLO frame. Convenience over the raw
+// encodeFramed for the only payload type serial actually carries.
+std::vector<uint8_t> encodeFramed(const HelloPayload& hello);
 
-using BinaryFrameHandler = std::function<void(const Frame&)>;
+using HelloFrameHandler = std::function<void(const HelloPayload&)>;
 
 // Parses one jack's serial byte stream into framed binary frames
 // (preamble 0xAA 0x55 + opcode + payload + CRC-16). One instance per jack.
@@ -52,8 +61,8 @@ public:
     /// the start of the next feed(), keeping parser state single-owner.
     void requestReset() { resetRequested.store(true); }
 
-    /// Registers the validated-frame consumer.
-    void setBinaryFrameHandler(BinaryFrameHandler cb) { binaryFrameHandler = std::move(cb); }
+    /// Registers the consumer for CRC-valid HELLO frames, decoded to HelloPayload.
+    void setHelloFrameHandler(HelloFrameHandler cb) { helloFrameHandler = std::move(cb); }
 
 private:
     enum class ParseState {
@@ -81,7 +90,7 @@ private:
 
     std::atomic<bool> resetRequested{false};
 
-    BinaryFrameHandler binaryFrameHandler;
+    HelloFrameHandler helloFrameHandler;
 
     // Wall-clock window after which a mid-frame parser resets to scan-for-sync.
     static constexpr unsigned long PARSER_TIMEOUT_MS = 50;

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -315,8 +315,8 @@ PortStatus RemoteDeviceCoordinator::getPortStatus(SerialIdentifier port) {
     if (isHelloJack(port)) {
         return mapHelloLinkToStatus(port);
     }
-    // Daisy-chained peers no longer upgrade the status: a port is CONNECTED or
-    // it isn't. Chain position is a device-level fact (getChainRole()).
+    // A port is CONNECTED or it isn't; a daisy-chained peer does not upgrade its
+    // status. Chain position is a device-level fact (getChainRole()).
     return mapHandshakeStateToStatus(port);
 }
 

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -613,8 +613,15 @@ void RemoteDeviceCoordinator::emitHello() {
 }
 
 void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const HelloPayload& hello) {
+    // Reject an all-zero source (open jack) and our own echo before any liveness
+    // stamp: the output TX pin can loop back through the TRS contacts, and a
+    // self-HELLO must never keep a dead cable "alive" or fake a peer.
+    if (MacToUInt64(hello.source) == 0) return;
+    if (memcmp(hello.source, selfMac_.data(), 6) == 0) return;
+
     JackHelloLink& link = helloByPort_[portIndex(jack)];
     link.lastHelloMs = nowMs();
+    memcpy(link.peerMac.data(), hello.source, 6);
 
     // Idle jack + first HELLO from a source = a new link opening. CONNECTING/
     // CONNECTED just refresh liveness above.

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -10,6 +10,12 @@
 #include "wireless/mac-functions.hpp"
 #include "device/drivers/peer-comms-types.hpp"
 
+static constexpr std::array<SerialIdentifier, 3> HELLO_JACKS = {
+    SerialIdentifier::OUTPUT_JACK,
+    SerialIdentifier::INPUT_JACK,
+    SerialIdentifier::INPUT_JACK_SECONDARY,
+};
+
 RemoteDeviceCoordinator::RemoteDeviceCoordinator() : handshakeWirelessManager(HandshakeWirelessManager()) {}
 
 #ifndef NATIVE_BUILD
@@ -545,9 +551,7 @@ void RemoteDeviceCoordinator::enableHelloConnectivity() {
         if (mac != nullptr) memcpy(selfMac_.data(), mac, 6);
     }
 
-    for (SerialIdentifier port : {SerialIdentifier::OUTPUT_JACK,
-                                  SerialIdentifier::INPUT_JACK,
-                                  SerialIdentifier::INPUT_JACK_SECONDARY}) {
+    for (SerialIdentifier port : HELLO_JACKS) {
         HWSerialWrapper* hw = jackWrapper(port);
         if (hw == nullptr) continue;
         JackHelloLink& link = helloByPort_[portIndex(port)];
@@ -578,9 +582,7 @@ void RemoteDeviceCoordinator::emitHello() {
     hello.confirmed = 0;
 
     const std::vector<uint8_t> frame = encodeFramed(hello);
-    for (SerialIdentifier port : {SerialIdentifier::OUTPUT_JACK,
-                                  SerialIdentifier::INPUT_JACK,
-                                  SerialIdentifier::INPUT_JACK_SECONDARY}) {
+    for (SerialIdentifier port : HELLO_JACKS) {
         HWSerialWrapper* hw = jackWrapper(port);
         if (hw == nullptr) continue;
         for (uint8_t b : frame)
@@ -595,8 +597,6 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
     // Idle jack + first HELLO from a source = a new link opening. CONNECTING/
     // CONNECTED just refresh liveness above.
     if (link.state == HelloLinkState::IDLE) {
-        memcpy(link.sourceMac.data(), hello.source, 6);
-        link.hasSource = true;
         link.state = HelloLinkState::CONNECTING;
         link.connectingSinceMs = link.lastHelloMs;
         // Output-jack-initiates: only the OUT jack requests the context exchange.
@@ -617,9 +617,7 @@ void RemoteDeviceCoordinator::serviceConnectivity() {
     if (!helloConnectivityEnabled) return;
     const unsigned long now = nowMs();
 
-    for (SerialIdentifier port : {SerialIdentifier::OUTPUT_JACK,
-                                  SerialIdentifier::INPUT_JACK,
-                                  SerialIdentifier::INPUT_JACK_SECONDARY}) {
+    for (SerialIdentifier port : HELLO_JACKS) {
         if (!isHelloJack(port)) continue;
         JackHelloLink& link = helloByPort_[portIndex(port)];
         const unsigned long sinceHello = now >= link.lastHelloMs ? now - link.lastHelloMs : 0;
@@ -648,8 +646,6 @@ void RemoteDeviceCoordinator::serviceConnectivity() {
 
 void RemoteDeviceCoordinator::resetHelloLink(JackHelloLink& link) {
     link.state = HelloLinkState::IDLE;
-    link.hasSource = false;
-    link.sourceMac = {};
     // Drop any half-read frame so the next device's bytes don't merge in.
     link.parser.requestReset();
 }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -19,26 +19,48 @@ static constexpr std::array<SerialIdentifier, 3> HELLO_JACKS = {
 RemoteDeviceCoordinator::RemoteDeviceCoordinator() : handshakeWirelessManager(HandshakeWirelessManager()) {}
 
 #ifndef NATIVE_BUILD
-// The connectivity task's only job is periodic HELLO TX. Kept free-standing so
-// xTaskCreate can take it directly; it touches no SM state through emitHello().
+// Free entry point xTaskCreate can take directly; the loop lives in a member so
+// it can read the cooperative-stop flags.
 static void connectivityTaskEntry(void* ctx) {
-    auto* rdc = static_cast<RemoteDeviceCoordinator*>(ctx);
+    static_cast<RemoteDeviceCoordinator*>(ctx)->connectivityTaskBody();
+}
+
+void RemoteDeviceCoordinator::connectivityTaskBody() {
     for (;;) {
-        rdc->emitHello();
-        vTaskDelay(pdMS_TO_TICKS(RemoteDeviceCoordinator::HELLO_CADENCE_MS));
+        // Check before touching any state so a stop can never race an emit.
+        if (connectivityTaskStopRequested.load()) {
+            connectivityTaskExited.store(true);
+            vTaskDelete(nullptr);  // self-delete; never returns
+        }
+        emitHello();
+        vTaskDelay(pdMS_TO_TICKS(HELLO_CADENCE_MS));
     }
 }
 #endif
 
 RemoteDeviceCoordinator::~RemoteDeviceCoordinator() {
 #ifndef NATIVE_BUILD
-    // Stop the emit task before tearing down anything it could touch. A delete
-    // mid-emit at worst truncates one HELLO frame; the peer's CRC drops it.
+    // Cooperatively stop the emit task before freeing anything it dereferences:
+    // request exit, then wait for the task to observe it and self-delete. A
+    // cross-core vTaskDelete could otherwise cut it mid-emit, stranding the UART
+    // lock or dereferencing freed state.
     if (connectivityTaskHandle != nullptr) {
-        vTaskDelete(connectivityTaskHandle);
+        connectivityTaskStopRequested.store(true);
+        while (!connectivityTaskExited.load()) {
+            vTaskDelay(pdMS_TO_TICKS(HELLO_CADENCE_MS));
+        }
         connectivityTaskHandle = nullptr;
     }
 #endif
+    // Drop the byte callbacks: they capture `this` and live on the externally
+    // owned jacks, so a post-destruction exec() would otherwise call a lambda
+    // over freed memory.
+    if (helloConnectivityEnabled) {
+        for (SerialIdentifier port : HELLO_JACKS) {
+            HWSerialWrapper* hw = jackWrapper(port);
+            if (hw != nullptr) hw->setByteCallback(nullptr);
+        }
+    }
     delete inputPortHandshake;
     delete outputPortHandshake;
     delete secondaryInputPortHandshake;

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -12,7 +12,27 @@
 
 RemoteDeviceCoordinator::RemoteDeviceCoordinator() : handshakeWirelessManager(HandshakeWirelessManager()) {}
 
+#ifndef NATIVE_BUILD
+// The connectivity task's only job is periodic HELLO TX. Kept free-standing so
+// xTaskCreate can take it directly; it touches no SM state through emitHello().
+static void connectivityTaskEntry(void* ctx) {
+    auto* rdc = static_cast<RemoteDeviceCoordinator*>(ctx);
+    for (;;) {
+        rdc->emitHello();
+        vTaskDelay(pdMS_TO_TICKS(RemoteDeviceCoordinator::HELLO_CADENCE_MS));
+    }
+}
+#endif
+
 RemoteDeviceCoordinator::~RemoteDeviceCoordinator() {
+#ifndef NATIVE_BUILD
+    // Stop the emit task before tearing down anything it could touch. A delete
+    // mid-emit at worst truncates one HELLO frame; the peer's CRC drops it.
+    if (connectivityTaskHandle != nullptr) {
+        vTaskDelete(connectivityTaskHandle);
+        connectivityTaskHandle = nullptr;
+    }
+#endif
     delete inputPortHandshake;
     delete outputPortHandshake;
     delete secondaryInputPortHandshake;
@@ -22,6 +42,9 @@ RemoteDeviceCoordinator::~RemoteDeviceCoordinator() {
 void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, SerialManager* serialManager, Device* PDN) {
     this->serialManager = serialManager;
     this->wirelessManager_ = wirelessManager;
+    if (PDN != nullptr) {
+        selfDeviceType = PDN->getDeviceType();
+    }
 
     handshakeWirelessManager.initialize(wirelessManager);
 
@@ -149,6 +172,15 @@ void RemoteDeviceCoordinator::processChainAnnouncementPacket(const uint8_t* from
 }
 
 void RemoteDeviceCoordinator::sync(Device* PDN) {
+    if (helloConnectivityEnabled) {
+        // The handshake is quiesced on HELLO jacks: skipping its onStateLoop is
+        // what keeps it off the UART (it neither consumes RX nor writes TX). The
+        // chain-announcement machinery below rides handshake CONNECTED state, so
+        // it stays dormant here too until HELLO drives its own peer identity (#157).
+        serviceConnectivity();
+        return;
+    }
+
     if (inputPortHandshake)          inputPortHandshake->onStateLoop(PDN);
     if (outputPortHandshake)         outputPortHandshake->onStateLoop(PDN);
     if (secondaryInputPortHandshake) secondaryInputPortHandshake->onStateLoop(PDN);
@@ -244,6 +276,11 @@ size_t RemoteDeviceCoordinator::portIndex(SerialIdentifier port) const {
 }
 
 PortStatus RemoteDeviceCoordinator::getPortStatus(SerialIdentifier port) {
+    // When HELLO owns the jack, connectivity comes from its link SM, not the
+    // quiesced handshake.
+    if (isHelloJack(port)) {
+        return mapHelloLinkToStatus(port);
+    }
     // Daisy-chained peers no longer upgrade the status: a port is CONNECTED or
     // it isn't. Chain position is a device-level fact (getChainRole()).
     return mapHandshakeStateToStatus(port);
@@ -476,4 +513,157 @@ void RemoteDeviceCoordinator::unregisterPeer(const uint8_t* macAddress) {
             handshakeWirelessManager.removeMacPeer(port);
         }
     }
+}
+
+// ---- Per-jack HELLO connectivity (#155) ----
+
+unsigned long RemoteDeviceCoordinator::nowMs() {
+    PlatformClock* clock = SimpleTimer::getPlatformClock();
+    return clock != nullptr ? clock->milliseconds() : 0;
+}
+
+HWSerialWrapper* RemoteDeviceCoordinator::jackWrapper(SerialIdentifier port) const {
+    if (serialManager == nullptr) return nullptr;
+    switch (port) {
+        case SerialIdentifier::OUTPUT_JACK: return serialManager->getOutputJack();
+        case SerialIdentifier::INPUT_JACK: return serialManager->getInputJack();
+        case SerialIdentifier::INPUT_JACK_SECONDARY: return serialManager->getSecondaryInputJack();
+        default: return nullptr;
+    }
+}
+
+bool RemoteDeviceCoordinator::isHelloJack(SerialIdentifier port) const {
+    return helloConnectivityEnabled && jackWrapper(port) != nullptr;
+}
+
+void RemoteDeviceCoordinator::enableHelloConnectivity() {
+    if (helloConnectivityEnabled) return;
+    helloConnectivityEnabled = true;
+
+    if (wirelessManager_ != nullptr) {
+        const uint8_t* mac = wirelessManager_->getMacAddress();
+        if (mac != nullptr) memcpy(selfMac_.data(), mac, 6);
+    }
+
+    for (SerialIdentifier port : {SerialIdentifier::OUTPUT_JACK,
+                                  SerialIdentifier::INPUT_JACK,
+                                  SerialIdentifier::INPUT_JACK_SECONDARY}) {
+        HWSerialWrapper* hw = jackWrapper(port);
+        if (hw == nullptr) continue;
+        JackHelloLink& link = helloByPort_[portIndex(port)];
+        link.parser.setHelloFrameHandler(
+            [this, port](const HelloPayload& hello) { onHelloReceived(port, hello); });
+        // exec() runs on the main loop, so the parser is fed single-threaded.
+        hw->setByteCallback([this, port](uint8_t b) {
+            helloByPort_[portIndex(port)].parser.feed(&b, 1);
+        });
+    }
+
+#ifndef NATIVE_BUILD
+    if (!externalConnectivityTask && connectivityTaskHandle == nullptr) {
+        xTaskCreate(connectivityTaskEntry, "rdc-hello", kConnectivityTaskStack, this,
+                    kConnectivityTaskPriority, &connectivityTaskHandle);
+    }
+#endif
+}
+
+void RemoteDeviceCoordinator::emitHello() {
+    if (!helloConnectivityEnabled) return;
+
+    HelloPayload hello{};
+    memcpy(hello.source, selfMac_.data(), 6);
+    hello.deviceType = static_cast<uint8_t>(selfDeviceType);
+    // headMac stays zero and confirmed stays 0 until the device chain SM (#156)
+    // learns the head and completes its context exchange.
+    hello.confirmed = 0;
+
+    const std::vector<uint8_t> frame = encodeFramed(hello);
+    for (SerialIdentifier port : {SerialIdentifier::OUTPUT_JACK,
+                                  SerialIdentifier::INPUT_JACK,
+                                  SerialIdentifier::INPUT_JACK_SECONDARY}) {
+        HWSerialWrapper* hw = jackWrapper(port);
+        if (hw == nullptr) continue;
+        for (uint8_t b : frame)
+            hw->print(static_cast<char>(b));
+    }
+}
+
+void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const HelloPayload& hello) {
+    JackHelloLink& link = helloByPort_[portIndex(jack)];
+    link.lastHelloMs = nowMs();
+
+    // Idle jack + first HELLO from a source = a new link opening. CONNECTING/
+    // CONNECTED just refresh liveness above.
+    if (link.state == HelloLinkState::IDLE) {
+        memcpy(link.sourceMac.data(), hello.source, 6);
+        link.hasSource = true;
+        link.state = HelloLinkState::CONNECTING;
+        link.connectingSinceMs = link.lastHelloMs;
+        // Output-jack-initiates: only the OUT jack requests the context exchange.
+        if (jack == SerialIdentifier::OUTPUT_JACK && contextRequestCallback) {
+            contextRequestCallback(jack);
+        }
+    }
+}
+
+void RemoteDeviceCoordinator::onContextExchangeComplete(SerialIdentifier jack) {
+    JackHelloLink& link = helloByPort_[portIndex(jack)];
+    if (link.state != HelloLinkState::CONNECTING) return;
+    link.state = HelloLinkState::CONNECTED;
+    if (jackChangeCallback) jackChangeCallback(jack, true);
+}
+
+void RemoteDeviceCoordinator::serviceConnectivity() {
+    if (!helloConnectivityEnabled) return;
+    const unsigned long now = nowMs();
+
+    for (SerialIdentifier port : {SerialIdentifier::OUTPUT_JACK,
+                                  SerialIdentifier::INPUT_JACK,
+                                  SerialIdentifier::INPUT_JACK_SECONDARY}) {
+        if (!isHelloJack(port)) continue;
+        JackHelloLink& link = helloByPort_[portIndex(port)];
+        const unsigned long sinceHello = now >= link.lastHelloMs ? now - link.lastHelloMs : 0;
+
+        switch (link.state) {
+            case HelloLinkState::CONNECTING: {
+                const unsigned long connecting =
+                    now >= link.connectingSinceMs ? now - link.connectingSinceMs : 0;
+                if (sinceHello > HELLO_SILENT_LINK_MS ||
+                    connecting > CONTEXT_EXCHANGE_TIMEOUT_MS) {
+                    resetHelloLink(link);
+                }
+                break;
+            }
+            case HelloLinkState::CONNECTED:
+                if (sinceHello > HELLO_SILENT_LINK_MS) {
+                    resetHelloLink(link);
+                    if (jackChangeCallback) jackChangeCallback(port, false);
+                }
+                break;
+            case HelloLinkState::IDLE:
+                break;
+        }
+    }
+}
+
+void RemoteDeviceCoordinator::resetHelloLink(JackHelloLink& link) {
+    link.state = HelloLinkState::IDLE;
+    link.hasSource = false;
+    link.sourceMac = {};
+    // Drop any half-read frame so the next device's bytes don't merge in.
+    link.parser.requestReset();
+}
+
+RemoteDeviceCoordinator::HelloLinkState
+RemoteDeviceCoordinator::getHelloLinkState(SerialIdentifier jack) const {
+    return helloByPort_[portIndex(jack)].state;
+}
+
+PortStatus RemoteDeviceCoordinator::mapHelloLinkToStatus(SerialIdentifier port) const {
+    switch (helloByPort_[portIndex(port)].state) {
+        case HelloLinkState::CONNECTED: return PortStatus::CONNECTED;
+        case HelloLinkState::CONNECTING: return PortStatus::CONNECTING;
+        case HelloLinkState::IDLE: return PortStatus::DISCONNECTED;
+    }
+    return PortStatus::DISCONNECTED;
 }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -9,6 +9,7 @@
 #include "wireless/handshake-wireless-manager.hpp"
 #include "wireless/mac-functions.hpp"
 #include "device/drivers/peer-comms-types.hpp"
+#include "device/hello-link-machine.hpp"
 
 static constexpr std::array<SerialIdentifier, 3> HELLO_JACKS = {
     SerialIdentifier::OUTPUT_JACK,
@@ -59,6 +60,8 @@ RemoteDeviceCoordinator::~RemoteDeviceCoordinator() {
         for (SerialIdentifier port : HELLO_JACKS) {
             HWSerialWrapper* hw = jackWrapper(port);
             if (hw != nullptr) hw->setByteCallback(nullptr);
+            delete helloByPort_[portIndex(port)].machine;
+            helloByPort_[portIndex(port)].machine = nullptr;
         }
     }
     delete inputPortHandshake;
@@ -205,7 +208,10 @@ void RemoteDeviceCoordinator::sync(Device* PDN) {
         // what keeps it off the UART (it neither consumes RX nor writes TX). The
         // chain-announcement machinery below rides handshake CONNECTED state, so
         // it stays dormant here too until HELLO drives its own peer identity (#157).
-        serviceConnectivity();
+        for (SerialIdentifier port : HELLO_JACKS) {
+            HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+            if (machine) machine->onStateLoop(PDN);
+        }
         return;
     }
 
@@ -583,6 +589,23 @@ void RemoteDeviceCoordinator::enableHelloConnectivity() {
         hw->setByteCallback([this, port](uint8_t b) {
             helloByPort_[portIndex(port)].parser.feed(&b, 1);
         });
+
+        HelloLinkContext context;
+        context.jack = port;
+        context.nowMs = [] { return RemoteDeviceCoordinator::nowMs(); };
+        context.onContextRequest = [this](SerialIdentifier j) {
+            if (contextRequestCallback) contextRequestCallback(j);
+        };
+        context.onJackChange = [this](SerialIdentifier j, bool connected) {
+            if (jackChangeCallback) jackChangeCallback(j, connected);
+        };
+        context.resetParser = [this, port] {
+            helloByPort_[portIndex(port)].parser.requestReset();
+        };
+        context.silentLinkMs = HELLO_SILENT_LINK_MS;
+        context.contextTimeoutMs = CONTEXT_EXCHANGE_TIMEOUT_MS;
+        link.machine = new HelloLinkMachine(std::move(context));
+        link.machine->initialize(nullptr);  // states ignore Device*; mounts Idle
     }
 
 #ifndef NATIVE_BUILD
@@ -615,80 +638,37 @@ void RemoteDeviceCoordinator::emitHello() {
 void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const HelloPayload& hello) {
     // Reject an all-zero source (open jack) and our own echo before any liveness
     // stamp: the output TX pin can loop back through the TRS contacts, and a
-    // self-HELLO must never keep a dead cable "alive" or fake a peer.
+    // self-HELLO must never keep a dead cable "alive" or fake a peer. The RDC owns
+    // selfMac, so this guard stays here rather than in the link SM.
     if (MacToUInt64(hello.source) == 0) return;
     if (memcmp(hello.source, selfMac_.data(), 6) == 0) return;
 
-    JackHelloLink& link = helloByPort_[portIndex(jack)];
-    link.lastHelloMs = nowMs();
-    memcpy(link.peerMac.data(), hello.source, 6);
-
-    // Idle jack + first HELLO from a source = a new link opening. CONNECTING/
-    // CONNECTED just refresh liveness above.
-    if (link.state == HelloLinkState::IDLE) {
-        link.state = HelloLinkState::CONNECTING;
-        link.connectingSinceMs = link.lastHelloMs;
-        // Output-jack-initiates: only the OUT jack requests the context exchange.
-        if (jack == SerialIdentifier::OUTPUT_JACK && contextRequestCallback) {
-            contextRequestCallback(jack);
-        }
-    }
+    HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
+    if (machine) machine->onHelloReceived(hello);
 }
 
 void RemoteDeviceCoordinator::onContextExchangeComplete(SerialIdentifier jack) {
-    JackHelloLink& link = helloByPort_[portIndex(jack)];
-    if (link.state != HelloLinkState::CONNECTING) return;
-    link.state = HelloLinkState::CONNECTED;
-    if (jackChangeCallback) jackChangeCallback(jack, true);
-}
-
-void RemoteDeviceCoordinator::serviceConnectivity() {
-    if (!helloConnectivityEnabled) return;
-    const unsigned long now = nowMs();
-
-    for (SerialIdentifier port : HELLO_JACKS) {
-        if (!isHelloJack(port)) continue;
-        JackHelloLink& link = helloByPort_[portIndex(port)];
-        const unsigned long sinceHello = now >= link.lastHelloMs ? now - link.lastHelloMs : 0;
-
-        switch (link.state) {
-            case HelloLinkState::CONNECTING: {
-                const unsigned long connecting =
-                    now >= link.connectingSinceMs ? now - link.connectingSinceMs : 0;
-                if (sinceHello > HELLO_SILENT_LINK_MS ||
-                    connecting > CONTEXT_EXCHANGE_TIMEOUT_MS) {
-                    resetHelloLink(link);
-                }
-                break;
-            }
-            case HelloLinkState::CONNECTED:
-                if (sinceHello > HELLO_SILENT_LINK_MS) {
-                    resetHelloLink(link);
-                    if (jackChangeCallback) jackChangeCallback(port, false);
-                }
-                break;
-            case HelloLinkState::IDLE:
-                break;
-        }
-    }
-}
-
-void RemoteDeviceCoordinator::resetHelloLink(JackHelloLink& link) {
-    link.state = HelloLinkState::IDLE;
-    // Drop any half-read frame so the next device's bytes don't merge in.
-    link.parser.requestReset();
+    HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
+    if (machine) machine->onContextExchangeComplete();
 }
 
 RemoteDeviceCoordinator::HelloLinkState
 RemoteDeviceCoordinator::getHelloLinkState(SerialIdentifier jack) const {
-    return helloByPort_[portIndex(jack)].state;
+    const HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
+    if (machine == nullptr) return HelloLinkState::IDLE;
+    switch (machine->currentStateId()) {
+        case HELLO_LINK_CONNECTED:  return HelloLinkState::CONNECTED;
+        case HELLO_LINK_CONNECTING: return HelloLinkState::CONNECTING;
+        default:                    return HelloLinkState::IDLE;
+    }
 }
 
 PortStatus RemoteDeviceCoordinator::mapHelloLinkToStatus(SerialIdentifier port) const {
-    switch (helloByPort_[portIndex(port)].state) {
-        case HelloLinkState::CONNECTED: return PortStatus::CONNECTED;
-        case HelloLinkState::CONNECTING: return PortStatus::CONNECTING;
-        case HelloLinkState::IDLE: return PortStatus::DISCONNECTED;
+    const HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+    if (machine == nullptr) return PortStatus::DISCONNECTED;
+    switch (machine->currentStateId()) {
+        case HELLO_LINK_CONNECTED:  return PortStatus::CONNECTED;
+        case HELLO_LINK_CONNECTING: return PortStatus::CONNECTING;
+        default:                    return PortStatus::DISCONNECTED;
     }
-    return PortStatus::DISCONNECTED;
 }

--- a/lib/core/src/device/serial-frame-parser.cpp
+++ b/lib/core/src/device/serial-frame-parser.cpp
@@ -3,6 +3,7 @@
 #include "utils/simple-timer.hpp"
 #include "wireless/crc16.hpp"
 
+#include <cstring>
 #include <limits>
 #include <utility>
 
@@ -26,6 +27,11 @@ std::vector<uint8_t> encodeFramed(uint8_t opcode, const std::vector<uint8_t>& pa
     frame.push_back(static_cast<uint8_t>(crc >> 8));
     frame.push_back(static_cast<uint8_t>(crc & 0xFF));
     return frame;
+}
+
+std::vector<uint8_t> encodeFramed(const HelloPayload& hello) {
+    const uint8_t* bytes = reinterpret_cast<const uint8_t*>(&hello);
+    return encodeFramed(OP_HELLO, std::vector<uint8_t>(bytes, bytes + sizeof(hello)));
 }
 
 unsigned long SerialFrameParser::nowMs() {
@@ -129,11 +135,13 @@ void SerialFrameParser::feed(const uint8_t* data, size_t len) {
                     uint16_t expected = crc16(&parser.opcode, 1);
                     expected = crc16Update(expected, parser.payloadBuf.data(),
                                            parser.payloadBuf.size());
-                    if (got == expected && binaryFrameHandler) {
-                        // Move, don't copy: resetParser()'s clear() is valid on
-                        // the moved-from buffer.
-                        Frame f{parser.opcode, std::move(parser.payloadBuf)};
-                        binaryFrameHandler(f);
+                    if (got == expected && helloFrameHandler &&
+                        parser.payloadBuf.size() == sizeof(HelloPayload)) {
+                        // The packed struct mirrors the wire byte-for-byte, so
+                        // the validated payload copies straight in.
+                        HelloPayload hello;
+                        std::memcpy(&hello, parser.payloadBuf.data(), sizeof(hello));
+                        helloFrameHandler(hello);
                     }
                     resetParser();
                 }

--- a/lib/esp32-drivers/include/device/drivers/esp32-s3/esp32-s3-serial-driver.hpp
+++ b/lib/esp32-drivers/include/device/drivers/esp32-s3/esp32-s3-serial-driver.hpp
@@ -39,6 +39,13 @@ public:
     void exec() override {
         while (Serial1.available() > 0) {
             char incomingChar = Serial1.read();
+            // Byte mode routes each RX byte to the byte callback (HELLO
+            // framing) and skips string assembly; the two are mutually
+            // exclusive per jack.
+            if (byteCallback) {
+                byteCallback(static_cast<uint8_t>(incomingChar));
+                continue;
+            }
             if (incomingChar == STRING_START) {
                 std::string receivedString = std::string(Serial1.readStringUntil(STRING_TERM).c_str());
                 LOG_D("SERIAL1", "Received: '%s' (len=%d)", receivedString.c_str(), receivedString.length());
@@ -89,8 +96,14 @@ public:
         stringCallback = callback;
     }
 
+    /// Routes RX bytes to the byte callback in exec(); see HWSerialWrapper.
+    void setByteCallback(const SerialByteCallback& callback) override {
+        byteCallback = callback;
+    }
+
 private:
     SerialStringCallback stringCallback;
+    SerialByteCallback byteCallback;
     uint8_t txPin;
     uint8_t rxPin;
 };
@@ -122,6 +135,13 @@ public:
     void exec() override {
         while (Serial2.available() > 0) {
             char incomingChar = Serial2.read();
+            // Byte mode routes each RX byte to the byte callback (HELLO
+            // framing) and skips string assembly; the two are mutually
+            // exclusive per jack.
+            if (byteCallback) {
+                byteCallback(static_cast<uint8_t>(incomingChar));
+                continue;
+            }
             if (incomingChar == STRING_START) {
                 std::string receivedString = std::string(Serial2.readStringUntil(STRING_TERM).c_str());
                 LOG_D("SERIAL2", "Received: '%s' (len=%d)", receivedString.c_str(), receivedString.length());
@@ -172,8 +192,14 @@ public:
         stringCallback = callback;
     }
 
+    /// Routes RX bytes to the byte callback in exec(); see HWSerialWrapper.
+    void setByteCallback(const SerialByteCallback& callback) override {
+        byteCallback = callback;
+    }
+
 private:
     SerialStringCallback stringCallback;
+    SerialByteCallback byteCallback;
     uint8_t txPin;
     uint8_t rxPin;
 };
@@ -207,6 +233,13 @@ public:
     void exec() override {
         while (Serial1.available() > 0) {
             char incomingChar = Serial1.read();
+            // Byte mode routes each RX byte to the byte callback (HELLO
+            // framing) and skips string assembly; the two are mutually
+            // exclusive per jack.
+            if (byteCallback) {
+                byteCallback(static_cast<uint8_t>(incomingChar));
+                continue;
+            }
             if (incomingChar == STRING_START) {
                 std::string receivedString = std::string(Serial1.readStringUntil(STRING_TERM).c_str());
                 LOG_D("SERIAL1_SEC", "Received: '%s' (len=%d)", receivedString.c_str(), receivedString.length());
@@ -235,8 +268,14 @@ public:
         stringCallback = callback;
     }
 
+    /// Routes RX bytes to the byte callback in exec(); see HWSerialWrapper.
+    void setByteCallback(const SerialByteCallback& callback) override {
+        byteCallback = callback;
+    }
+
 private:
     SerialStringCallback stringCallback;
+    SerialByteCallback byteCallback;
     uint8_t txPin;
     uint8_t rxPin;
 };

--- a/lib/native-drivers/include/device/drivers/native/native-serial-driver.hpp
+++ b/lib/native-drivers/include/device/drivers/native/native-serial-driver.hpp
@@ -4,6 +4,7 @@
 #include <queue>
 #include <deque>
 #include <string>
+#include <vector>
 
 class NativeSerialDriver : public SerialDriverInterface {
 public:
@@ -20,7 +21,14 @@ public:
     }
 
     void exec() override {
-        // Process any incoming serial data
+        // Byte mode drains the RX buffer straight to the byte callback (HELLO
+        // framing); no string assembly. Legacy string jacks push through
+        // injectInput() and leave exec() a no-op.
+        if (byteCallback_) {
+            while (available() > 0) {
+                byteCallback_(static_cast<uint8_t>(read()));
+            }
+        }
     }
 
     int availableForWrite() override {
@@ -92,6 +100,20 @@ public:
         stringCallback_ = callback;
     }
 
+    /// Routes RX bytes to the byte callback in exec(); see HWSerialWrapper.
+    void setByteCallback(const SerialByteCallback& callback) override {
+        byteCallback_ = callback;
+    }
+
+    /// Test/broker helper: buffers raw bytes for exec() to drain to the byte
+    /// callback. The binary-framing analogue of injectInput().
+    void injectBytes(const std::vector<uint8_t>& bytes) {
+        while (inputBuffer_.size() >= MAX_INPUT_QUEUE_SIZE) {
+            inputBuffer_.pop();
+        }
+        inputBuffer_.push(std::string(bytes.begin(), bytes.end()));
+    }
+
     // Test helper methods
     void injectInput(const std::string& input) {
         // Enforce FIFO limit on input queue
@@ -141,7 +163,8 @@ private:
     std::queue<std::string> inputBuffer_;
     std::string outputBuffer_;
     SerialStringCallback stringCallback_;
-    
+    SerialByteCallback byteCallback_;
+
     // Message history (most recent at back)
     std::deque<std::string> sentHistory_;
     std::deque<std::string> receivedHistory_;

--- a/test/test_core/device-mock.hpp
+++ b/test/test_core/device-mock.hpp
@@ -80,8 +80,14 @@ class FakeHWSerialWrapper : public HWSerialWrapper {
         stringCallback = callback;
     }
 
+    /// Routes RX bytes to the byte callback; see HWSerialWrapper.
+    void setByteCallback(const SerialByteCallback& callback) override {
+        byteCallback = callback;
+    }
+
     deque<char> msgQueue;
     SerialStringCallback stringCallback;
+    SerialByteCallback byteCallback;
 };
 
 class FakeDevice : public Device {

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -84,10 +84,13 @@ public:
     }
 
     MockDevice device;
-    RemoteDeviceCoordinator rdc;
     FakePlatformClock* fakeClock = nullptr;
     NativeSerialDriver outJack{"hello-out"};
     NativeSerialDriver inJack{"hello-in"};
+    // Declared after the jacks so it is destroyed FIRST: the RDC dtor clears the
+    // byte callbacks on the jacks, which must still be alive (mirrors production,
+    // where the serial drivers outlive the RDC).
+    RemoteDeviceCoordinator rdc;
     uint8_t localMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
 
     int connectCount = 0;

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -99,6 +99,29 @@ public:
     SerialIdentifier lastDisconnectJack = SerialIdentifier::OUTPUT_JACK;
 };
 
+// A looped-back own HELLO or an all-zero-source (open-jack) HELLO must not open a
+// link: on real hardware the output TX pin bleeds back through the TRS contacts,
+// and treating that as a peer would keep a dead cable "alive". A genuine distinct
+// peer must still connect, so the guard is not over-broad.
+inline void rdcHelloRejectsSelfAndZeroSource(RDCHelloTests* suite) {
+    HelloPayload zero{};
+    zero.deviceType = static_cast<uint8_t>(DeviceType::PDN);
+    suite->deliverHello(suite->outJack, encodeFramed(zero));
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+
+    HelloPayload self{};
+    for (int i = 0; i < 6; ++i) self.source[i] = suite->localMac[i];
+    self.deviceType = static_cast<uint8_t>(DeviceType::PDN);
+    suite->deliverHello(suite->outJack, encodeFramed(self));
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+}
+
 // (a) A HELLO from a new MAC drives that jack Idle -> Connecting.
 inline void rdcHelloNewMacDrivesConnecting(RDCHelloTests* suite) {
     EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -1,0 +1,263 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "device-mock.hpp"
+#include "utility-tests.hpp"
+#include "device/remote-device-coordinator.hpp"
+#include "device/serial-frame-parser.hpp"
+#include "device/drivers/native/native-serial-driver.hpp"
+#include "protocol-constants.hpp"
+
+#include <cstring>
+#include <vector>
+
+using ::testing::_;
+using ::testing::Return;
+
+// ============================================
+// RDC per-jack HELLO connectivity (#155)
+// ============================================
+//
+// Drives HELLO through the real production feed path: RDC wires the jack byte
+// callback, bytes are pushed into the native driver's RX and drained by exec()
+// into the SerialFrameParser. Single-threaded via setExternalConnectivityTask —
+// the test calls emitHello()/sync() itself instead of the FreeRTOS task.
+
+class RDCHelloTests : public testing::Test {
+public:
+    /// Fake clock, mocked radio, native jacks swapped in, RDC in HELLO mode with
+    /// the emit task externalized so the test drives it single-threaded.
+    void SetUp() override {
+        fakeClock = new FakePlatformClock();
+        SimpleTimer::setPlatformClock(fakeClock);
+        fakeClock->setTime(1000);
+
+        ON_CALL(*device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+        ON_CALL(*device.mockPeerComms, getMacAddress()).WillByDefault(Return(localMac));
+        ON_CALL(*device.mockPeerComms, addEspNowPeer(_)).WillByDefault(Return(0));
+        ON_CALL(*device.mockPeerComms, removeEspNowPeer(_)).WillByDefault(Return(0));
+        ON_CALL(*device.mockPeerComms, getPeerCommsState())
+            .WillByDefault(Return(PeerCommsState::CONNECTED));
+
+        device.serialManager->setOutputJack(&outJack);
+        device.serialManager->setInputJack(&inJack);
+
+        rdc.setExternalConnectivityTask(true);
+        rdc.initialize(device.wirelessManager, device.serialManager, &device);
+        rdc.setOnJackChange([this](SerialIdentifier jack, bool connected) {
+            if (connected) {
+                connectCount++;
+                lastConnectJack = jack;
+            } else {
+                disconnectCount++;
+                lastDisconnectJack = jack;
+            }
+        });
+        rdc.enableHelloConnectivity();
+    }
+
+    /// Restores the real platform clock.
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        delete fakeClock;
+    }
+
+    /// A HELLO frame whose source MAC starts with firstByte (rest fixed).
+    std::vector<uint8_t> helloFrame(uint8_t firstByte) {
+        HelloPayload hello{};
+        hello.source[0] = firstByte;
+        hello.source[1] = 0x02;
+        hello.source[2] = 0x03;
+        hello.source[3] = 0x04;
+        hello.source[4] = 0x05;
+        hello.source[5] = 0x06;
+        hello.deviceType = static_cast<uint8_t>(DeviceType::PDN);
+        return encodeFramed(hello);
+    }
+
+    /// Pushes a frame into a jack's RX and drains it via the real exec() pump.
+    void deliverHello(NativeSerialDriver& jack, const std::vector<uint8_t>& frame) {
+        jack.injectBytes(frame);
+        jack.exec();
+    }
+
+    MockDevice device;
+    RemoteDeviceCoordinator rdc;
+    FakePlatformClock* fakeClock = nullptr;
+    NativeSerialDriver outJack{"hello-out"};
+    NativeSerialDriver inJack{"hello-in"};
+    uint8_t localMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+
+    int connectCount = 0;
+    int disconnectCount = 0;
+    SerialIdentifier lastConnectJack = SerialIdentifier::OUTPUT_JACK;
+    SerialIdentifier lastDisconnectJack = SerialIdentifier::OUTPUT_JACK;
+};
+
+// (a) A HELLO from a new MAC drives that jack Idle -> Connecting.
+inline void rdcHelloNewMacDrivesConnecting(RDCHelloTests* suite) {
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+    EXPECT_EQ(suite->rdc.getPortStatus(SerialIdentifier::OUTPUT_JACK), PortStatus::CONNECTING);
+    // A distinct jack is untouched.
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+}
+
+// (b) onContextExchangeComplete drives Connecting -> Connected and fires jack-connect.
+inline void rdcHelloContextCompleteConnects(RDCHelloTests* suite) {
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+
+    suite->rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);
+
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_EQ(suite->rdc.getPortStatus(SerialIdentifier::OUTPUT_JACK), PortStatus::CONNECTED);
+    EXPECT_EQ(suite->connectCount, 1);
+    EXPECT_EQ(suite->lastConnectJack, SerialIdentifier::OUTPUT_JACK);
+    EXPECT_EQ(suite->disconnectCount, 0);
+}
+
+// (c) Clock past silent-link with no HELLO drives Connected -> Idle, fires disconnect.
+inline void rdcHelloSilentLinkDisconnects(RDCHelloTests* suite) {
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->rdc.sync(&suite->device);
+
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    EXPECT_EQ(suite->rdc.getPortStatus(SerialIdentifier::OUTPUT_JACK), PortStatus::DISCONNECTED);
+    EXPECT_EQ(suite->disconnectCount, 1);
+    EXPECT_EQ(suite->lastDisconnectJack, SerialIdentifier::OUTPUT_JACK);
+}
+
+// (d) The emit step produces HELLO frame bytes on both jacks, carrying our MAC.
+inline void rdcHelloEmitProducesFramesOnBothJacks(RDCHelloTests* suite) {
+    suite->outJack.clearOutput();
+    suite->inJack.clearOutput();
+
+    suite->rdc.emitHello();
+
+    for (const std::string& out : {suite->outJack.getOutput(), suite->inJack.getOutput()}) {
+        ASSERT_GE(out.size(), static_cast<size_t>(HELLO_PAYLOAD_LEN));
+        EXPECT_EQ(static_cast<uint8_t>(out[0]), FRAME_PREAMBLE_0);
+        EXPECT_EQ(static_cast<uint8_t>(out[1]), FRAME_PREAMBLE_1);
+
+        // Decode the emitted bytes back through the parser: it must be a valid
+        // HELLO carrying this device's MAC and type.
+        SerialFrameParser parser;
+        int frames = 0;
+        HelloPayload got{};
+        parser.setHelloFrameHandler([&](const HelloPayload& h) {
+            got = h;
+            frames++;
+        });
+        std::vector<uint8_t> bytes(out.begin(), out.end());
+        parser.feed(bytes.data(), bytes.size());
+
+        ASSERT_EQ(frames, 1);
+        EXPECT_EQ(0, memcmp(got.source, suite->localMac, 6));
+        EXPECT_EQ(got.deviceType, static_cast<uint8_t>(DeviceType::PDN));
+    }
+}
+
+// (e) A new HELLO MAC on the OUT jack invokes the context-request placeholder;
+// the IN jack does not.
+inline void rdcHelloOutputJackInitiatesContext(RDCHelloTests* suite) {
+    int outRequests = 0;
+    int inRequests = 0;
+    suite->rdc.setOnContextRequest([&](SerialIdentifier jack) {
+        if (jack == SerialIdentifier::OUTPUT_JACK)
+            outRequests++;
+        else
+            inRequests++;
+    });
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
+
+    EXPECT_EQ(outRequests, 1);
+    EXPECT_EQ(inRequests, 0);
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+}
+
+// (f) With a byte callback set the driver exec() routes RX bytes to it and does
+// NOT assemble strings; with no byte callback the legacy string path is intact.
+inline void rdcHelloByteModeSuppressesStringAssembly() {
+    NativeSerialDriver jack("f");
+    int bytes = 0;
+    bool stringFired = false;
+    jack.setStringCallback([&](std::string) { stringFired = true; });
+    jack.setByteCallback([&](uint8_t) { bytes++; });
+
+    // Bytes that WOULD delimit a legacy string (STRING_START ... STRING_TERM).
+    const std::string legacy = std::string(1, STRING_START) + "hello" + STRING_TERM;
+    jack.injectBytes(std::vector<uint8_t>(legacy.begin(), legacy.end()));
+    jack.exec();
+
+    EXPECT_EQ(bytes, static_cast<int>(legacy.size()));
+    EXPECT_FALSE(stringFired);
+
+    // No byte callback: the legacy string delivery path still fires.
+    NativeSerialDriver legacyJack("f-legacy");
+    bool legacyString = false;
+    legacyJack.setStringCallback([&](std::string) { legacyString = true; });
+    legacyJack.injectInput(std::string(1, STRING_START) + "hi" + STRING_TERM);
+    EXPECT_TRUE(legacyString);
+}
+
+// (g) RDC::sync() does not run the old handshake onStateLoop on a HELLO jack.
+// Falsifiable: the same serial MAC drives the handshake to SEND_ID (which emits
+// a kHandshakeCommand) on a plain RDC, but not on a HELLO-enabled one.
+inline void rdcHelloSyncSkipsHandshakeOnStateLoop() {
+    static uint8_t selfMac[6] = {0x99, 0x88, 0x77, 0x66, 0x55, 0x44};
+
+    auto driveHandshakeMac = [](MockDevice& dev, RemoteDeviceCoordinator& coord,
+                                int& handshakeSends) {
+        ON_CALL(*dev.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+        ON_CALL(*dev.mockPeerComms, getMacAddress()).WillByDefault(Return(selfMac));
+        ON_CALL(*dev.mockPeerComms, addEspNowPeer(_)).WillByDefault(Return(0));
+        ON_CALL(*dev.mockPeerComms, sendData(_, PktType::kHandshakeCommand, _, _))
+            .WillByDefault(testing::DoAll(
+                testing::InvokeWithoutArgs([&handshakeSends]() { handshakeSends++; }),
+                Return(1)));
+        coord.setExternalConnectivityTask(true);
+        coord.initialize(dev.wirelessManager, dev.serialManager, &dev);
+    };
+
+    // Control: a plain RDC advances the handshake on sync(), emitting a
+    // kHandshakeCommand from OUTPUT_SEND_ID_STATE. Proves the input is live.
+    MockDevice control;
+    RemoteDeviceCoordinator controlRdc;
+    int controlSends = 0;
+    driveHandshakeMac(control, controlRdc, controlSends);
+    control.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
+    controlRdc.sync(&control);
+    EXPECT_GT(controlSends, 0);
+
+    // Subject: a HELLO-enabled RDC skips the handshake onStateLoop, so the same
+    // serial MAC never advances it to SEND_ID.
+    MockDevice subject;
+    RemoteDeviceCoordinator subjectRdc;
+    int subjectSends = 0;
+    driveHandshakeMac(subject, subjectRdc, subjectSends);
+    subjectRdc.enableHelloConnectivity();
+    subject.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
+    subjectRdc.sync(&subject);
+    subjectRdc.sync(&subject);
+    EXPECT_EQ(subjectSends, 0);
+}

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -118,6 +118,7 @@ inline void rdcHelloRejectsSelfAndZeroSource(RDCHelloTests* suite) {
               RemoteDeviceCoordinator::HelloLinkState::IDLE);
 
     suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
     EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
 }
@@ -128,6 +129,7 @@ inline void rdcHelloNewMacDrivesConnecting(RDCHelloTests* suite) {
               RemoteDeviceCoordinator::HelloLinkState::IDLE);
 
     suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
 
     EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
@@ -140,10 +142,12 @@ inline void rdcHelloNewMacDrivesConnecting(RDCHelloTests* suite) {
 // (b) onContextExchangeComplete drives Connecting -> Connected and fires jack-connect.
 inline void rdcHelloContextCompleteConnects(RDCHelloTests* suite) {
     suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
     ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
 
     suite->rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);
+    suite->rdc.sync(&suite->device);
 
     EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
@@ -156,7 +160,9 @@ inline void rdcHelloContextCompleteConnects(RDCHelloTests* suite) {
 // (c) Clock past silent-link with no HELLO drives Connected -> Idle, fires disconnect.
 inline void rdcHelloSilentLinkDisconnects(RDCHelloTests* suite) {
     suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
     suite->rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);
+    suite->rdc.sync(&suite->device);
     ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
 
@@ -214,6 +220,7 @@ inline void rdcHelloOutputJackInitiatesContext(RDCHelloTests* suite) {
 
     suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
     suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
+    suite->rdc.sync(&suite->device);
 
     EXPECT_EQ(outRequests, 1);
     EXPECT_EQ(inRequests, 0);

--- a/test/test_core/serial-frame-parser-tests.hpp
+++ b/test/test_core/serial-frame-parser-tests.hpp
@@ -45,7 +45,7 @@ public:
         return out;
     }
 
-    /// HELLO payload: source mac[6] + deviceType[1] + headMac[6] + confirmed[1].
+    /// HELLO payload bytes: source mac[6] + deviceType[1] + headMac[6] + confirmed[1].
     std::vector<uint8_t> helloPayload(uint8_t firstMacByte = 0x10) {
         std::vector<uint8_t> p = {firstMacByte, 0x20, 0x30, 0x40, 0x50, 0x60,  // source
                                   0x01,                                        // deviceType
@@ -64,40 +64,90 @@ public:
     FakePlatformClock* fakeClock = nullptr;
 };
 
-TEST_F(SerialFrameParserTests, validBinaryFrameRoutesToFrameHandler) {
+TEST_F(SerialFrameParserTests, validFrameDecodesToHelloPayload) {
     int frameCount = 0;
-    Frame got;
-    parser.setBinaryFrameHandler([&](const Frame& f) { got = f; ++frameCount; });
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; ++frameCount; });
 
-    std::vector<uint8_t> frame = buildFrame(OP_HELLO, helloPayload());
+    feed(buildFrame(OP_HELLO, helloPayload()));
+
+    ASSERT_EQ(frameCount, 1);
+    EXPECT_EQ(got.source[0], 0x10);
+    EXPECT_EQ(got.source[5], 0x60);
+    EXPECT_EQ(got.deviceType, 0x01);
+    EXPECT_EQ(got.headMac[0], 0xAA);
+    EXPECT_EQ(got.headMac[5], 0xFF);
+    EXPECT_EQ(got.confirmed, 0x00);
+}
+
+TEST_F(SerialFrameParserTests, decodeMapsEveryWireByteToItsField) {
+    // Independent of buildFrame/encodeFramed: a hand-laid frame whose CRC is the
+    // precomputed CRC-16/XMODEM of (opcode + payload). Pins the exact byte->field
+    // mapping so a reordered or repacked struct fails here, not silently on the wire.
+    // Layout: preamble 0xAA 0x55, OP_HELLO 0x00, source[6]=11..66, deviceType=01,
+    // headMac[6]=DE AD BE EF 00 01, confirmed=01, then CRC 0xDC48.
+    const std::vector<uint8_t> frame = {0xAA, 0x55, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x01,
+                                        0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x01, 0xDC, 0x48};
+
+    int frameCount = 0;
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; ++frameCount; });
     feed(frame);
 
     ASSERT_EQ(frameCount, 1);
-    EXPECT_EQ(got.opcode, OP_HELLO);
-    ASSERT_EQ(got.payload.size(), HELLO_PAYLOAD_LEN);
-    EXPECT_EQ(got.payload[0], 0x10);
-    EXPECT_EQ(got.payload[13], 0x00);
+    const uint8_t expectedSource[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    const uint8_t expectedHead[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01};
+    for (int i = 0; i < 6; ++i) {
+        EXPECT_EQ(got.source[i], expectedSource[i]);
+        EXPECT_EQ(got.headMac[i], expectedHead[i]);
+    }
+    EXPECT_EQ(got.deviceType, 0x01);
+    EXPECT_EQ(got.confirmed, 0x01);
+}
+
+TEST_F(SerialFrameParserTests, encodeFramedEmitsExactFrameBytes) {
+    // The typed encoder must produce the identical bytes the hand oracle above
+    // expects: preamble + opcode + packed payload + precomputed CRC.
+    HelloPayload hello{};
+    const uint8_t source[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    const uint8_t head[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01};
+    for (int i = 0; i < 6; ++i) {
+        hello.source[i] = source[i];
+        hello.headMac[i] = head[i];
+    }
+    hello.deviceType = 0x01;
+    hello.confirmed = 0x01;
+
+    // Same bytes the decode oracle above pins: preamble, OP_HELLO, payload, CRC 0xDC48.
+    const std::vector<uint8_t> expected = {0xAA, 0x55, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x01,
+                                           0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x01, 0xDC, 0x48};
+    EXPECT_EQ(encodeFramed(hello), expected);
 }
 
 TEST_F(SerialFrameParserTests, encodeFramedRoundTripsThroughParser) {
-    // The encoder is the parser's inverse: a frame produced by encodeFramed
-    // must parse back to the identical opcode + payload.
+    // The typed encoder is the parser's inverse: a HelloPayload framed by
+    // encodeFramed must decode back to the identical field values.
     int frameCount = 0;
-    Frame got;
-    parser.setBinaryFrameHandler([&](const Frame& f) { got = f; ++frameCount; });
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; ++frameCount; });
 
-    std::vector<uint8_t> payload = helloPayload(0xA7);
-    std::vector<uint8_t> frame = encodeFramed(OP_HELLO, payload);
-    feed(frame);
+    HelloPayload sent{};
+    sent.source[0] = 0xA7;
+    sent.deviceType = 0x02;
+    sent.headMac[3] = 0x99;
+    sent.confirmed = 0x01;
+    feed(encodeFramed(sent));
 
     ASSERT_EQ(frameCount, 1);
-    EXPECT_EQ(got.opcode, OP_HELLO);
-    EXPECT_EQ(got.payload, payload);
+    EXPECT_EQ(got.source[0], 0xA7);
+    EXPECT_EQ(got.deviceType, 0x02);
+    EXPECT_EQ(got.headMac[3], 0x99);
+    EXPECT_EQ(got.confirmed, 0x01);
 }
 
 TEST_F(SerialFrameParserTests, badCrcDropsFrame) {
     int frameCount = 0;
-    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
 
     // Full-length frame so the parser consumes everything and actually reaches
     // the CRC comparison. A short payload would end mid-CRC-read and drop the
@@ -118,7 +168,7 @@ TEST_F(SerialFrameParserTests, badCrcDropsFrame) {
 
 TEST_F(SerialFrameParserTests, unknownOpcodeDrops) {
     int frameCount = 0;
-    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
 
     // 0x99 is not an opcode; neither is 0x01 (the fork's BEACON, not ported).
     feed({0xAA, 0x55, 0x99, 0x01, 0x02, 0x03, 0x04});
@@ -132,8 +182,8 @@ TEST_F(SerialFrameParserTests, unknownOpcodeDrops) {
 
 TEST_F(SerialFrameParserTests, fragmentedFrameAssembles) {
     int frameCount = 0;
-    Frame got;
-    parser.setBinaryFrameHandler([&](const Frame& f) { got = f; ++frameCount; });
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; ++frameCount; });
 
     std::vector<uint8_t> frame = buildFrame(OP_HELLO, helloPayload(0x01));
     for (uint8_t b : frame) {
@@ -142,15 +192,13 @@ TEST_F(SerialFrameParserTests, fragmentedFrameAssembles) {
     }
 
     ASSERT_EQ(frameCount, 1);
-    EXPECT_EQ(got.opcode, OP_HELLO);
-    ASSERT_EQ(got.payload.size(), HELLO_PAYLOAD_LEN);
-    EXPECT_EQ(got.payload[0], 0x01);
-    EXPECT_EQ(got.payload[5], 0x60);
+    EXPECT_EQ(got.source[0], 0x01);
+    EXPECT_EQ(got.source[5], 0x60);
 }
 
 TEST_F(SerialFrameParserTests, midFrameTimeoutResets) {
     int frameCount = 0;
-    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
 
     // Inject just the preamble + opcode + partial payload, then stall.
     feed({0xAA, 0x55, OP_HELLO, 0xDE, 0xAD, 0xBE});
@@ -169,7 +217,7 @@ TEST_F(SerialFrameParserTests, requestResetClearsPartialFrameAtNextFeed) {
     // The cross-thread reset used when a jack is declared dead: mid-frame state
     // from the dying connection must not corrupt the next device to plug in.
     int frameCount = 0;
-    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
 
     // Partial frame in flight, then a reset requested from "another thread".
     feed({0xAA, 0x55, OP_HELLO, 0x01, 0x02, 0x03});
@@ -183,8 +231,8 @@ TEST_F(SerialFrameParserTests, requestResetClearsPartialFrameAtNextFeed) {
 
 TEST_F(SerialFrameParserTests, garbageThenValidFrameResyncs) {
     int frameCount = 0;
-    Frame got;
-    parser.setBinaryFrameHandler([&](const Frame& f) { got = f; ++frameCount; });
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; ++frameCount; });
 
     // Leading line noise with no preamble must be discarded, and the parser must
     // resync on the next 0xAA 0x55 rather than swallowing the following frame.
@@ -192,13 +240,12 @@ TEST_F(SerialFrameParserTests, garbageThenValidFrameResyncs) {
     feed(buildFrame(OP_HELLO, helloPayload(0xA1)));
 
     ASSERT_EQ(frameCount, 1);
-    EXPECT_EQ(got.opcode, OP_HELLO);
-    EXPECT_EQ(got.payload[0], 0xA1);
+    EXPECT_EQ(got.source[0], 0xA1);
 }
 
 TEST_F(SerialFrameParserTests, doubleAAResyncsToPreamble) {
     int frameCount = 0;
-    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
 
     // A stray extra 0xAA before the real preamble: GotAA on another 0xAA must
     // stay in GotAA so 0xAA 0xAA 0x55 still opens a frame rather than aborting.
@@ -213,7 +260,7 @@ TEST_F(SerialFrameParserTests, doubleAAResyncsToPreamble) {
 
 TEST_F(SerialFrameParserTests, splitPreambleAcrossFeeds) {
     int frameCount = 0;
-    parser.setBinaryFrameHandler([&](const Frame&) { ++frameCount; });
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
 
     // The 0xAA and 0x55 of the preamble arrive in separate feed() calls; the
     // GotAA state must survive across reads.

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -16,6 +16,7 @@
 #include "quickdraw-integration-tests.hpp"
 #include "hwm-tests.hpp"
 #include "rdc-tests.hpp"
+#include "rdc-hello-tests.hpp"
 #include "chain-duel-manager-tests.hpp"
 #include "chain-duel-multi-device-fixture.hpp"
 #include "shootout-manager-tests.hpp"
@@ -1285,6 +1286,38 @@ TEST_F(RDCTests, ackedAnnouncementDoesNotRetransmit) {
 
 TEST_F(RDCTests, announcementAbandonedAfterMaxRetries) {
     rdcAnnouncementAbandonedAfterMaxRetries(this);
+}
+
+// ============================================
+// RDC PER-JACK HELLO TESTS (#155)
+// ============================================
+
+TEST_F(RDCHelloTests, newMacDrivesConnecting) {
+    rdcHelloNewMacDrivesConnecting(this);
+}
+
+TEST_F(RDCHelloTests, contextCompleteConnects) {
+    rdcHelloContextCompleteConnects(this);
+}
+
+TEST_F(RDCHelloTests, silentLinkDisconnects) {
+    rdcHelloSilentLinkDisconnects(this);
+}
+
+TEST_F(RDCHelloTests, emitProducesFramesOnBothJacks) {
+    rdcHelloEmitProducesFramesOnBothJacks(this);
+}
+
+TEST_F(RDCHelloTests, outputJackInitiatesContext) {
+    rdcHelloOutputJackInitiatesContext(this);
+}
+
+TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {
+    rdcHelloByteModeSuppressesStringAssembly();
+}
+
+TEST(RDCHelloStandalone, syncSkipsHandshakeOnStateLoop) {
+    rdcHelloSyncSkipsHandshakeOnStateLoop();
 }
 
 // ============================================

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1296,6 +1296,10 @@ TEST_F(RDCHelloTests, newMacDrivesConnecting) {
     rdcHelloNewMacDrivesConnecting(this);
 }
 
+TEST_F(RDCHelloTests, rejectsSelfAndZeroSource) {
+    rdcHelloRejectsSelfAndZeroSource(this);
+}
+
 TEST_F(RDCHelloTests, contextCompleteConnects) {
     rdcHelloContextCompleteConnects(this);
 }


### PR DESCRIPTION
Closes #155. **Stacked on #186** (HelloPayload). Until #186 merges this PR's diff also shows its HelloPayload commit; the #155 work is the three `rdc:` commits on top.

HELLO is **off by default** (`enableHelloConnectivity()` has no production caller yet), so production stays on the old handshake until #156/#157 wire it on. This adds the machinery alongside the untouched handshake, per scope.

## Where to look
- **Serial coexistence.** One RX pump per jack, and string-assembly vs binary-framing are mutually exclusive. So the native serial driver gets an additive byte-callback mode (`exec()` feeds raw bytes to the parser when set, else unchanged), the RDC feeds each HELLO jack's `SerialFrameParser`, and `sync()` skips the handshake `onStateLoop` on HELLO jacks. HandshakeApp is quiesced, not deleted (that's #160).
- **Threading split.** The FreeRTOS task does TX-only HELLO emit; all RX/SM/watchdog/callbacks run on the main loop from `sync()`, so the jack SM is single-threaded. TX-on-task + RX-on-main-loop share the UART safely (separate FIFOs).
- **Teardown.** Cooperative task stop (no cross-core `vTaskDelete`) and the dtor clears the jack byte callbacks (they capture `this`). Fixture declares the RDC after the drivers so it's destroyed first, matching production lifetime.

## Validation
Native suite green; esp32 firmware compiles. The FreeRTOS task path is compile-verified only, **not hardware-validated**. Context exchange (#157) and the device chain SM (#156) are placeholders here.