### PR TITLE
rdc: ESP-NOW context exchange over ReliableChannel (#157)

### DIFF
--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -19,8 +19,44 @@ enum class PktType : uint8_t {
     kShootoutCommandAck = 12,
     kSymbolMatchCommand = 13,
     kFdnConnect = 14,
+    kPdnConnectionContext = 15,
+    kFdnConnectionContext = 16,
     kNumPacketTypes  // Not a real packet type, DO NOT USE
 };
+
+// A player's identity + game state, exchanged once per jack connection so a
+// neighbour knows who it is plugged into. Packed: the struct layout IS the
+// wire format (both ends run the same firmware). RDC never reads these fields —
+// it forwards the profile to the game layer opaquely.
+struct PlayerProfile {
+    uint16_t userId;
+    uint8_t gameRole;
+    uint8_t allegiance;
+    char faction[8];
+    char name[16];
+} __attribute__((packed));
+
+// PDN-to-neighbour connection context. seqId is stamped by the ReliableChannel.
+// chainRole is recorded by the receiver for the device chain SM (#156); this
+// issue does not act on it.
+struct PdnConnectionContext {
+    uint8_t seqId;
+    uint8_t chainRole;
+    PlayerProfile player;
+} __attribute__((packed));
+
+// FDN self-description. ponytail: fields TBD (#156-era); one reserved byte keeps
+// the struct non-empty and packed until the FDN profile is designed.
+struct FdnProfile {
+    uint8_t reserved;
+} __attribute__((packed));
+
+// FDN-to-neighbour connection context; mirrors PdnConnectionContext.
+struct FdnConnectionContext {
+    uint8_t seqId;
+    uint8_t chainRole;
+    FdnProfile fdn;
+} __attribute__((packed));
 
 struct DataPktHdr
 {

--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -37,8 +37,7 @@ struct PlayerProfile {
 } __attribute__((packed));
 
 // PDN-to-neighbour connection context. seqId is stamped by the ReliableChannel.
-// chainRole is recorded by the receiver for the device chain SM (#156); this
-// issue does not act on it.
+// chainRole is recorded by the receiver for the device chain SM (#156).
 struct PdnConnectionContext {
     uint8_t seqId;
     uint8_t chainRole;

--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -37,7 +37,8 @@ struct PlayerProfile {
 } __attribute__((packed));
 
 // PDN-to-neighbour connection context. seqId is stamped by the ReliableChannel.
-// chainRole is recorded by the receiver for the device chain SM (#156).
+// chainRole is recorded by the receiver for the device chain SM (#156). The peer's
+// device kind arrives out-of-band in HELLO and picks which context struct to decode.
 struct PdnConnectionContext {
     uint8_t seqId;
     uint8_t chainRole;
@@ -50,7 +51,7 @@ struct FdnProfile {
     uint8_t reserved;
 } __attribute__((packed));
 
-// FDN-to-neighbour connection context; mirrors PdnConnectionContext.
+// FDN-to-neighbour connection context; same header as PdnConnectionContext, FDN body.
 struct FdnConnectionContext {
     uint8_t seqId;
     uint8_t chainRole;

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -30,9 +30,12 @@ enum HelloLinkStateId {
 struct HelloLinkContext {
     SerialIdentifier jack{};
     std::function<unsigned long()> nowMs;
-    std::function<void(SerialIdentifier)> onContextRequest;   // OUT jack only
+    std::function<void(SerialIdentifier)> onContextRequest;    // OUT jack only
     std::function<void(SerialIdentifier, bool)> onJackChange;  // connect / disconnect
     std::function<void()> resetParser;                         // on link death
+    // Fired once per link death with the peer the link was tracking; both the
+    // Connected silent-link edge and the Connecting timeout converge on Idle.
+    std::function<void(SerialIdentifier, const std::array<uint8_t, 6>&)> onLinkDown;
 
     unsigned long silentLinkMs = 100;
     unsigned long contextTimeoutMs = 500;
@@ -50,9 +53,21 @@ struct HelloLinkContext {
 
 class HelloIdleState : public State {
 public:
-    explicit HelloIdleState(HelloLinkContext* context) : State(HELLO_LINK_IDLE), context(context) {}
+    explicit HelloIdleState(HelloLinkContext* context)
+        : State(HELLO_LINK_IDLE)
+        , context(context) {}
 
-    void onStateMounted(Device*) override { transitionToConnectingState = false; }
+    // Every teardown (silent link or context timeout) converges on Idle, so this is
+    // the one seam where a tracked peer is released. The initial mount sees an
+    // all-zero peerMac and fires nothing; clearing keeps peer() true to its contract.
+    void onStateMounted(Device*) override {
+        transitionToConnectingState = false;
+        const std::array<uint8_t, 6> zero{};
+        if (context->peerMac != zero) {
+            if (context->onLinkDown) context->onLinkDown(context->jack, context->peerMac);
+            context->peerMac = zero;
+        }
+    }
 
     void arm() { transitionToConnectingState = true; }
     bool transitionToConnecting() { return transitionToConnectingState; }

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -164,8 +164,7 @@ public:
         return currentState ? currentState->getStateId() : HELLO_LINK_IDLE;
     }
 
-    /// The peer this link tracks (last HELLO source); all-zero while Idle. #157
-    /// matches a received context back to its jack through this.
+    /// The peer this link tracks (last HELLO source); all-zero while Idle.
     const std::array<uint8_t, 6>& peer() const { return context.peerMac; }
 
 private:

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -164,6 +164,10 @@ public:
         return currentState ? currentState->getStateId() : HELLO_LINK_IDLE;
     }
 
+    /// The peer this link tracks (last HELLO source); all-zero while Idle. #157
+    /// matches a received context back to its jack through this.
+    const std::array<uint8_t, 6>& peer() const { return context.peerMac; }
+
 private:
     HelloLinkContext context;
 };

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -53,13 +53,14 @@ struct HelloLinkContext {
 
 class HelloIdleState : public State {
 public:
+    /// Binds the shared per-jack context; the machine owns the state.
     explicit HelloIdleState(HelloLinkContext* context)
         : State(HELLO_LINK_IDLE)
         , context(context) {}
 
-    // Every teardown (silent link or context timeout) converges on Idle, so this is
-    // the one seam where a tracked peer is released. The initial mount sees an
-    // all-zero peerMac and fires nothing; clearing keeps peer() true to its contract.
+    /// Every teardown (silent link or context timeout) converges on Idle, so this is
+    /// the one seam where a tracked peer is released. The initial mount sees an
+    /// all-zero peerMac and fires nothing; clearing keeps peer() true to its contract.
     void onStateMounted(Device*) override {
         transitionToConnectingState = false;
         const std::array<uint8_t, 6> zero{};

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -179,6 +179,14 @@ public:
         return currentState ? currentState->getStateId() : HELLO_LINK_IDLE;
     }
 
+    /// True in the window between the exchange completing and the Connecting ->
+    /// Connected commit (which lands at the end of the next tick); the jack still
+    /// reports Connecting there, so callers use this to spot the duplicate.
+    bool didMarkContextComplete() const {
+        return currentState && currentState->getStateId() == HELLO_LINK_CONNECTING &&
+               static_cast<HelloConnectingState*>(currentState)->transitionToConnected();
+    }
+
     /// The peer this link tracks (last HELLO source); all-zero while Idle.
     const std::array<uint8_t, 6>& peer() const { return context.peerMac; }
 

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -70,10 +70,10 @@ public:
     void onStateMounted(Device*) override {
         connectingSinceMs = context->nowMs();
         transitionToConnectedState = false;
-        // Output-jack-initiates: only the OUT jack requests the context exchange.
-        if (context->jack == SerialIdentifier::OUTPUT_JACK && context->onContextRequest) {
-            context->onContextRequest(context->jack);
-        }
+        // Every jack initiates its own context on connecting and completes when the
+        // peer's arrives; there is no initiator/replier asymmetry, so two devices
+        // whose jacks face each other (a 2-node ring) can't ping-pong.
+        if (context->onContextRequest) context->onContextRequest(context->jack);
     }
 
     void markContextComplete() { transitionToConnectedState = true; }

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -30,7 +30,7 @@ enum HelloLinkStateId {
 struct HelloLinkContext {
     SerialIdentifier jack{};
     std::function<unsigned long()> nowMs;
-    std::function<void(SerialIdentifier)> onContextRequest;    // OUT jack only
+    std::function<void(SerialIdentifier)> onContextRequest;    // every jack, on entering Connecting
     std::function<void(SerialIdentifier, bool)> onJackChange;  // connect / disconnect
     std::function<void()> resetParser;                         // on link death
     // Fired once per link death with the peer the link was tracking; both the

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -347,13 +347,10 @@ private:
     void initiateContextExchange(SerialIdentifier jack);
     // Serialize + reliably send this device's context to `mac` per selfDeviceType.
     void sendSelfContext(const uint8_t* mac);
-    // Base channel for this device's own context type (nullptr before init).
-    ReliableChannelBase* selfContextChannel() const;
     // A received peer context: register, record chainRole, hand off the profile
-    // opaquely, match the MAC to its jack, and complete that jack's exchange.
+    // opaquely, match the MAC to its jack(s), and complete each jack's exchange.
     void onContextReceived(const uint8_t* fromMac, DeviceType peerType,
                            uint8_t chainRole, const uint8_t* profile, size_t len);
-    // Jack whose HELLO link currently names `mac`, or false if none.
 #ifndef NATIVE_BUILD
     TaskHandle_t connectivityTaskHandle = nullptr;
     // Cooperative stop: the destructor sets stopRequested and waits for the task

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -152,7 +152,7 @@ public:
     }
 
     /// Supplies this device's outgoing player profile, forwarded verbatim in the
-    /// context this device sends to a new OUT-jack peer. Opaque to RDC.
+    /// context this device sends to a new peer on any jack. Opaque to RDC.
     void setSelfPlayerProfile(const PlayerProfile& profile) {
         selfPlayerProfile = profile;
     }
@@ -342,8 +342,9 @@ private:
     ReliableChannel<PdnConnectionContext>* pdnContextChannel = nullptr;
     ReliableChannel<FdnConnectionContext>* fdnContextChannel = nullptr;
 
-    // OUT jack initiates: register the peer as a radio slot, then send this
-    // device's context reliably. Re-callable to re-send after a headMac change.
+    // A jack entering Connecting initiates: register the peer as a radio slot, then
+    // reliably send this device's context (skipped if our other jack already has a
+    // send pending to that same peer, as in a 2-node ring).
     void initiateContextExchange(SerialIdentifier jack);
     // Serialize + reliably send this device's context to `mac` per selfDeviceType.
     void sendSelfContext(const uint8_t* mac);

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -353,6 +353,8 @@ private:
     // early-arrival (that link then half-opens, same as with no buffer). Legitimate
     // occupancy is at most one per jack.
     static constexpr size_t CONTEXT_BUFFER_SLOTS = 8;
+    // TTL = silent-link window on purpose: a live peer's HELLO lands inside that
+    // window, so a context older than it can never pair with a connecting jack.
     static constexpr unsigned long CONTEXT_BUFFER_TTL_MS = HELLO_SILENT_LINK_MS;
     struct BufferedContext {
         std::array<uint8_t, 6> mac{};
@@ -362,6 +364,9 @@ private:
         size_t len = 0;
         unsigned long arrivedAtMs = 0;
         bool valid = false;
+        bool isExpiredAt(unsigned long now) const {
+            return now >= arrivedAtMs && now - arrivedAtMs > CONTEXT_BUFFER_TTL_MS;
+        }
     };
     std::array<BufferedContext, CONTEXT_BUFFER_SLOTS> contextBuffer_;
 
@@ -371,9 +376,7 @@ private:
     void initiateContextExchange(SerialIdentifier jack);
     // Serialize + reliably send this device's context to `mac` per selfDeviceType.
     void sendSelfContext(const uint8_t* mac);
-    // Route a received peer context: cache it keyed by MAC, then complete every jack
-    // already CONNECTING for that MAC. Caching also serves a jack that reaches
-    // CONNECTING after this arrives (early context, or a 2-node ring's second jack).
+    // Cache a received peer context by MAC, then apply it to jacks (rationale in .cpp).
     void onContextReceived(const uint8_t* fromMac, DeviceType peerType,
                            uint8_t chainRole, const uint8_t* profile, size_t len);
     // Completes every jack currently CONNECTING to `fromMac` (live receive path).

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -165,7 +165,7 @@ public:
     /// The chainRole recorded from the peer's context on `jack`; 0 until one
     /// arrives. Recorded for the device chain SM (#156), not acted on here.
     uint8_t getPeerChainRole(SerialIdentifier jack) const {
-        return helloByPort_[portIndex(jack)].peerChainRole;
+        return helloByPort[portIndex(jack)].peerChainRole;
     }
 
     /// True while a context send to `mac` is still awaiting its SEND_SUCCESS.
@@ -330,12 +330,12 @@ private:
         // CONNECTED-state resend so two CONNECTED sides can't volley at radio RTT.
         unsigned long lastContextResendMs = 0;
     };
-    std::array<JackHelloLink, kNumPorts> helloByPort_;
+    std::array<JackHelloLink, kNumPorts> helloByPort;
     bool helloConnectivityEnabled = false;
     bool externalConnectivityTask = false;
     ContextReceivedCallback contextReceivedCallback;
     PlayerProfile selfPlayerProfile{};
-    std::array<uint8_t, 6> selfMac_{};
+    std::array<uint8_t, 6> selfMac{};
     DeviceType selfDeviceType = DeviceType::UNKNOWN;
 
     // Owned reliable transport + one context channel per device-type PktType.
@@ -368,7 +368,7 @@ private:
             return now >= arrivedAtMs && now - arrivedAtMs > CONTEXT_BUFFER_TTL_MS;
         }
     };
-    std::array<BufferedContext, CONTEXT_BUFFER_SLOTS> contextBuffer_;
+    std::array<BufferedContext, CONTEXT_BUFFER_SLOTS> contextBuffer;
 
     // A jack entering Connecting initiates: apply any context buffered for its peer,
     // register the peer as a radio slot, then reliably send this device's context

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -342,16 +342,44 @@ private:
     ReliableChannel<PdnConnectionContext>* pdnContextChannel = nullptr;
     ReliableChannel<FdnConnectionContext>* fdnContextChannel = nullptr;
 
-    // A jack entering Connecting initiates: register the peer as a radio slot, then
-    // reliably send this device's context (skipped if our other jack already has a
-    // send pending to that same peer, as in a 2-node ring).
+    // A context (ESP-NOW) can beat its own HELLO (serial) and arrive before any jack
+    // is CONNECTING for that MAC. Rather than drop it, hold it here and apply it when
+    // the jack connects. Bounded + TTL'd on purpose: an on-channel attacker who knows
+    // our MAC can spray contexts from fabricated sources, so the fixed cap is the OOM
+    // guard and the short TTL clears junk; the worst it can do is evict a genuine
+    // early-arrival (that link then half-opens, same as with no buffer). Legitimate
+    // occupancy is at most one per jack.
+    static constexpr size_t CONTEXT_BUFFER_SLOTS = 8;
+    static constexpr unsigned long CONTEXT_BUFFER_TTL_MS = HELLO_SILENT_LINK_MS;
+    struct BufferedContext {
+        std::array<uint8_t, 6> mac{};
+        DeviceType peerType = DeviceType::UNKNOWN;
+        uint8_t chainRole = 0;
+        std::array<uint8_t, sizeof(PlayerProfile)> profile{};
+        size_t len = 0;
+        unsigned long arrivedAtMs = 0;
+        bool valid = false;
+    };
+    std::array<BufferedContext, CONTEXT_BUFFER_SLOTS> contextBuffer_;
+
+    // A jack entering Connecting initiates: apply any context buffered for its peer,
+    // register the peer as a radio slot, then reliably send this device's context
+    // (skipped if our other jack already has a send pending to that same peer).
     void initiateContextExchange(SerialIdentifier jack);
     // Serialize + reliably send this device's context to `mac` per selfDeviceType.
     void sendSelfContext(const uint8_t* mac);
-    // A received peer context: register, record chainRole, hand off the profile
-    // opaquely, match the MAC to its jack(s), and complete each jack's exchange.
+    // Route a received peer context: complete every CONNECTING jack for its MAC, or
+    // buffer it if none is CONNECTING yet (its HELLO hasn't arrived).
     void onContextReceived(const uint8_t* fromMac, DeviceType peerType,
                            uint8_t chainRole, const uint8_t* profile, size_t len);
+    // Completes every CONNECTING jack whose peer is `fromMac`; true if any matched.
+    bool applyContextToJacks(const uint8_t* fromMac, DeviceType peerType,
+                             uint8_t chainRole, const uint8_t* profile, size_t len);
+    // Holds a context whose jack is not yet CONNECTING; evicts oldest when full.
+    void bufferContext(const uint8_t* fromMac, DeviceType peerType, uint8_t chainRole,
+                       const uint8_t* profile, size_t len);
+    // Applies and clears any buffered context for `mac` now that its jack connects.
+    void drainBufferedContext(const uint8_t* mac);
 #ifndef NATIVE_BUILD
     TaskHandle_t connectivityTaskHandle = nullptr;
     // Cooperative stop: the destructor sets stopRequested and waits for the task

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -10,6 +10,7 @@
 #include "device/serial-frame-parser.hpp"
 #include "utils/simple-timer.hpp"
 #include "wireless/handshake-wireless-manager.hpp"
+#include "wireless/reliable-transport.hpp"
 #include "device/device-type.hpp"
 
 #ifndef NATIVE_BUILD
@@ -139,13 +140,36 @@ public:
                                 CONNECTING,
                                 CONNECTED };
 
-    // Fires on the OUT jack when a new HELLO source appears: the output jack
-    // initiates the context request (#157 placeholder). The IN jacks never do.
-    using ContextRequestCallback = std::function<void(SerialIdentifier jack)>;
-    /// Registers the output-jack context-request initiator (#157 placeholder).
-    void setOnContextRequest(ContextRequestCallback callback) {
-        contextRequestCallback = std::move(callback);
+    /// Hands a received peer context to the game layer opaquely: the jack it
+    /// arrived on, the peer's device kind, and the raw profile bytes
+    /// (PlayerProfile for PDN, FdnProfile for FDN). RDC never interprets them.
+    using ContextReceivedCallback =
+        std::function<void(SerialIdentifier jack, DeviceType peerType,
+                           const uint8_t* profile, size_t len)>;
+    /// Registers the opaque peer-context consumer.
+    void setOnContextReceived(ContextReceivedCallback callback) {
+        contextReceivedCallback = std::move(callback);
     }
+
+    /// Supplies this device's outgoing player profile, forwarded verbatim in the
+    /// context this device sends to a new OUT-jack peer. Opaque to RDC.
+    void setSelfPlayerProfile(const PlayerProfile& profile) {
+        selfPlayerProfile = profile;
+    }
+
+    /// The chainRole recorded from the peer's context on `jack`; 0 until one
+    /// arrives. Recorded for the device chain SM (#156), not acted on here.
+    uint8_t getPeerChainRole(SerialIdentifier jack) const {
+        return helloByPort_[portIndex(jack)].peerChainRole;
+    }
+
+    /// True while a context send to `mac` is still awaiting its SEND_SUCCESS.
+    bool isContextSendPending(const uint8_t* mac) const;
+
+    /// The reliable transport driving the context exchange. Exposed so tests can
+    /// inject SEND_SUCCESS (onSendResult) and inbound contexts (deliverIncoming)
+    /// without a radio.
+    ReliableTransport* getReliableTransport() { return transport; }
 
     /// Wires byte callbacks + parsers on every present jack, quiesces the
     /// handshake, and (unless external) spawns the emit task. Idempotent.
@@ -300,13 +324,37 @@ private:
     struct JackHelloLink {
         SerialFrameParser parser;  // non-copyable; default-constructed in place
         HelloLinkMachine* machine = nullptr;  // per-jack link SM; owned, deleted in dtor
+        // Recorded from the peer's received context; consumed by the chain SM (#156).
+        uint8_t peerChainRole = 0;
     };
     std::array<JackHelloLink, kNumPorts> helloByPort_;
     bool helloConnectivityEnabled = false;
     bool externalConnectivityTask = false;
-    ContextRequestCallback contextRequestCallback;
+    ContextReceivedCallback contextReceivedCallback;
+    PlayerProfile selfPlayerProfile{};
     std::array<uint8_t, 6> selfMac_{};
     DeviceType selfDeviceType = DeviceType::UNKNOWN;
+
+    // Owned reliable transport + one context channel per device-type PktType.
+    // Device-level, not per-jack: on receive the source MAC is matched back to a
+    // jack. Constructed in initialize() once the WirelessManager is known.
+    ReliableTransport* transport = nullptr;
+    ReliableChannel<PdnConnectionContext>* pdnContextChannel = nullptr;
+    ReliableChannel<FdnConnectionContext>* fdnContextChannel = nullptr;
+
+    // OUT jack initiates: register the peer as a radio slot, then send this
+    // device's context reliably. Re-callable to re-send after a headMac change.
+    void initiateContextExchange(SerialIdentifier jack);
+    // Serialize + reliably send this device's context to `mac` per selfDeviceType.
+    void sendSelfContext(const uint8_t* mac);
+    // Base channel for this device's own context type (nullptr before init).
+    ReliableChannelBase* selfContextChannel() const;
+    // A received peer context: register, record chainRole, hand off the profile
+    // opaquely, match the MAC to its jack, and complete that jack's exchange.
+    void onContextReceived(const uint8_t* fromMac, DeviceType peerType,
+                           uint8_t chainRole, const uint8_t* profile, size_t len);
+    // Jack whose HELLO link currently names `mac`, or false if none.
+    bool findJackForMac(const uint8_t* mac, SerialIdentifier& jack) const;
 #ifndef NATIVE_BUILD
     TaskHandle_t connectivityTaskHandle = nullptr;
     // Cooperative stop: the destructor sets stopRequested and waits for the task

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -21,6 +21,7 @@
 class Device;
 class HandshakeApp;
 class HelloLinkMachine;
+class RDCHelloTests;  // drives the context exchange via the owned transport in tests
 
 enum class PortStatus {
     DISCONNECTED = 0,  // No Connection. Handshake is in Idle state.
@@ -46,6 +47,10 @@ struct PortState {
 };
 
 class RemoteDeviceCoordinator {
+    // Reaches the owned transport to inject SEND_SUCCESS / inbound contexts without
+    // a radio; the transport stays out of the public API.
+    friend class RDCHelloTests;
+
 public:
     /// Fires on a per-jack connect (true) / disconnect (false) transition.
     using JackChangeCallback = std::function<void(SerialIdentifier jack, bool connected)>;
@@ -165,11 +170,6 @@ public:
 
     /// True while a context send to `mac` is still awaiting its SEND_SUCCESS.
     bool isContextSendPending(const uint8_t* mac) const;
-
-    /// The reliable transport driving the context exchange. Exposed so tests can
-    /// inject SEND_SUCCESS (onSendResult) and inbound contexts (deliverIncoming)
-    /// without a radio.
-    ReliableTransport* getReliableTransport() { return transport; }
 
     /// Wires byte callbacks + parsers on every present jack, quiesces the
     /// handshake, and (unless external) spawns the emit task. Idempotent.
@@ -368,18 +368,24 @@ private:
     void initiateContextExchange(SerialIdentifier jack);
     // Serialize + reliably send this device's context to `mac` per selfDeviceType.
     void sendSelfContext(const uint8_t* mac);
-    // Route a received peer context: complete every CONNECTING jack for its MAC, or
-    // buffer it if none is CONNECTING yet (its HELLO hasn't arrived).
+    // Route a received peer context: cache it keyed by MAC, then complete every jack
+    // already CONNECTING for that MAC. Caching also serves a jack that reaches
+    // CONNECTING after this arrives (early context, or a 2-node ring's second jack).
     void onContextReceived(const uint8_t* fromMac, DeviceType peerType,
                            uint8_t chainRole, const uint8_t* profile, size_t len);
-    // Completes every CONNECTING jack whose peer is `fromMac`; true if any matched.
-    bool applyContextToJacks(const uint8_t* fromMac, DeviceType peerType,
+    // Completes every jack currently CONNECTING to `fromMac` (live receive path).
+    void applyContextToJacks(const uint8_t* fromMac, DeviceType peerType,
                              uint8_t chainRole, const uint8_t* profile, size_t len);
+    // Assumes `jack` is CONNECTING to this peer; both timing paths route through here,
+    // so the context callback fires exactly once per jack.
+    void completeJackContext(SerialIdentifier jack, DeviceType peerType, uint8_t chainRole,
+                             const uint8_t* profile, size_t len);
     // Holds a context whose jack is not yet CONNECTING; evicts oldest when full.
     void bufferContext(const uint8_t* fromMac, DeviceType peerType, uint8_t chainRole,
                        const uint8_t* profile, size_t len);
-    // Applies and clears any buffered context for `mac` now that its jack connects.
-    void drainBufferedContext(const uint8_t* mac);
+    // Applies any cached context for `jack`'s peer to `jack` as it connects. Leaves
+    // the cache entry for the peer's other jack (2-node ring); the TTL clears it.
+    void drainBufferedContext(SerialIdentifier jack, const uint8_t* mac);
 #ifndef NATIVE_BUILD
     TaskHandle_t connectivityTaskHandle = nullptr;
     // Cooperative stop: the destructor sets stopRequested and waits for the task

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -326,9 +326,6 @@ private:
         HelloLinkMachine* machine = nullptr;  // per-jack link SM; owned, deleted in dtor
         // Recorded from the peer's received context; consumed by the chain SM (#156).
         uint8_t peerChainRole = 0;
-        // Last head advertised in this peer's HELLO; a change mid-exchange re-sends
-        // our context to the new head. The link SM does not model headMac.
-        std::array<uint8_t, 6> lastHeadMac{};
     };
     std::array<JackHelloLink, kNumPorts> helloByPort_;
     bool helloConnectivityEnabled = false;

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -326,6 +326,9 @@ private:
         HelloLinkMachine* machine = nullptr;  // per-jack link SM; owned, deleted in dtor
         // Recorded from the peer's received context; consumed by the chain SM (#156).
         uint8_t peerChainRole = 0;
+        // Last recovery resend to this jack's peer (0 = never); throttles the
+        // CONNECTED-state resend so two CONNECTED sides can't volley at radio RTT.
+        unsigned long lastContextResendMs = 0;
     };
     std::array<JackHelloLink, kNumPorts> helloByPort_;
     bool helloConnectivityEnabled = false;

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -386,6 +386,9 @@ private:
     // Applies any cached context for `jack`'s peer to `jack` as it connects. Leaves
     // the cache entry for the peer's other jack (2-node ring); the TTL clears it.
     void drainBufferedContext(SerialIdentifier jack, const uint8_t* mac);
+    // Link death on `jack`: release the peer's radio slot unless another jack or a
+    // daisy chain still references the MAC (2-node ring keeps the slot).
+    void releaseHelloPeer(SerialIdentifier jack, const uint8_t* mac);
 #ifndef NATIVE_BUILD
     TaskHandle_t connectivityTaskHandle = nullptr;
     // Cooperative stop: the destructor sets stopRequested and waits for the task

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -326,6 +326,9 @@ private:
         HelloLinkMachine* machine = nullptr;  // per-jack link SM; owned, deleted in dtor
         // Recorded from the peer's received context; consumed by the chain SM (#156).
         uint8_t peerChainRole = 0;
+        // Last head advertised in this peer's HELLO; a change mid-exchange re-sends
+        // our context to the new head. The link SM does not model headMac.
+        std::array<uint8_t, 6> lastHeadMac{};
     };
     std::array<JackHelloLink, kNumPorts> helloByPort_;
     bool helloConnectivityEnabled = false;

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -354,7 +354,6 @@ private:
     void onContextReceived(const uint8_t* fromMac, DeviceType peerType,
                            uint8_t chainRole, const uint8_t* profile, size_t len);
     // Jack whose HELLO link currently names `mac`, or false if none.
-    bool findJackForMac(const uint8_t* mac, SerialIdentifier& jack) const;
 #ifndef NATIVE_BUILD
     TaskHandle_t connectivityTaskHandle = nullptr;
     // Cooperative stop: the destructor sets stopRequested and waits for the task

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -636,6 +636,9 @@ void RemoteDeviceCoordinator::enableHelloConnectivity() {
         context.resetParser = [this, port] {
             helloByPort_[portIndex(port)].parser.requestReset();
         };
+        context.onLinkDown = [this](SerialIdentifier j, const std::array<uint8_t, 6>& mac) {
+            releaseHelloPeer(j, mac.data());
+        };
         context.silentLinkMs = HELLO_SILENT_LINK_MS;
         context.contextTimeoutMs = CONTEXT_EXCHANGE_TIMEOUT_MS;
         link.machine = new HelloLinkMachine(std::move(context));
@@ -802,6 +805,26 @@ void RemoteDeviceCoordinator::drainBufferedContext(SerialIdentifier jack, const 
         // per-jack keeps the context callback firing exactly once per jack. TTL clears it.
         completeJackContext(jack, e.peerType, e.chainRole, e.profile.data(), e.len);
     }
+}
+
+void RemoteDeviceCoordinator::releaseHelloPeer(SerialIdentifier jack, const uint8_t* mac) {
+    // A 2-node ring has the same peer on both jacks: releasing the radio slot on a
+    // one-cable disconnect would silently break wireless for the still-connected
+    // link, so any other jack tracking this MAC keeps the slot alive.
+    for (SerialIdentifier port : HELLO_JACKS) {
+        if (port == jack) continue;
+        const HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+        if (machine == nullptr || machine->currentStateId() == HELLO_LINK_IDLE) continue;
+        if (memcmp(machine->peer().data(), mac, 6) == 0) return;
+    }
+    // Same guard removeDaisyChainedPeer applies in reverse: a MAC still reachable
+    // through a daisy chain keeps its slot.
+    for (const std::vector<std::array<uint8_t, 6>>& chain : daisyChainedByPort_) {
+        for (const std::array<uint8_t, 6>& m : chain) {
+            if (memcmp(m.data(), mac, 6) == 0) return;
+        }
+    }
+    unregisterPeer(mac);
 }
 
 void RemoteDeviceCoordinator::onContextExchangeComplete(SerialIdentifier jack) {

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -742,7 +742,15 @@ void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceTy
     // Recorded for the device chain SM (#156); not acted on here.
     helloByPort_[portIndex(jack)].peerChainRole = chainRole;
     if (contextReceivedCallback) contextReceivedCallback(jack, peerType, profile, len);
+    // Output initiates, input replies: a peer that arrived on an input jack sent
+    // its context first, so send ours back so its out-jack completes too.
+    // Complete our side BEFORE replying so a same-tick SEND_SUCCESS can't race.
+    // The initiator (this peer on our OUTPUT jack) already sent its context and
+    // must not reply, or the two would ping-pong forever.
     onContextExchangeComplete(jack);
+    if (jack != SerialIdentifier::OUTPUT_JACK) {
+        sendSelfContext(fromMac);
+    }
 }
 
 void RemoteDeviceCoordinator::onContextExchangeComplete(SerialIdentifier jack) {

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -789,6 +789,11 @@ void RemoteDeviceCoordinator::applyContextToJacks(const uint8_t* fromMac, Device
 void RemoteDeviceCoordinator::completeJackContext(SerialIdentifier jack, DeviceType peerType,
                                                   uint8_t chainRole, const uint8_t* profile,
                                                   size_t len) {
+    // A second fresh-seqId context can land before the Connecting -> Connected
+    // commit while the jack still reports CONNECTING; the game callback must
+    // fire exactly once per connect.
+    HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
+    if (machine != nullptr && machine->didMarkContextComplete()) return;
     helloByPort_[portIndex(jack)].peerChainRole = chainRole;
     if (contextReceivedCallback) contextReceivedCallback(jack, peerType, profile, len);
     onContextExchangeComplete(jack);

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -767,10 +767,21 @@ void RemoteDeviceCoordinator::applyContextToJacks(const uint8_t* fromMac, Device
     // ours so its cycle completes. No ping-pong: only the CONNECTING side retries,
     // and it stops once this lands.
     for (SerialIdentifier port : HELLO_JACKS) {
-        const HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
-        if (machine == nullptr || machine->currentStateId() != HELLO_LINK_CONNECTED) continue;
-        if (memcmp(machine->peer().data(), fromMac, 6) != 0) continue;
-        if (!isContextSendPending(fromMac)) sendSelfContext(fromMac);
+        JackHelloLink& link = helloByPort_[portIndex(port)];
+        if (link.machine == nullptr || link.machine->currentStateId() != HELLO_LINK_CONNECTED)
+            continue;
+        if (memcmp(link.machine->peer().data(), fromMac, 6) != 0) continue;
+        // Throttle to one resend per exchange window: every send stamps a fresh
+        // seqId, so dedup can't brake two CONNECTED sides answering each other —
+        // unthrottled they'd volley at radio RTT until link death.
+        const unsigned long now = nowMs();
+        if (link.lastContextResendMs != 0 && now >= link.lastContextResendMs &&
+            now - link.lastContextResendMs < CONTEXT_EXCHANGE_TIMEOUT_MS)
+            return;
+        if (!isContextSendPending(fromMac)) {
+            sendSelfContext(fromMac);
+            link.lastContextResendMs = now;
+        }
         return;
     }
 }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -131,11 +131,10 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
         this
     );
 
-    // Reliable context exchange (#157): one device-level channel per device-type
-    // PktType. Claiming a channel makes its receive path live (the transport
-    // installs the driver rx handler). The abandon callback is a no-op: an
-    // unreachable peer's jack link self-heals to IDLE via the context-exchange
-    // timeout in serviceConnectivity().
+    // One device-level channel per device-type PktType. Claiming a channel makes
+    // its receive path live (the transport installs the driver rx handler). The
+    // abandon callback is a no-op: an unreachable peer's jack link self-heals to
+    // IDLE via the context-exchange timeout (HelloConnectingState, contextTimeoutMs).
     transport = new ReliableTransport(wirelessManager);
     pdnContextChannel = transport->channel<PdnConnectionContext>(
         PktType::kPdnConnectionContext, [](uint8_t, const uint8_t*) {});

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -707,7 +707,7 @@ void RemoteDeviceCoordinator::initiateContextExchange(SerialIdentifier jack) {
 void RemoteDeviceCoordinator::sendSelfContext(const uint8_t* mac) {
     // Each device describes itself, so the payload is chosen by THIS device's kind,
     // not the peer's. chainRole 0 = unresolved: the device chain SM (#156) fills it
-    // once it learns this device's position; out of scope here.
+    // once it learns this device's position.
     if (selfDeviceType == DeviceType::FDN) {
         if (fdnContextChannel == nullptr) return;
         FdnConnectionContext ctx{};

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -838,6 +838,11 @@ void RemoteDeviceCoordinator::drainBufferedContext(SerialIdentifier jack, const 
 }
 
 void RemoteDeviceCoordinator::releaseHelloPeer(SerialIdentifier jack, const uint8_t* mac) {
+    // Per-jack residue clears unconditionally: the keep-slot guards below are
+    // per-MAC, and the next peer on this jack must not inherit the departed
+    // peer's chainRole during its CONNECTING window (#156 reads it then).
+    helloByPort_[portIndex(jack)].peerChainRole = 0;
+    helloByPort_[portIndex(jack)].lastContextResendMs = 0;
     // A 2-node ring has the same peer on both jacks: releasing the radio slot on a
     // one-cable disconnect would silently break wireless for the still-connected
     // link, so any other jack tracking this MAC keeps the slot alive.

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -720,37 +720,37 @@ bool RemoteDeviceCoordinator::isContextSendPending(const uint8_t* mac) const {
     return false;
 }
 
-bool RemoteDeviceCoordinator::findJackForMac(const uint8_t* mac, SerialIdentifier& jack) const {
-    for (SerialIdentifier port : HELLO_JACKS) {
-        const HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
-        if (machine == nullptr || machine->currentStateId() == HELLO_LINK_IDLE) continue;
-        if (memcmp(machine->peer().data(), mac, 6) == 0) {
-            jack = port;
-            return true;
-        }
-    }
-    return false;
-}
-
 void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceType peerType,
                                                 uint8_t chainRole, const uint8_t* profile,
                                                 size_t len) {
-    SerialIdentifier jack;
-    if (!findJackForMac(fromMac, jack)) return;
-    // Register only after a jack matches: an unmatched or late context (its link
-    // already timed out to IDLE) must not leak a peer slot we never send to.
-    registerPeer(fromMac);
-    helloByPort_[portIndex(jack)].peerChainRole = chainRole;
-    if (contextReceivedCallback) contextReceivedCallback(jack, peerType, profile, len);
-    // Output initiates, input replies: a peer that arrived on an input jack sent
-    // its context first, so send ours back so its out-jack completes too.
-    // Complete our side BEFORE replying so a same-tick SEND_SUCCESS can't race.
-    // The initiator (this peer on our OUTPUT jack) already sent its context and
-    // must not reply, or the two would ping-pong forever.
-    onContextExchangeComplete(jack);
-    if (jack != SerialIdentifier::OUTPUT_JACK) {
-        sendSelfContext(fromMac);
+    // A 2-node ring cables BOTH our jacks to the same peer, so one context can
+    // complete more than one link. Complete every jack mid-exchange with this MAC,
+    // not just the first, or the unmatched link times out and opens the ring. Only
+    // a Connecting jack consumes a context: an Idle jack isn't ours, and an
+    // already-Connected one is a duplicate to drop (this also stops the input-reply
+    // below from ping-ponging once both links are up).
+    bool matched = false;
+    bool replyToInput = false;
+    for (SerialIdentifier port : HELLO_JACKS) {
+        HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+        if (machine == nullptr || machine->currentStateId() != HELLO_LINK_CONNECTING) continue;
+        if (memcmp(machine->peer().data(), fromMac, 6) != 0) continue;
+        if (!matched) {
+            matched = true;
+            // Register only after a jack matches, so an unmatched/late context can't
+            // leak a peer slot we never send to.
+            registerPeer(fromMac);
+        }
+        helloByPort_[portIndex(port)].peerChainRole = chainRole;
+        if (contextReceivedCallback) contextReceivedCallback(port, peerType, profile, len);
+        // Complete our side BEFORE replying so a same-tick SEND_SUCCESS can't race.
+        onContextExchangeComplete(port);
+        if (port != SerialIdentifier::OUTPUT_JACK) replyToInput = true;
     }
+    // Output initiates, input replies: a peer that arrived on an input jack sent its
+    // context first, so send ours back so its out-jack completes too. The OUTPUT
+    // initiator already sent first and must not reply, or the two ping-pong.
+    if (replyToInput) sendSelfContext(fromMac);
 }
 
 void RemoteDeviceCoordinator::onContextExchangeComplete(SerialIdentifier jack) {

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -135,8 +135,8 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
     // its receive path live (the transport installs the driver rx handler). The
     // abandon callback is a no-op: an unreachable peer's jack link self-heals to
     // IDLE via the context-exchange timeout (HelloConnectingState, contextTimeoutMs).
-    // The peer's device kind is known from HELLO before the context lands and picks
-    // which channel decodes it; RDC forwards the profile bytes opaquely either way.
+    // The packet's PktType alone picks which channel decodes a context; the
+    // HELLO deviceType is not consulted. RDC forwards the profile bytes opaquely.
     transport = new ReliableTransport(wirelessManager);
     pdnContextChannel = transport->channel<PdnConnectionContext>(
         PktType::kPdnConnectionContext, [](uint8_t, const uint8_t*) {});
@@ -810,8 +810,7 @@ void RemoteDeviceCoordinator::bufferContext(const uint8_t* fromMac, DeviceType p
             slot = &e;
             break;
         }
-        const bool reusable =
-            !e.valid || (now >= e.arrivedAtMs && now - e.arrivedAtMs > CONTEXT_BUFFER_TTL_MS);
+        const bool reusable = !e.valid || e.isExpiredAt(now);
         if (reusable && slot == nullptr) slot = &e;
         if (e.arrivedAtMs < oldest->arrivedAtMs) oldest = &e;
     }
@@ -830,7 +829,7 @@ void RemoteDeviceCoordinator::drainBufferedContext(SerialIdentifier jack, const 
     const unsigned long now = nowMs();
     for (BufferedContext& e : contextBuffer_) {
         if (!e.valid) continue;
-        if (now >= e.arrivedAtMs && now - e.arrivedAtMs > CONTEXT_BUFFER_TTL_MS) {
+        if (e.isExpiredAt(now)) {
             e.valid = false;  // expired before its jack ever connected (stale/attacker)
             continue;
         }
@@ -857,8 +856,7 @@ void RemoteDeviceCoordinator::releaseHelloPeer(SerialIdentifier jack, const uint
         if (machine == nullptr || machine->currentStateId() == HELLO_LINK_IDLE) continue;
         if (memcmp(machine->peer().data(), mac, 6) == 0) return;
     }
-    // Same guard removeDaisyChainedPeer applies in reverse: a MAC still reachable
-    // through a daisy chain keeps its slot.
+    // A MAC still routed through a daisy chain keeps its slot too.
     for (const std::vector<std::array<uint8_t, 6>>& chain : daisyChainedByPort_) {
         for (const std::array<uint8_t, 6>& m : chain) {
             if (memcmp(m.data(), mac, 6) == 0) return;

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -60,8 +60,8 @@ RemoteDeviceCoordinator::~RemoteDeviceCoordinator() {
         for (SerialIdentifier port : HELLO_JACKS) {
             HWSerialWrapper* hw = jackWrapper(port);
             if (hw != nullptr) hw->setByteCallback(nullptr);
-            delete helloByPort_[portIndex(port)].machine;
-            helloByPort_[portIndex(port)].machine = nullptr;
+            delete helloByPort[portIndex(port)].machine;
+            helloByPort[portIndex(port)].machine = nullptr;
         }
     }
     delete inputPortHandshake;
@@ -243,7 +243,7 @@ void RemoteDeviceCoordinator::sync(Device* PDN) {
         // chain-announcement machinery below rides handshake CONNECTED state, so
         // it stays dormant here too until HELLO drives its own peer identity (#157).
         for (SerialIdentifier port : HELLO_JACKS) {
-            HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+            HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
             if (machine) machine->onStateLoop(PDN);
         }
         return;
@@ -610,18 +610,18 @@ void RemoteDeviceCoordinator::enableHelloConnectivity() {
 
     if (wirelessManager_ != nullptr) {
         const uint8_t* mac = wirelessManager_->getMacAddress();
-        if (mac != nullptr) memcpy(selfMac_.data(), mac, 6);
+        if (mac != nullptr) memcpy(selfMac.data(), mac, 6);
     }
 
     for (SerialIdentifier port : HELLO_JACKS) {
         HWSerialWrapper* hw = jackWrapper(port);
         if (hw == nullptr) continue;
-        JackHelloLink& link = helloByPort_[portIndex(port)];
+        JackHelloLink& link = helloByPort[portIndex(port)];
         link.parser.setHelloFrameHandler(
             [this, port](const HelloPayload& hello) { onHelloReceived(port, hello); });
         // exec() runs on the main loop, so the parser is fed single-threaded.
         hw->setByteCallback([this, port](uint8_t b) {
-            helloByPort_[portIndex(port)].parser.feed(&b, 1);
+            helloByPort[portIndex(port)].parser.feed(&b, 1);
         });
 
         HelloLinkContext context;
@@ -634,7 +634,7 @@ void RemoteDeviceCoordinator::enableHelloConnectivity() {
             if (jackChangeCallback) jackChangeCallback(j, connected);
         };
         context.resetParser = [this, port] {
-            helloByPort_[portIndex(port)].parser.requestReset();
+            helloByPort[portIndex(port)].parser.requestReset();
         };
         context.onLinkDown = [this](SerialIdentifier j, const std::array<uint8_t, 6>& mac) {
             releaseHelloPeer(j, mac.data());
@@ -657,7 +657,7 @@ void RemoteDeviceCoordinator::emitHello() {
     if (!helloConnectivityEnabled) return;
 
     HelloPayload hello{};
-    memcpy(hello.source, selfMac_.data(), 6);
+    memcpy(hello.source, selfMac.data(), 6);
     hello.deviceType = static_cast<uint8_t>(selfDeviceType);
     // headMac stays zero and confirmed stays 0 until the device chain SM (#156)
     // learns the head and completes its context exchange.
@@ -678,17 +678,17 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
     // self-HELLO must never keep a dead cable "alive" or fake a peer. The RDC owns
     // selfMac, so this guard stays here rather than in the link SM.
     if (MacToUInt64(hello.source) == 0) return;
-    if (memcmp(hello.source, selfMac_.data(), 6) == 0) return;
+    if (memcmp(hello.source, selfMac.data(), 6) == 0) return;
 
     // The machine records the peer MAC and, for a first HELLO on any Idle jack,
     // fires onContextRequest -> initiateContextExchange as it enters Connecting.
-    JackHelloLink& link = helloByPort_[portIndex(jack)];
+    JackHelloLink& link = helloByPort[portIndex(jack)];
     if (link.machine) link.machine->onHelloReceived(hello);
 }
 
 
 void RemoteDeviceCoordinator::initiateContextExchange(SerialIdentifier jack) {
-    HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
+    HelloLinkMachine* machine = helloByPort[portIndex(jack)].machine;
     if (machine == nullptr) return;
     const uint8_t* mac = machine->peer().data();
     // Radio slot first (the driver add is idempotent): the drain below can announce
@@ -753,7 +753,7 @@ void RemoteDeviceCoordinator::applyContextToJacks(const uint8_t* fromMac, Device
     // radio slot (registered when our jack initiated), so nothing to register here.
     bool appliedToConnectingJack = false;
     for (SerialIdentifier port : HELLO_JACKS) {
-        HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+        HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
         if (machine == nullptr || machine->currentStateId() != HELLO_LINK_CONNECTING) continue;
         if (memcmp(machine->peer().data(), fromMac, 6) != 0) continue;
         completeJackContext(port, peerType, chainRole, profile, len);
@@ -767,7 +767,7 @@ void RemoteDeviceCoordinator::applyContextToJacks(const uint8_t* fromMac, Device
     // ours so its cycle completes. No ping-pong: only the CONNECTING side retries,
     // and it stops once this lands.
     for (SerialIdentifier port : HELLO_JACKS) {
-        JackHelloLink& link = helloByPort_[portIndex(port)];
+        JackHelloLink& link = helloByPort[portIndex(port)];
         if (link.machine == nullptr || link.machine->currentStateId() != HELLO_LINK_CONNECTED)
             continue;
         if (memcmp(link.machine->peer().data(), fromMac, 6) != 0) continue;
@@ -792,9 +792,9 @@ void RemoteDeviceCoordinator::completeJackContext(SerialIdentifier jack, DeviceT
     // A second fresh-seqId context can land before the Connecting -> Connected
     // commit while the jack still reports CONNECTING; the game callback must
     // fire exactly once per connect.
-    HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
+    HelloLinkMachine* machine = helloByPort[portIndex(jack)].machine;
     if (machine != nullptr && machine->didMarkContextComplete()) return;
-    helloByPort_[portIndex(jack)].peerChainRole = chainRole;
+    helloByPort[portIndex(jack)].peerChainRole = chainRole;
     if (contextReceivedCallback) contextReceivedCallback(jack, peerType, profile, len);
     onContextExchangeComplete(jack);
 }
@@ -804,8 +804,8 @@ void RemoteDeviceCoordinator::bufferContext(const uint8_t* fromMac, DeviceType p
                                             size_t len) {
     const unsigned long now = nowMs();
     BufferedContext* slot = nullptr;
-    BufferedContext* oldest = &contextBuffer_[0];
-    for (BufferedContext& e : contextBuffer_) {
+    BufferedContext* oldest = &contextBuffer[0];
+    for (BufferedContext& e : contextBuffer) {
         if (e.valid && memcmp(e.mac.data(), fromMac, 6) == 0) {  // latest for a MAC wins
             slot = &e;
             break;
@@ -827,7 +827,7 @@ void RemoteDeviceCoordinator::bufferContext(const uint8_t* fromMac, DeviceType p
 
 void RemoteDeviceCoordinator::drainBufferedContext(SerialIdentifier jack, const uint8_t* mac) {
     const unsigned long now = nowMs();
-    for (BufferedContext& e : contextBuffer_) {
+    for (BufferedContext& e : contextBuffer) {
         if (!e.valid) continue;
         if (e.isExpiredAt(now)) {
             e.valid = false;  // expired before its jack ever connected (stale/attacker)
@@ -845,14 +845,14 @@ void RemoteDeviceCoordinator::releaseHelloPeer(SerialIdentifier jack, const uint
     // Per-jack residue clears unconditionally: the keep-slot guards below are
     // per-MAC, and the next peer on this jack must not inherit the departed
     // peer's chainRole during its CONNECTING window (#156 reads it then).
-    helloByPort_[portIndex(jack)].peerChainRole = 0;
-    helloByPort_[portIndex(jack)].lastContextResendMs = 0;
+    helloByPort[portIndex(jack)].peerChainRole = 0;
+    helloByPort[portIndex(jack)].lastContextResendMs = 0;
     // A 2-node ring has the same peer on both jacks: releasing the radio slot on a
     // one-cable disconnect would silently break wireless for the still-connected
     // link, so any other jack tracking this MAC keeps the slot alive.
     for (SerialIdentifier port : HELLO_JACKS) {
         if (port == jack) continue;
-        const HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+        const HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
         if (machine == nullptr || machine->currentStateId() == HELLO_LINK_IDLE) continue;
         if (memcmp(machine->peer().data(), mac, 6) == 0) return;
     }
@@ -871,13 +871,13 @@ void RemoteDeviceCoordinator::releaseHelloPeer(SerialIdentifier jack, const uint
 }
 
 void RemoteDeviceCoordinator::onContextExchangeComplete(SerialIdentifier jack) {
-    HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
+    HelloLinkMachine* machine = helloByPort[portIndex(jack)].machine;
     if (machine) machine->onContextExchangeComplete();
 }
 
 RemoteDeviceCoordinator::HelloLinkState
 RemoteDeviceCoordinator::getHelloLinkState(SerialIdentifier jack) const {
-    const HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
+    const HelloLinkMachine* machine = helloByPort[portIndex(jack)].machine;
     if (machine == nullptr) return HelloLinkState::IDLE;
     switch (machine->currentStateId()) {
         case HELLO_LINK_CONNECTED:  return HelloLinkState::CONNECTED;
@@ -887,7 +887,7 @@ RemoteDeviceCoordinator::getHelloLinkState(SerialIdentifier jack) const {
 }
 
 PortStatus RemoteDeviceCoordinator::mapHelloLinkToStatus(SerialIdentifier port) const {
-    const HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+    const HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
     if (machine == nullptr) return PortStatus::DISCONNECTED;
     switch (machine->currentStateId()) {
         case HELLO_LINK_CONNECTED:  return PortStatus::CONNECTED;

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -678,8 +678,19 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
 
     // The machine records the peer MAC and, for a first HELLO on an Idle OUT jack,
     // fires onContextRequest -> initiateContextExchange as it enters Connecting.
-    HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
-    if (machine) machine->onHelloReceived(hello);
+    JackHelloLink& link = helloByPort_[portIndex(jack)];
+    const bool headChanged = memcmp(link.lastHeadMac.data(), hello.headMac, 6) != 0;
+    memcpy(link.lastHeadMac.data(), hello.headMac, 6);
+    if (link.machine) link.machine->onHelloReceived(hello);
+
+    // A head change while the OUT-jack exchange is still mid-flight re-sends our
+    // context to the new head. The initial send is driven by onContextRequest as
+    // the link enters Connecting; the machine does not model headMac, so this
+    // re-send stays here.
+    if (headChanged && jack == SerialIdentifier::OUTPUT_JACK && link.machine &&
+        link.machine->currentStateId() == HELLO_LINK_CONNECTING) {
+        initiateContextExchange(jack);
+    }
 }
 
 ReliableChannelBase* RemoteDeviceCoordinator::selfContextChannel() const {

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -681,19 +681,15 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
     if (link.machine) link.machine->onHelloReceived(hello);
 }
 
-ReliableChannelBase* RemoteDeviceCoordinator::selfContextChannel() const {
-    return selfDeviceType == DeviceType::FDN
-               ? static_cast<ReliableChannelBase*>(fdnContextChannel)
-               : static_cast<ReliableChannelBase*>(pdnContextChannel);
-}
 
 void RemoteDeviceCoordinator::initiateContextExchange(SerialIdentifier jack) {
     HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
     if (machine == nullptr) return;
     const uint8_t* mac = machine->peer().data();
     registerPeer(mac);
-    ReliableChannelBase* channel = selfContextChannel();
-    if (channel != nullptr) channel->cancel(mac);
+    // No explicit cancel: the channel's SUPERSEDE_PER_TARGET drops any prior unacked
+    // send to this MAC when the new one goes out (e.g. our other jack's send to the
+    // same peer in a 2-node ring).
     sendSelfContext(mac);
 }
 
@@ -723,14 +719,12 @@ bool RemoteDeviceCoordinator::isContextSendPending(const uint8_t* mac) const {
 void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceType peerType,
                                                 uint8_t chainRole, const uint8_t* profile,
                                                 size_t len) {
-    // A 2-node ring cables BOTH our jacks to the same peer, so one context can
-    // complete more than one link. Complete every jack mid-exchange with this MAC,
-    // not just the first, or the unmatched link times out and opens the ring. Only
-    // a Connecting jack consumes a context: an Idle jack isn't ours, and an
-    // already-Connected one is a duplicate to drop (this also stops the input-reply
-    // below from ping-ponging once both links are up).
+    // Every jack sends its own context on connecting, so receiving the peer's just
+    // completes our side; there is no reply. A 2-node ring cables the SAME peer to
+    // both jacks, so one context completes both links (SUPERSEDE_PER_TARGET already
+    // collapsed our two sends to that peer into one). Complete every jack still
+    // mid-exchange with this MAC, not just the first, or the other opens the ring.
     bool matched = false;
-    bool replyToInput = false;
     for (SerialIdentifier port : HELLO_JACKS) {
         HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
         if (machine == nullptr || machine->currentStateId() != HELLO_LINK_CONNECTING) continue;
@@ -743,14 +737,8 @@ void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceTy
         }
         helloByPort_[portIndex(port)].peerChainRole = chainRole;
         if (contextReceivedCallback) contextReceivedCallback(port, peerType, profile, len);
-        // Complete our side BEFORE replying so a same-tick SEND_SUCCESS can't race.
         onContextExchangeComplete(port);
-        if (port != SerialIdentifier::OUTPUT_JACK) replyToInput = true;
     }
-    // Output initiates, input replies: a peer that arrived on an input jack sent its
-    // context first, so send ours back so its out-jack completes too. The OUTPUT
-    // initiator already sent first and must not reply, or the two ping-pong.
-    if (replyToInput) sendSelfContext(fromMac);
 }
 
 void RemoteDeviceCoordinator::onContextExchangeComplete(SerialIdentifier jack) {

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -732,7 +732,7 @@ void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceTy
                                                 uint8_t chainRole, const uint8_t* profile,
                                                 size_t len) {
     // Every jack sends its own context on connecting, so receiving the peer's just
-    // completes our matching jack(s); there is no reply. Cache it keyed by MAC AND
+    // completes our matching jack(s); no reply in the normal exchange. Cache it keyed by MAC AND
     // apply it now: caching (not only applying) covers a jack that reaches CONNECTING
     // AFTER this arrives. That happens two ways — a context beats its own HELLO
     // (ESP-NOW vs serial) so no jack is CONNECTING yet, and in a 2-node ring the two
@@ -748,11 +748,27 @@ void RemoteDeviceCoordinator::applyContextToJacks(const uint8_t* fromMac, Device
     // Live receive path: a 2-node ring points both our jacks at the same peer with
     // both already CONNECTING, so one context completes both. The peer is already a
     // radio slot (registered when our jack initiated), so nothing to register here.
+    bool appliedToConnectingJack = false;
     for (SerialIdentifier port : HELLO_JACKS) {
         HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
         if (machine == nullptr || machine->currentStateId() != HELLO_LINK_CONNECTING) continue;
         if (memcmp(machine->peer().data(), fromMac, 6) != 0) continue;
         completeJackContext(port, peerType, chainRole, profile, len);
+        appliedToConnectingJack = true;
+    }
+    if (appliedToConnectingJack) return;
+
+    // A context from a MAC a CONNECTED jack already tracks means the peer is still
+    // cycling CONNECTING — our earlier context was lost app-side (SEND_SUCCESS is
+    // MAC-ack only) or the peer rebooted and its first resend was deduped. Resend
+    // ours so its cycle completes. No ping-pong: only the CONNECTING side retries,
+    // and it stops once this lands.
+    for (SerialIdentifier port : HELLO_JACKS) {
+        const HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+        if (machine == nullptr || machine->currentStateId() != HELLO_LINK_CONNECTED) continue;
+        if (memcmp(machine->peer().data(), fromMac, 6) != 0) continue;
+        if (!isContextSendPending(fromMac)) sendSelfContext(fromMac);
+        return;
     }
 }
 

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -691,6 +691,10 @@ void RemoteDeviceCoordinator::initiateContextExchange(SerialIdentifier jack) {
     HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
     if (machine == nullptr) return;
     const uint8_t* mac = machine->peer().data();
+    // Radio slot first (the driver add is idempotent): the drain below can announce
+    // the peer to game code, and a pending send from our other jack skips the send
+    // path entirely — neither may run before the peer has its ESP-NOW slot.
+    registerPeer(mac);
     // Apply any context that beat this jack's HELLO and was cached while it was still
     // Idle. Runs for every jack entering Connecting, before the send-collapse below,
     // so the second jack of a 2-node ring still gets the cached context.
@@ -700,7 +704,6 @@ void RemoteDeviceCoordinator::initiateContextExchange(SerialIdentifier jack) {
     // to this MAC is already pending rather than putting a second frame on the air
     // (the Resender transmits each send immediately, so it would NOT be collapsed).
     if (isContextSendPending(mac)) return;
-    registerPeer(mac);
     sendSelfContext(mac);
 }
 
@@ -840,6 +843,11 @@ void RemoteDeviceCoordinator::releaseHelloPeer(SerialIdentifier jack, const uint
             if (memcmp(m.data(), mac, 6) == 0) return;
         }
     }
+    // Drop the context retries with the slot: a retransmit re-registers its target
+    // inside the driver (EnsurePeerIsRegistered), which would re-add the slot just
+    // removed and leak it. cancel() is silent — no abandon callback fires.
+    if (pdnContextChannel != nullptr) pdnContextChannel->cancel(mac);
+    if (fdnContextChannel != nullptr) fdnContextChannel->cancel(mac);
     unregisterPeer(mac);
 }
 

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -135,6 +135,8 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
     // its receive path live (the transport installs the driver rx handler). The
     // abandon callback is a no-op: an unreachable peer's jack link self-heals to
     // IDLE via the context-exchange timeout (HelloConnectingState, contextTimeoutMs).
+    // The peer's device kind is known from HELLO before the context lands and picks
+    // which channel decodes it; RDC forwards the profile bytes opaquely either way.
     transport = new ReliableTransport(wirelessManager);
     pdnContextChannel = transport->channel<PdnConnectionContext>(
         PktType::kPdnConnectionContext, [](uint8_t, const uint8_t*) {});
@@ -686,10 +688,10 @@ void RemoteDeviceCoordinator::initiateContextExchange(SerialIdentifier jack) {
     HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
     if (machine == nullptr) return;
     const uint8_t* mac = machine->peer().data();
-    // Apply any context that beat this jack's HELLO and was buffered while it was
-    // still Idle. Runs for every jack entering Connecting, before the send-collapse
-    // below, so the second jack of a 2-node ring still gets its buffered context.
-    drainBufferedContext(mac);
+    // Apply any context that beat this jack's HELLO and was cached while it was still
+    // Idle. Runs for every jack entering Connecting, before the send-collapse below,
+    // so the second jack of a 2-node ring still gets the cached context.
+    drainBufferedContext(jack, mac);
     // In a 2-node ring both our jacks face the same peer and connect in the same
     // tick; our context is identical on each, so one copy suffices. Skip if a send
     // to this MAC is already pending rather than putting a second frame on the air
@@ -700,8 +702,9 @@ void RemoteDeviceCoordinator::initiateContextExchange(SerialIdentifier jack) {
 }
 
 void RemoteDeviceCoordinator::sendSelfContext(const uint8_t* mac) {
-    // chainRole 0 = unresolved: the device chain SM (#156) fills it once it
-    // learns this device's position; out of scope here.
+    // Each device describes itself, so the payload is chosen by THIS device's kind,
+    // not the peer's. chainRole 0 = unresolved: the device chain SM (#156) fills it
+    // once it learns this device's position; out of scope here.
     if (selfDeviceType == DeviceType::FDN) {
         if (fdnContextChannel == nullptr) return;
         FdnConnectionContext ctx{};
@@ -726,31 +729,36 @@ void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceTy
                                                 uint8_t chainRole, const uint8_t* profile,
                                                 size_t len) {
     // Every jack sends its own context on connecting, so receiving the peer's just
-    // completes our matching jack(s); there is no reply. A context can beat its own
-    // HELLO (ESP-NOW vs serial) and land before any jack is CONNECTING for this MAC;
-    // hold it and apply it when the jack connects rather than discarding it.
-    if (!applyContextToJacks(fromMac, peerType, chainRole, profile, len)) {
-        bufferContext(fromMac, peerType, chainRole, profile, len);
-    }
+    // completes our matching jack(s); there is no reply. Cache it keyed by MAC AND
+    // apply it now: caching (not only applying) covers a jack that reaches CONNECTING
+    // AFTER this arrives. That happens two ways — a context beats its own HELLO
+    // (ESP-NOW vs serial) so no jack is CONNECTING yet, and in a 2-node ring the two
+    // jacks facing this peer enter CONNECTING one tick apart (sync() drives them in
+    // order), so the later jack must still find the context. The TTL clears the cache.
+    bufferContext(fromMac, peerType, chainRole, profile, len);
+    applyContextToJacks(fromMac, peerType, chainRole, profile, len);
 }
 
-bool RemoteDeviceCoordinator::applyContextToJacks(const uint8_t* fromMac, DeviceType peerType,
+void RemoteDeviceCoordinator::applyContextToJacks(const uint8_t* fromMac, DeviceType peerType,
                                                   uint8_t chainRole, const uint8_t* profile,
                                                   size_t len) {
-    // A 2-node ring points both our jacks at the same peer, so one context completes
-    // both. The peer is already a radio slot (registered when our jack initiated), so
-    // nothing to register here.
-    bool applied = false;
+    // Live receive path: a 2-node ring points both our jacks at the same peer with
+    // both already CONNECTING, so one context completes both. The peer is already a
+    // radio slot (registered when our jack initiated), so nothing to register here.
     for (SerialIdentifier port : HELLO_JACKS) {
         HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
         if (machine == nullptr || machine->currentStateId() != HELLO_LINK_CONNECTING) continue;
         if (memcmp(machine->peer().data(), fromMac, 6) != 0) continue;
-        helloByPort_[portIndex(port)].peerChainRole = chainRole;
-        if (contextReceivedCallback) contextReceivedCallback(port, peerType, profile, len);
-        onContextExchangeComplete(port);
-        applied = true;
+        completeJackContext(port, peerType, chainRole, profile, len);
     }
-    return applied;
+}
+
+void RemoteDeviceCoordinator::completeJackContext(SerialIdentifier jack, DeviceType peerType,
+                                                  uint8_t chainRole, const uint8_t* profile,
+                                                  size_t len) {
+    helloByPort_[portIndex(jack)].peerChainRole = chainRole;
+    if (contextReceivedCallback) contextReceivedCallback(jack, peerType, profile, len);
+    onContextExchangeComplete(jack);
 }
 
 void RemoteDeviceCoordinator::bufferContext(const uint8_t* fromMac, DeviceType peerType,
@@ -780,7 +788,7 @@ void RemoteDeviceCoordinator::bufferContext(const uint8_t* fromMac, DeviceType p
     slot->valid = true;
 }
 
-void RemoteDeviceCoordinator::drainBufferedContext(const uint8_t* mac) {
+void RemoteDeviceCoordinator::drainBufferedContext(SerialIdentifier jack, const uint8_t* mac) {
     const unsigned long now = nowMs();
     for (BufferedContext& e : contextBuffer_) {
         if (!e.valid) continue;
@@ -789,9 +797,10 @@ void RemoteDeviceCoordinator::drainBufferedContext(const uint8_t* mac) {
             continue;
         }
         if (memcmp(e.mac.data(), mac, 6) != 0) continue;
-        if (applyContextToJacks(e.mac.data(), e.peerType, e.chainRole, e.profile.data(), e.len)) {
-            e.valid = false;
-        }
+        // Apply to THIS jack only, and leave the entry valid: the peer's other jack (a
+        // 2-node ring) drains its own copy when it connects a tick later. Applying
+        // per-jack keeps the context callback firing exactly once per jack. TTL clears it.
+        completeJackContext(jack, e.peerType, e.chainRole, e.profile.data(), e.len);
     }
 }
 

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -675,7 +675,7 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
     if (MacToUInt64(hello.source) == 0) return;
     if (memcmp(hello.source, selfMac_.data(), 6) == 0) return;
 
-    // The machine records the peer MAC and, for a first HELLO on an Idle OUT jack,
+    // The machine records the peer MAC and, for a first HELLO on any Idle jack,
     // fires onContextRequest -> initiateContextExchange as it enters Connecting.
     JackHelloLink& link = helloByPort_[portIndex(jack)];
     if (link.machine) link.machine->onHelloReceived(hello);
@@ -686,10 +686,12 @@ void RemoteDeviceCoordinator::initiateContextExchange(SerialIdentifier jack) {
     HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
     if (machine == nullptr) return;
     const uint8_t* mac = machine->peer().data();
+    // In a 2-node ring both our jacks face the same peer and connect in the same
+    // tick; our context is identical on each, so one copy suffices. Skip if a send
+    // to this MAC is already pending rather than putting a second frame on the air
+    // (the Resender transmits each send immediately, so it would NOT be collapsed).
+    if (isContextSendPending(mac)) return;
     registerPeer(mac);
-    // No explicit cancel: the channel's SUPERSEDE_PER_TARGET drops any prior unacked
-    // send to this MAC when the new one goes out (e.g. our other jack's send to the
-    // same peer in a 2-node ring).
     sendSelfContext(mac);
 }
 
@@ -720,21 +722,13 @@ void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceTy
                                                 uint8_t chainRole, const uint8_t* profile,
                                                 size_t len) {
     // Every jack sends its own context on connecting, so receiving the peer's just
-    // completes our side; there is no reply. A 2-node ring cables the SAME peer to
-    // both jacks, so one context completes both links (SUPERSEDE_PER_TARGET already
-    // collapsed our two sends to that peer into one). Complete every jack still
-    // mid-exchange with this MAC, not just the first, or the other opens the ring.
-    bool matched = false;
+    // completes our matching jack(s); there is no reply. A 2-node ring points both
+    // our jacks at the same peer, so one context completes both. The peer is already
+    // a radio slot (registered when our jack initiated), so nothing to register here.
     for (SerialIdentifier port : HELLO_JACKS) {
         HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
         if (machine == nullptr || machine->currentStateId() != HELLO_LINK_CONNECTING) continue;
         if (memcmp(machine->peer().data(), fromMac, 6) != 0) continue;
-        if (!matched) {
-            matched = true;
-            // Register only after a jack matches, so an unmatched/late context can't
-            // leak a peer slot we never send to.
-            registerPeer(fromMac);
-        }
         helloByPort_[portIndex(port)].peerChainRole = chainRole;
         if (contextReceivedCallback) contextReceivedCallback(port, peerType, profile, len);
         onContextExchangeComplete(port);

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -67,6 +67,8 @@ RemoteDeviceCoordinator::~RemoteDeviceCoordinator() {
     delete inputPortHandshake;
     delete outputPortHandshake;
     delete secondaryInputPortHandshake;
+    // Owns the channels; deletes them and their driver rx bindings.
+    delete transport;
 }
 
 
@@ -128,6 +130,33 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
         },
         this
     );
+
+    // Reliable context exchange (#157): one device-level channel per device-type
+    // PktType. Claiming a channel makes its receive path live (the transport
+    // installs the driver rx handler). The abandon callback is a no-op: an
+    // unreachable peer's jack link self-heals to IDLE via the context-exchange
+    // timeout in serviceConnectivity().
+    transport = new ReliableTransport(wirelessManager);
+    pdnContextChannel = transport->channel<PdnConnectionContext>(
+        PktType::kPdnConnectionContext, [](uint8_t, const uint8_t*) {});
+    if (pdnContextChannel != nullptr) {
+        pdnContextChannel->onReceive(
+            [this](const uint8_t* fromMac, const PdnConnectionContext& ctx) {
+                onContextReceived(fromMac, DeviceType::PDN, ctx.chainRole,
+                                  reinterpret_cast<const uint8_t*>(&ctx.player),
+                                  sizeof(ctx.player));
+            });
+    }
+    fdnContextChannel = transport->channel<FdnConnectionContext>(
+        PktType::kFdnConnectionContext, [](uint8_t, const uint8_t*) {});
+    if (fdnContextChannel != nullptr) {
+        fdnContextChannel->onReceive(
+            [this](const uint8_t* fromMac, const FdnConnectionContext& ctx) {
+                onContextReceived(fromMac, DeviceType::FDN, ctx.chainRole,
+                                  reinterpret_cast<const uint8_t*>(&ctx.fdn),
+                                  sizeof(ctx.fdn));
+            });
+    }
 }
 
 std::vector<SerialIdentifier> RemoteDeviceCoordinator::activePorts() const {
@@ -203,6 +232,10 @@ void RemoteDeviceCoordinator::processChainAnnouncementPacket(const uint8_t* from
 }
 
 void RemoteDeviceCoordinator::sync(Device* PDN) {
+    // Platform-loop-owns-the-pump: drive reliable-transport retransmits/abandon
+    // here every tick. Game managers must not pump it.
+    if (transport != nullptr) transport->sync();
+
     if (helloConnectivityEnabled) {
         // The handshake is quiesced on HELLO jacks: skipping its onStateLoop is
         // what keeps it off the UART (it neither consumes RX nor writes TX). The
@@ -594,7 +627,7 @@ void RemoteDeviceCoordinator::enableHelloConnectivity() {
         context.jack = port;
         context.nowMs = [] { return RemoteDeviceCoordinator::nowMs(); };
         context.onContextRequest = [this](SerialIdentifier j) {
-            if (contextRequestCallback) contextRequestCallback(j);
+            initiateContextExchange(j);
         };
         context.onJackChange = [this](SerialIdentifier j, bool connected) {
             if (jackChangeCallback) jackChangeCallback(j, connected);
@@ -643,8 +676,73 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
     if (MacToUInt64(hello.source) == 0) return;
     if (memcmp(hello.source, selfMac_.data(), 6) == 0) return;
 
+    // The machine records the peer MAC and, for a first HELLO on an Idle OUT jack,
+    // fires onContextRequest -> initiateContextExchange as it enters Connecting.
     HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
     if (machine) machine->onHelloReceived(hello);
+}
+
+ReliableChannelBase* RemoteDeviceCoordinator::selfContextChannel() const {
+    return selfDeviceType == DeviceType::FDN
+               ? static_cast<ReliableChannelBase*>(fdnContextChannel)
+               : static_cast<ReliableChannelBase*>(pdnContextChannel);
+}
+
+void RemoteDeviceCoordinator::initiateContextExchange(SerialIdentifier jack) {
+    HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
+    if (machine == nullptr) return;
+    const uint8_t* mac = machine->peer().data();
+    registerPeer(mac);
+    ReliableChannelBase* channel = selfContextChannel();
+    if (channel != nullptr) channel->cancel(mac);
+    sendSelfContext(mac);
+}
+
+void RemoteDeviceCoordinator::sendSelfContext(const uint8_t* mac) {
+    // chainRole 0 = unresolved: the device chain SM (#156) fills it once it
+    // learns this device's position; out of scope here.
+    if (selfDeviceType == DeviceType::FDN) {
+        if (fdnContextChannel == nullptr) return;
+        FdnConnectionContext ctx{};
+        ctx.chainRole = 0;
+        fdnContextChannel->sendReliable(mac, ctx);
+        return;
+    }
+    if (pdnContextChannel == nullptr) return;
+    PdnConnectionContext ctx{};
+    ctx.chainRole = 0;
+    ctx.player = selfPlayerProfile;
+    pdnContextChannel->sendReliable(mac, ctx);
+}
+
+bool RemoteDeviceCoordinator::isContextSendPending(const uint8_t* mac) const {
+    if (pdnContextChannel != nullptr && pdnContextChannel->isPending(mac)) return true;
+    if (fdnContextChannel != nullptr && fdnContextChannel->isPending(mac)) return true;
+    return false;
+}
+
+bool RemoteDeviceCoordinator::findJackForMac(const uint8_t* mac, SerialIdentifier& jack) const {
+    for (SerialIdentifier port : HELLO_JACKS) {
+        const HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+        if (machine == nullptr || machine->currentStateId() == HELLO_LINK_IDLE) continue;
+        if (memcmp(machine->peer().data(), mac, 6) == 0) {
+            jack = port;
+            return true;
+        }
+    }
+    return false;
+}
+
+void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceType peerType,
+                                                uint8_t chainRole, const uint8_t* profile,
+                                                size_t len) {
+    registerPeer(fromMac);
+    SerialIdentifier jack;
+    if (!findJackForMac(fromMac, jack)) return;
+    // Recorded for the device chain SM (#156); not acted on here.
+    helloByPort_[portIndex(jack)].peerChainRole = chainRole;
+    if (contextReceivedCallback) contextReceivedCallback(jack, peerType, profile, len);
+    onContextExchangeComplete(jack);
 }
 
 void RemoteDeviceCoordinator::onContextExchangeComplete(SerialIdentifier jack) {

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -678,18 +678,7 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
     // The machine records the peer MAC and, for a first HELLO on an Idle OUT jack,
     // fires onContextRequest -> initiateContextExchange as it enters Connecting.
     JackHelloLink& link = helloByPort_[portIndex(jack)];
-    const bool headChanged = memcmp(link.lastHeadMac.data(), hello.headMac, 6) != 0;
-    memcpy(link.lastHeadMac.data(), hello.headMac, 6);
     if (link.machine) link.machine->onHelloReceived(hello);
-
-    // A head change while the OUT-jack exchange is still mid-flight re-sends our
-    // context to the new head. The initial send is driven by onContextRequest as
-    // the link enters Connecting; the machine does not model headMac, so this
-    // re-send stays here.
-    if (headChanged && jack == SerialIdentifier::OUTPUT_JACK && link.machine &&
-        link.machine->currentStateId() == HELLO_LINK_CONNECTING) {
-        initiateContextExchange(jack);
-    }
 }
 
 ReliableChannelBase* RemoteDeviceCoordinator::selfContextChannel() const {
@@ -746,10 +735,11 @@ bool RemoteDeviceCoordinator::findJackForMac(const uint8_t* mac, SerialIdentifie
 void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceType peerType,
                                                 uint8_t chainRole, const uint8_t* profile,
                                                 size_t len) {
-    registerPeer(fromMac);
     SerialIdentifier jack;
     if (!findJackForMac(fromMac, jack)) return;
-    // Recorded for the device chain SM (#156); not acted on here.
+    // Register only after a jack matches: an unmatched or late context (its link
+    // already timed out to IDLE) must not leak a peer slot we never send to.
+    registerPeer(fromMac);
     helloByPort_[portIndex(jack)].peerChainRole = chainRole;
     if (contextReceivedCallback) contextReceivedCallback(jack, peerType, profile, len);
     // Output initiates, input replies: a peer that arrived on an input jack sent

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -686,6 +686,10 @@ void RemoteDeviceCoordinator::initiateContextExchange(SerialIdentifier jack) {
     HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
     if (machine == nullptr) return;
     const uint8_t* mac = machine->peer().data();
+    // Apply any context that beat this jack's HELLO and was buffered while it was
+    // still Idle. Runs for every jack entering Connecting, before the send-collapse
+    // below, so the second jack of a 2-node ring still gets its buffered context.
+    drainBufferedContext(mac);
     // In a 2-node ring both our jacks face the same peer and connect in the same
     // tick; our context is identical on each, so one copy suffices. Skip if a send
     // to this MAC is already pending rather than putting a second frame on the air
@@ -722,9 +726,21 @@ void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceTy
                                                 uint8_t chainRole, const uint8_t* profile,
                                                 size_t len) {
     // Every jack sends its own context on connecting, so receiving the peer's just
-    // completes our matching jack(s); there is no reply. A 2-node ring points both
-    // our jacks at the same peer, so one context completes both. The peer is already
-    // a radio slot (registered when our jack initiated), so nothing to register here.
+    // completes our matching jack(s); there is no reply. A context can beat its own
+    // HELLO (ESP-NOW vs serial) and land before any jack is CONNECTING for this MAC;
+    // hold it and apply it when the jack connects rather than discarding it.
+    if (!applyContextToJacks(fromMac, peerType, chainRole, profile, len)) {
+        bufferContext(fromMac, peerType, chainRole, profile, len);
+    }
+}
+
+bool RemoteDeviceCoordinator::applyContextToJacks(const uint8_t* fromMac, DeviceType peerType,
+                                                  uint8_t chainRole, const uint8_t* profile,
+                                                  size_t len) {
+    // A 2-node ring points both our jacks at the same peer, so one context completes
+    // both. The peer is already a radio slot (registered when our jack initiated), so
+    // nothing to register here.
+    bool applied = false;
     for (SerialIdentifier port : HELLO_JACKS) {
         HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
         if (machine == nullptr || machine->currentStateId() != HELLO_LINK_CONNECTING) continue;
@@ -732,6 +748,50 @@ void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceTy
         helloByPort_[portIndex(port)].peerChainRole = chainRole;
         if (contextReceivedCallback) contextReceivedCallback(port, peerType, profile, len);
         onContextExchangeComplete(port);
+        applied = true;
+    }
+    return applied;
+}
+
+void RemoteDeviceCoordinator::bufferContext(const uint8_t* fromMac, DeviceType peerType,
+                                            uint8_t chainRole, const uint8_t* profile,
+                                            size_t len) {
+    const unsigned long now = nowMs();
+    BufferedContext* slot = nullptr;
+    BufferedContext* oldest = &contextBuffer_[0];
+    for (BufferedContext& e : contextBuffer_) {
+        if (e.valid && memcmp(e.mac.data(), fromMac, 6) == 0) {  // latest for a MAC wins
+            slot = &e;
+            break;
+        }
+        const bool reusable =
+            !e.valid || (now >= e.arrivedAtMs && now - e.arrivedAtMs > CONTEXT_BUFFER_TTL_MS);
+        if (reusable && slot == nullptr) slot = &e;
+        if (e.arrivedAtMs < oldest->arrivedAtMs) oldest = &e;
+    }
+    if (slot == nullptr) slot = oldest;  // full of fresh entries: evict the oldest
+
+    memcpy(slot->mac.data(), fromMac, 6);
+    slot->peerType = peerType;
+    slot->chainRole = chainRole;
+    slot->len = len < slot->profile.size() ? len : slot->profile.size();
+    memcpy(slot->profile.data(), profile, slot->len);
+    slot->arrivedAtMs = now;
+    slot->valid = true;
+}
+
+void RemoteDeviceCoordinator::drainBufferedContext(const uint8_t* mac) {
+    const unsigned long now = nowMs();
+    for (BufferedContext& e : contextBuffer_) {
+        if (!e.valid) continue;
+        if (now >= e.arrivedAtMs && now - e.arrivedAtMs > CONTEXT_BUFFER_TTL_MS) {
+            e.valid = false;  // expired before its jack ever connected (stale/attacker)
+            continue;
+        }
+        if (memcmp(e.mac.data(), mac, 6) != 0) continue;
+        if (applyContextToJacks(e.mac.data(), e.peerType, e.chainRole, e.profile.data(), e.len)) {
+            e.valid = false;
+        }
     }
 }
 

--- a/lib/native-drivers/include/device/drivers/native/native-peer-comms-driver.hpp
+++ b/lib/native-drivers/include/device/drivers/native/native-peer-comms-driver.hpp
@@ -54,14 +54,14 @@ public:
 
         // Fire deferred SEND_SUCCESS callbacks (drives the reliable transport's
         // ack, exactly as the esp32 driver does from its exec()).
-        while (!sendResultQueue_.empty()) {
-            auto& r = sendResultQueue_.front();
-            auto it = sendStatusHandlers_.find(r.type);
-            if (it != sendStatusHandlers_.end()) {
+        while (!sendResultQueue.empty()) {
+            DeferredSendResult& r = sendResultQueue.front();
+            auto it = sendStatusHandlers.find(r.type);
+            if (it != sendStatusHandlers.end()) {
                 it->second.callback(r.dst, r.data.data(), r.data.size(), true,
                                     it->second.context);
             }
-            sendResultQueue_.pop();
+            sendResultQueue.pop();
         }
     }
 
@@ -105,12 +105,12 @@ public:
         // Report SEND_SUCCESS on the next exec() (never inline: that would
         // re-enter Resender::send mid-transmit). The sim's broker delivery is
         // reliable, so every send succeeds.
-        if (sendStatusHandlers_.count(packetType)) {
+        if (sendStatusHandlers.count(packetType)) {
             DeferredSendResult r;
             r.type = packetType;
             memcpy(r.dst, dst, 6);
             r.data.assign(data, data + length);
-            sendResultQueue_.push(std::move(r));
+            sendResultQueue.push(std::move(r));
         }
         return 0; // Success
     }
@@ -123,12 +123,15 @@ public:
         handlers_.erase(packetType);
     }
 
+    /// Registers the SEND_SUCCESS/SEND_FAIL observer for a PktType; the sim
+    /// reports success for every send on the next exec().
     void setSendStatusHandler(PktType packetType, SendStatusCallback callback, void* ctx) override {
-        sendStatusHandlers_[packetType] = {callback, ctx};
+        sendStatusHandlers[packetType] = {callback, ctx};
     }
 
+    /// Drops the send-status observer for a PktType.
     void clearSendStatusHandler(PktType packetType) override {
-        sendStatusHandlers_.erase(packetType);
+        sendStatusHandlers.erase(packetType);
     }
 
     const uint8_t* getGlobalBroadcastAddress() override {
@@ -231,8 +234,8 @@ private:
     };
 
     std::map<PktType, HandlerEntry> handlers_;
-    std::map<PktType, SendStatusEntry> sendStatusHandlers_;
-    std::queue<DeferredSendResult> sendResultQueue_;
+    std::map<PktType, SendStatusEntry> sendStatusHandlers;
+    std::queue<DeferredSendResult> sendResultQueue;
     std::mutex recvMutex_;
     std::queue<DeferredPacket> recvQueue_;
     uint8_t macAddress_[6];

--- a/lib/native-drivers/include/device/drivers/native/native-peer-comms-driver.hpp
+++ b/lib/native-drivers/include/device/drivers/native/native-peer-comms-driver.hpp
@@ -51,6 +51,18 @@ public:
             }
             pending.pop();
         }
+
+        // Fire deferred SEND_SUCCESS callbacks (drives the reliable transport's
+        // ack, exactly as the esp32 driver does from its exec()).
+        while (!sendResultQueue_.empty()) {
+            auto& r = sendResultQueue_.front();
+            auto it = sendStatusHandlers_.find(r.type);
+            if (it != sendStatusHandlers_.end()) {
+                it->second.callback(r.dst, r.data.data(), r.data.size(), true,
+                                    it->second.context);
+            }
+            sendResultQueue_.pop();
+        }
     }
 
     void connect() override {
@@ -89,6 +101,17 @@ public:
         addToHistory(entry);
         
         NativePeerBroker::getInstance().sendPacket(macAddress_, dst, packetType, data, length);
+
+        // Report SEND_SUCCESS on the next exec() (never inline: that would
+        // re-enter Resender::send mid-transmit). The sim's broker delivery is
+        // reliable, so every send succeeds.
+        if (sendStatusHandlers_.count(packetType)) {
+            DeferredSendResult r;
+            r.type = packetType;
+            memcpy(r.dst, dst, 6);
+            r.data.assign(data, data + length);
+            sendResultQueue_.push(std::move(r));
+        }
         return 0; // Success
     }
 
@@ -98,6 +121,14 @@ public:
 
     void clearPacketHandler(PktType packetType) override {
         handlers_.erase(packetType);
+    }
+
+    void setSendStatusHandler(PktType packetType, SendStatusCallback callback, void* ctx) override {
+        sendStatusHandlers_[packetType] = {callback, ctx};
+    }
+
+    void clearSendStatusHandler(PktType packetType) override {
+        sendStatusHandlers_.erase(packetType);
     }
 
     const uint8_t* getGlobalBroadcastAddress() override {
@@ -187,7 +218,23 @@ private:
         std::vector<uint8_t> data;
     };
 
+    struct SendStatusEntry {
+        PeerCommsInterface::SendStatusCallback callback;
+        void* context;
+    };
+
+    // A send whose SEND_SUCCESS is reported on the next exec(), mirroring the
+    // esp32 driver's deferred dispatch so the reliable transport's ack is driven
+    // the same way in the sim (and never re-enters Resender::send mid-transmit).
+    struct DeferredSendResult {
+        PktType type;
+        uint8_t dst[6];
+        std::vector<uint8_t> data;
+    };
+
     std::map<PktType, HandlerEntry> handlers_;
+    std::map<PktType, SendStatusEntry> sendStatusHandlers_;
+    std::queue<DeferredSendResult> sendResultQueue_;
     std::mutex recvMutex_;
     std::queue<DeferredPacket> recvQueue_;
     uint8_t macAddress_[6];

--- a/lib/native-drivers/include/device/drivers/native/native-peer-comms-driver.hpp
+++ b/lib/native-drivers/include/device/drivers/native/native-peer-comms-driver.hpp
@@ -223,9 +223,7 @@ private:
         void* context;
     };
 
-    // A send whose SEND_SUCCESS is reported on the next exec(), mirroring the
-    // esp32 driver's deferred dispatch so the reliable transport's ack is driven
-    // the same way in the sim (and never re-enters Resender::send mid-transmit).
+    // A send whose SEND_SUCCESS is reported on the next exec() (see send()/exec()).
     struct DeferredSendResult {
         PktType type;
         uint8_t dst[6];

--- a/lib/native-drivers/include/device/drivers/native/native-serial-driver.hpp
+++ b/lib/native-drivers/include/device/drivers/native/native-serial-driver.hpp
@@ -105,6 +105,10 @@ public:
         byteCallback_ = callback;
     }
 
+    /// True when a byte callback is installed (HELLO/binary mode), so the cable
+    /// broker delivers raw bytes rather than re-framing STRING_START messages.
+    bool hasByteCallback() const { return static_cast<bool>(byteCallback_); }
+
     /// Test/broker helper: buffers raw bytes for exec() to drain to the byte
     /// callback. The binary-framing analogue of injectInput().
     void injectBytes(const std::vector<uint8_t>& bytes) {

--- a/src/cli/cli-serial-broker.hpp
+++ b/src/cli/cli-serial-broker.hpp
@@ -264,20 +264,18 @@ private:
             return;
         }
 
-        {
-            // Parse into messages (split by newlines, which is how println works)
-            size_t pos = 0;
-            while ((pos = data.find('\n')) != std::string::npos) {
-                std::string msg = data.substr(0, pos);
-                if (!msg.empty()) {
-                    // The message already has STRING_START (*) prepended by writeString
-                    // Just add the terminator that DeviceSerial expects
-                    to->injectInput(msg + "\r");
-                }
-                data.erase(0, pos + 1);
+        // Parse into messages (split by newlines, which is how println works)
+        size_t pos = 0;
+        while ((pos = data.find('\n')) != std::string::npos) {
+            std::string msg = data.substr(0, pos);
+            if (!msg.empty()) {
+                // The message already has STRING_START (*) prepended by writeString
+                // Just add the terminator that DeviceSerial expects
+                to->injectInput(msg + "\r");
             }
-            from->clearOutput();
+            data.erase(0, pos + 1);
         }
+        from->clearOutput();
     }
 };
 

--- a/src/cli/cli-serial-broker.hpp
+++ b/src/cli/cli-serial-broker.hpp
@@ -253,7 +253,18 @@ private:
      */
     void transferFromTo(NativeSerialDriver* from, NativeSerialDriver* to) {
         std::string data = from->getOutput();
-        if (!data.empty()) {
+        if (data.empty()) return;
+
+        // Byte/binary mode (HELLO): deliver the raw stream; the receiver's
+        // byte-mode exec() feeds it to the frame parser. The STRING_START
+        // re-framing below only applies to the legacy string handshake.
+        if (to->hasByteCallback()) {
+            to->injectBytes(std::vector<uint8_t>(data.begin(), data.end()));
+            from->clearOutput();
+            return;
+        }
+
+        {
             // Parse into messages (split by newlines, which is how println works)
             size_t pos = 0;
             while ((pos = data.find('\n')) != std::string::npos) {

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -206,9 +206,9 @@ inline void rdcHelloEmitProducesFramesOnBothJacks(RDCHelloTests* suite) {
     }
 }
 
-// (e) A new HELLO MAC on the OUT jack sends this device's context (pending
-// entry created); the IN jack does not initiate one.
-inline void rdcHelloOutputJackInitiatesContext(RDCHelloTests* suite) {
+// (e) A new HELLO MAC on EITHER jack sends this device's context (pending entry
+// created): every jack initiates its own context on connecting.
+inline void rdcHelloEveryJackInitiatesContext(RDCHelloTests* suite) {
     const uint8_t outPeer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
     const uint8_t inPeer[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
 
@@ -217,7 +217,7 @@ inline void rdcHelloOutputJackInitiatesContext(RDCHelloTests* suite) {
     suite->rdc.sync(&suite->device);
 
     EXPECT_TRUE(suite->rdc.isContextSendPending(outPeer));
-    EXPECT_FALSE(suite->rdc.isContextSendPending(inPeer));
+    EXPECT_TRUE(suite->rdc.isContextSendPending(inPeer));
     EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
 }
@@ -309,10 +309,10 @@ inline void rdcContextReceiveConnectsJack(RDCHelloTests* suite) {
     EXPECT_EQ(suite->lastConnectJack, SerialIdentifier::OUTPUT_JACK);
 }
 
-// (f) Output initiates, input replies: a context arriving on an INPUT jack
-// completes that jack AND sends our context back, so the initiator's out-jack
-// can also complete. Without the reply the initiator loops CONNECTING->IDLE.
-inline void rdcContextInputJackReplies(RDCHelloTests* suite) {
+// (f) Every jack initiates: a HELLO on the INPUT jack sends our context just like
+// the OUT jack does, and receiving the peer's context completes that jack. No
+// reply step, so two devices whose jacks face each other can't ping-pong.
+inline void rdcContextInputJackInitiates(RDCHelloTests* suite) {
     const uint8_t peer[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
 
     ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _))
@@ -320,14 +320,14 @@ inline void rdcContextInputJackReplies(RDCHelloTests* suite) {
     EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_))
         .Times(testing::AnyNumber());
 
-    // Peer arrives on the INPUT jack; an in-jack HELLO must NOT initiate a send.
+    // Peer arrives on the INPUT jack; the jack initiates its own context on connecting.
     suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
-    suite->rdc.sync(&suite->device);  // drive Idle->Connecting (input jack: no send)
+    suite->rdc.sync(&suite->device);  // drive Idle->Connecting; input jack initiates
     ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
-    ASSERT_FALSE(suite->rdc.isContextSendPending(peer));
+    ASSERT_TRUE(suite->rdc.isContextSendPending(peer));
 
-    // Receiving the peer's context completes the input jack AND replies.
+    // Receiving the peer's context completes the input jack; nothing is sent back.
     std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
     suite->rdc.getReliableTransport()->deliverIncoming(
         PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
@@ -335,7 +335,6 @@ inline void rdcContextInputJackReplies(RDCHelloTests* suite) {
 
     EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
-    EXPECT_TRUE(suite->rdc.isContextSendPending(peer));  // reply was sent
 }
 
 // A 2-node ring cables the same peer to BOTH jacks. One received context must
@@ -365,8 +364,6 @@ inline void rdcContextCompletesBothJacksForSamePeer(RDCHelloTests* suite) {
     EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
 }
-
-// (d) A headMac change mid-exchange cancels the in-flight send and re-initiates.
 
 // (f) With a byte callback set the driver exec() routes RX bytes to it and does
 // NOT assemble strings; with no byte callback the legacy string path is intact.

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -306,6 +306,33 @@ inline void rdcContextReceiveConnectsJack(RDCHelloTests* suite) {
     EXPECT_EQ(suite->lastConnectJack, SerialIdentifier::OUTPUT_JACK);
 }
 
+// (f) Output initiates, input replies: a context arriving on an INPUT jack
+// completes that jack AND sends our context back, so the initiator's out-jack
+// can also complete. Without the reply the initiator loops CONNECTING->IDLE.
+inline void rdcContextInputJackReplies(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _))
+        .WillByDefault(Return(1));
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_))
+        .Times(testing::AnyNumber());
+
+    // Peer arrives on the INPUT jack; an in-jack HELLO must NOT initiate a send.
+    suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+    ASSERT_FALSE(suite->rdc.isContextSendPending(peer));
+
+    // Receiving the peer's context completes the input jack AND replies.
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->rdc.getReliableTransport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_TRUE(suite->rdc.isContextSendPending(peer));  // reply was sent
+}
+
 // (d) A headMac change mid-exchange cancels the in-flight send and re-initiates.
 inline void rdcContextHeadChangeReinitiates(RDCHelloTests* suite) {
     const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -252,6 +252,7 @@ inline void rdcContextSendClearedBySendSuccess(RDCHelloTests* suite) {
             Return(1)));
 
     suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);  // drive Idle->Connecting; fires onContextRequest
     ASSERT_TRUE(suite->rdc.isContextSendPending(peer));
     ASSERT_EQ(sentPayload.size(), sizeof(PdnConnectionContext));
 
@@ -285,6 +286,7 @@ inline void rdcContextReceiveConnectsJack(RDCHelloTests* suite) {
     // The OUT jack must already know the peer MAC (from its HELLO) for the
     // received context to match a jack.
     suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);  // drive Idle->Connecting; fires onContextRequest
     ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
 
@@ -294,6 +296,7 @@ inline void rdcContextReceiveConnectsJack(RDCHelloTests* suite) {
     std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/2, /*userId=*/4242, /*seqId=*/9);
     suite->rdc.getReliableTransport()->deliverIncoming(
         PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);  // commit Connecting->Connected
 
     EXPECT_EQ(cbCount, 1);
     EXPECT_EQ(cbJack, SerialIdentifier::OUTPUT_JACK);
@@ -319,6 +322,7 @@ inline void rdcContextInputJackReplies(RDCHelloTests* suite) {
 
     // Peer arrives on the INPUT jack; an in-jack HELLO must NOT initiate a send.
     suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
+    suite->rdc.sync(&suite->device);  // drive Idle->Connecting (input jack: no send)
     ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
     ASSERT_FALSE(suite->rdc.isContextSendPending(peer));
@@ -327,6 +331,7 @@ inline void rdcContextInputJackReplies(RDCHelloTests* suite) {
     std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
     suite->rdc.getReliableTransport()->deliverIncoming(
         PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);  // commit Connecting->Connected
 
     EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
@@ -346,6 +351,7 @@ inline void rdcContextHeadChangeReinitiates(RDCHelloTests* suite) {
 
     // First HELLO: head all-zero. Opens the exchange (one send).
     suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);  // drive Idle->Connecting; fires onContextRequest
     ASSERT_TRUE(suite->rdc.isContextSendPending(peer));
     const int sendsAfterFirst = contextSends;
     ASSERT_EQ(sendsAfterFirst, 1);

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -339,36 +339,6 @@ inline void rdcContextInputJackReplies(RDCHelloTests* suite) {
 }
 
 // (d) A headMac change mid-exchange cancels the in-flight send and re-initiates.
-inline void rdcContextHeadChangeReinitiates(RDCHelloTests* suite) {
-    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
-
-    int contextSends = 0;
-    ON_CALL(*suite->device.mockPeerComms,
-            sendData(_, PktType::kPdnConnectionContext, _, _))
-        .WillByDefault(testing::DoAll(
-            testing::InvokeWithoutArgs([&contextSends]() { contextSends++; }),
-            Return(1)));
-
-    // First HELLO: head all-zero. Opens the exchange (one send).
-    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
-    suite->rdc.sync(&suite->device);  // drive Idle->Connecting; fires onContextRequest
-    ASSERT_TRUE(suite->rdc.isContextSendPending(peer));
-    const int sendsAfterFirst = contextSends;
-    ASSERT_EQ(sendsAfterFirst, 1);
-
-    // Second HELLO from the same source, now carrying a non-zero head: the
-    // exchange re-initiates (cancel + fresh send), the jack stays CONNECTING.
-    HelloPayload hello{};
-    memcpy(hello.source, peer, 6);
-    hello.deviceType = static_cast<uint8_t>(DeviceType::PDN);
-    hello.headMac[0] = 0xCC;
-    suite->deliverHello(suite->outJack, encodeFramed(hello));
-
-    EXPECT_EQ(contextSends, sendsAfterFirst + 1);
-    EXPECT_TRUE(suite->rdc.isContextSendPending(peer));
-    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
-              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
-}
 
 // (f) With a byte callback set the driver exec() routes RX bytes to it and does
 // NOT assemble strings; with no byte callback the legacy string path is intact.

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -719,6 +719,31 @@ inline void rdcConnectedRetryResendThrottled(RDCHelloTests* suite) {
     EXPECT_EQ(contextSends, 3);
 }
 
+// The departed peer's chainRole must not survive link death: #156 reads
+// getPeerChainRole during the NEXT peer's CONNECTING window, and the header
+// promises 0 until that peer's context arrives.
+inline void rdcLinkDeathClearsPeerChainRole(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/2, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    ASSERT_EQ(suite->rdc.getPeerChainRole(SerialIdentifier::OUTPUT_JACK), 2);
+
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    EXPECT_EQ(suite->rdc.getPeerChainRole(SerialIdentifier::OUTPUT_JACK), 0);
+}
+
 // (f) With a byte callback set the driver exec() routes RX bytes to it and does
 // NOT assemble strings; with no byte callback the legacy string path is intact.
 inline void rdcHelloByteModeSuppressesStringAssembly() {

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -83,6 +83,11 @@ public:
         jack.exec();
     }
 
+    /// The RDC's owned transport, reached via friendship so a test can inject
+    /// SEND_SUCCESS (onSendResult) and inbound contexts (deliverIncoming) without a
+    /// radio. Not part of the production API.
+    ReliableTransport* transport() { return rdc.transport; }
+
     MockDevice device;
     FakePlatformClock* fakeClock = nullptr;
     NativeSerialDriver outJack{"hello-out"};
@@ -222,8 +227,8 @@ inline void rdcHelloEveryJackInitiatesContext(RDCHelloTests* suite) {
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
 }
 
-// A PdnConnectionContext carrying the given chainRole + userId, serialized to
-// its wire bytes for deliverIncoming.
+// A PdnConnectionContext carrying the given chainRole + userId, serialized to its
+// wire bytes for deliverIncoming.
 inline std::vector<uint8_t> pdnContextBytes(uint8_t chainRole, uint16_t userId, uint8_t seqId) {
     PdnConnectionContext ctx{};
     ctx.seqId = seqId;
@@ -256,7 +261,7 @@ inline void rdcContextSendClearedBySendSuccess(RDCHelloTests* suite) {
     ASSERT_TRUE(suite->rdc.isContextSendPending(peer));
     ASSERT_EQ(sentPayload.size(), sizeof(PdnConnectionContext));
 
-    suite->rdc.getReliableTransport()->onSendResult(
+    suite->transport()->onSendResult(
         PktType::kPdnConnectionContext, peer, sentPayload.data(), sentPayload.size(), true);
 
     EXPECT_FALSE(suite->rdc.isContextSendPending(peer));
@@ -294,7 +299,7 @@ inline void rdcContextReceiveConnectsJack(RDCHelloTests* suite) {
         .Times(testing::AnyNumber());
 
     std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/2, /*userId=*/4242, /*seqId=*/9);
-    suite->rdc.getReliableTransport()->deliverIncoming(
+    suite->transport()->deliverIncoming(
         PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
     suite->rdc.sync(&suite->device);  // commit Connecting->Connected
 
@@ -329,7 +334,7 @@ inline void rdcContextInputJackInitiates(RDCHelloTests* suite) {
 
     // Receiving the peer's context completes the input jack; nothing is sent back.
     std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
-    suite->rdc.getReliableTransport()->deliverIncoming(
+    suite->transport()->deliverIncoming(
         PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
     suite->rdc.sync(&suite->device);  // commit Connecting->Connected
 
@@ -361,7 +366,7 @@ inline void rdcContextCompletesBothJacksForSamePeer(RDCHelloTests* suite) {
     EXPECT_EQ(contextSends, 1);
 
     std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
-    suite->rdc.getReliableTransport()->deliverIncoming(
+    suite->transport()->deliverIncoming(
         PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
     suite->rdc.sync(&suite->device);
 
@@ -384,7 +389,7 @@ inline void rdcContextBeforeConnectingIsBufferedAndApplied(RDCHelloTests* suite)
     ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::IDLE);
     std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
-    suite->rdc.getReliableTransport()->deliverIncoming(
+    suite->transport()->deliverIncoming(
         PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
     suite->rdc.sync(&suite->device);
     ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
@@ -398,6 +403,51 @@ inline void rdcContextBeforeConnectingIsBufferedAndApplied(RDCHelloTests* suite)
 
     EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+}
+
+// A 2-node ring (same peer on BOTH jacks) whose context beats both HELLOs: it is
+// cached while both jacks are still IDLE, then the jacks enter CONNECTING one at a
+// time (sync drives OUTPUT before INPUT). The first to connect must NOT consume the
+// cache out from under the second — both links must reach CONNECTED, and each jack's
+// context callback must fire exactly once. Regression: a per-arrival consume left the
+// second jack CONNECTING until it silent-linked to IDLE, half-opening the ring.
+inline void rdcCachedContextCompletesBoth2NodeRingJacks(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    int outCb = 0;
+    int inCb = 0;
+    suite->rdc.setOnContextReceived(
+        [&](SerialIdentifier jack, DeviceType, const uint8_t*, size_t) {
+            if (jack == SerialIdentifier::OUTPUT_JACK) outCb++;
+            else if (jack == SerialIdentifier::INPUT_JACK) inCb++;
+        });
+
+    // Context arrives before EITHER jack is CONNECTING: both are Idle, so it is cached.
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+
+    // Both HELLOs arrive from the same peer; one sync drives both jacks Idle->Connecting
+    // (OUTPUT first). OUTPUT drains the cache, and INPUT — connecting right after — must
+    // still find it.
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xB1));
+    suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
+    suite->rdc.sync(&suite->device);  // both drain the cache as they connect
+    suite->rdc.sync(&suite->device);  // commit Connecting->Connected
+
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_EQ(outCb, 1);
+    EXPECT_EQ(inCb, 1);
 }
 
 // (f) With a byte callback set the driver exec() routes RX bytes to it and does

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -371,6 +371,35 @@ inline void rdcContextCompletesBothJacksForSamePeer(RDCHelloTests* suite) {
               RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
 }
 
+// A context that beats its own HELLO (arrives while the jack is still IDLE) must be
+// buffered and applied when the jack connects, not dropped — else the link half-opens.
+inline void rdcContextBeforeConnectingIsBufferedAndApplied(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    // Context arrives BEFORE any HELLO: the input jack is still Idle, so it can't be
+    // completed yet — but it must be held, not discarded.
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->rdc.getReliableTransport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+
+    // The HELLO finally arrives: the jack connects and the buffered context completes
+    // it (no re-send from the peer needed).
+    suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
+    suite->rdc.sync(&suite->device);  // Idle->Connecting drains the buffer
+    suite->rdc.sync(&suite->device);  // commit Connecting->Connected
+
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+}
+
 // (f) With a byte callback set the driver exec() routes RX bytes to it and does
 // NOT assemble strings; with no byte callback the legacy string path is intact.
 inline void rdcHelloByteModeSuppressesStringAssembly() {

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -535,6 +535,57 @@ inline void rdc2NodeRingSingleJackDropKeepsPeerSlot(RDCHelloTests* suite) {
     EXPECT_EQ(removed, 1);
 }
 
+// Half-open recovery: we are CONNECTED but the peer never got our context (lost
+// app-side, or it rebooted). Its retry arrives from a MAC our CONNECTED jack already
+// tracks; we must resend our context so its cycle can complete, and stay CONNECTED.
+inline void rdcConnectedPeerRetryTriggersContextResend(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t stranger[6] = {0xD1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    int contextSends = 0;
+    std::vector<uint8_t> sentPayload;
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, PktType::kPdnConnectionContext, _, _))
+        .WillByDefault(testing::DoAll(
+            testing::Invoke([&](const uint8_t*, PktType, const uint8_t* data, size_t len) {
+                contextSends++;
+                sentPayload.assign(data, data + len);
+            }),
+            Return(1)));
+
+    // Full connect on the OUT jack; SEND_SUCCESS clears our pending send.
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(contextSends, 1);
+    suite->transport()->onSendResult(
+        PktType::kPdnConnectionContext, peer, sentPayload.data(), sentPayload.size(), true);
+    ASSERT_FALSE(suite->rdc.isContextSendPending(peer));
+
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    ASSERT_EQ(contextSends, 1);
+
+    // The peer retries (fresh seqId): we resend our context and stay CONNECTED.
+    std::vector<uint8_t> retry = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/4);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, retry.data(), retry.size());
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(contextSends, 2);
+    EXPECT_TRUE(suite->rdc.isContextSendPending(peer));
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+
+    // A context from a MAC no jack tracks is buffered only — no resend to strangers.
+    std::vector<uint8_t> unknown = pdnContextBytes(/*chainRole=*/1, /*userId=*/9, /*seqId=*/5);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, stranger, unknown.data(), unknown.size());
+    EXPECT_EQ(contextSends, 2);
+}
+
 // (f) With a byte callback set the driver exec() routes RX bytes to it and does
 // NOT assemble strings; with no byte callback the legacy string path is intact.
 inline void rdcHelloByteModeSuppressesStringAssembly() {

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -744,6 +744,36 @@ inline void rdcLinkDeathClearsPeerChainRole(RDCHelloTests* suite) {
     EXPECT_EQ(suite->rdc.getPeerChainRole(SerialIdentifier::OUTPUT_JACK), 0);
 }
 
+// Two fresh-seqId contexts from the same MAC in the same tick (before the
+// Connecting -> Connected commit) must fire the game context callback once, not
+// twice: the jack still reports CONNECTING in that window.
+inline void rdcDuplicateContextSameTickFiresCallbackOnce(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    int callbacks = 0;
+    suite->rdc.setOnContextReceived(
+        [&](SerialIdentifier, DeviceType, const uint8_t*, size_t) { callbacks++; });
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+
+    std::vector<uint8_t> first = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    std::vector<uint8_t> second = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/4);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, first.data(), first.size());
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, second.data(), second.size());
+    EXPECT_EQ(callbacks, 1);
+
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_EQ(callbacks, 1);
+}
+
 // (f) With a byte callback set the driver exec() routes RX bytes to it and does
 // NOT assemble strings; with no byte callback the legacy string path is intact.
 inline void rdcHelloByteModeSuppressesStringAssembly() {

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -206,25 +206,134 @@ inline void rdcHelloEmitProducesFramesOnBothJacks(RDCHelloTests* suite) {
     }
 }
 
-// (e) A new HELLO MAC on the OUT jack invokes the context-request placeholder;
-// the IN jack does not.
+// (e) A new HELLO MAC on the OUT jack sends this device's context (pending
+// entry created); the IN jack does not initiate one.
 inline void rdcHelloOutputJackInitiatesContext(RDCHelloTests* suite) {
-    int outRequests = 0;
-    int inRequests = 0;
-    suite->rdc.setOnContextRequest([&](SerialIdentifier jack) {
-        if (jack == SerialIdentifier::OUTPUT_JACK)
-            outRequests++;
-        else
-            inRequests++;
-    });
+    const uint8_t outPeer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t inPeer[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
 
     suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
     suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
     suite->rdc.sync(&suite->device);
 
-    EXPECT_EQ(outRequests, 1);
-    EXPECT_EQ(inRequests, 0);
+    EXPECT_TRUE(suite->rdc.isContextSendPending(outPeer));
+    EXPECT_FALSE(suite->rdc.isContextSendPending(inPeer));
     EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+}
+
+// A PdnConnectionContext carrying the given chainRole + userId, serialized to
+// its wire bytes for deliverIncoming.
+inline std::vector<uint8_t> pdnContextBytes(uint8_t chainRole, uint16_t userId, uint8_t seqId) {
+    PdnConnectionContext ctx{};
+    ctx.seqId = seqId;
+    ctx.chainRole = chainRole;
+    ctx.player.userId = userId;
+    std::vector<uint8_t> bytes(sizeof(ctx));
+    memcpy(bytes.data(), &ctx, sizeof(ctx));
+    return bytes;
+}
+
+// (a)+(b) A new OUT-jack HELLO MAC sends context (pending), and the #152
+// SEND_SUCCESS onSendResult clears that pending entry.
+inline void rdcContextSendClearedBySendSuccess(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    // Capture the exact bytes handed to the radio so the echoed seqId can be
+    // fed back through onSendResult, exactly as the driver's send callback does.
+    std::vector<uint8_t> sentPayload;
+    ON_CALL(*suite->device.mockPeerComms,
+            sendData(_, PktType::kPdnConnectionContext, _, _))
+        .WillByDefault(testing::DoAll(
+            testing::Invoke([&sentPayload](const uint8_t*, PktType, const uint8_t* data,
+                                           size_t len) {
+                sentPayload.assign(data, data + len);
+            }),
+            Return(1)));
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    ASSERT_TRUE(suite->rdc.isContextSendPending(peer));
+    ASSERT_EQ(sentPayload.size(), sizeof(PdnConnectionContext));
+
+    suite->rdc.getReliableTransport()->onSendResult(
+        PktType::kPdnConnectionContext, peer, sentPayload.data(), sentPayload.size(), true);
+
+    EXPECT_FALSE(suite->rdc.isContextSendPending(peer));
+}
+
+// (c) Receiving a peer's context registers it, records chainRole, fires the
+// opaque profile callback with the matched jack, and drives that jack
+// CONNECTING -> CONNECTED.
+inline void rdcContextReceiveConnectsJack(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    SerialIdentifier cbJack = SerialIdentifier::INPUT_JACK;
+    DeviceType cbType = DeviceType::UNKNOWN;
+    uint16_t cbUserId = 0;
+    int cbCount = 0;
+    suite->rdc.setOnContextReceived(
+        [&](SerialIdentifier jack, DeviceType type, const uint8_t* profile, size_t len) {
+            cbCount++;
+            cbJack = jack;
+            cbType = type;
+            ASSERT_EQ(len, sizeof(PlayerProfile));
+            PlayerProfile p{};
+            memcpy(&p, profile, len);
+            cbUserId = p.userId;
+        });
+
+    // The OUT jack must already know the peer MAC (from its HELLO) for the
+    // received context to match a jack.
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_))
+        .Times(testing::AnyNumber());
+
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/2, /*userId=*/4242, /*seqId=*/9);
+    suite->rdc.getReliableTransport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+
+    EXPECT_EQ(cbCount, 1);
+    EXPECT_EQ(cbJack, SerialIdentifier::OUTPUT_JACK);
+    EXPECT_EQ(cbType, DeviceType::PDN);
+    EXPECT_EQ(cbUserId, 4242);
+    EXPECT_EQ(suite->rdc.getPeerChainRole(SerialIdentifier::OUTPUT_JACK), 2);
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_EQ(suite->connectCount, 1);
+    EXPECT_EQ(suite->lastConnectJack, SerialIdentifier::OUTPUT_JACK);
+}
+
+// (d) A headMac change mid-exchange cancels the in-flight send and re-initiates.
+inline void rdcContextHeadChangeReinitiates(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    int contextSends = 0;
+    ON_CALL(*suite->device.mockPeerComms,
+            sendData(_, PktType::kPdnConnectionContext, _, _))
+        .WillByDefault(testing::DoAll(
+            testing::InvokeWithoutArgs([&contextSends]() { contextSends++; }),
+            Return(1)));
+
+    // First HELLO: head all-zero. Opens the exchange (one send).
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    ASSERT_TRUE(suite->rdc.isContextSendPending(peer));
+    const int sendsAfterFirst = contextSends;
+    ASSERT_EQ(sendsAfterFirst, 1);
+
+    // Second HELLO from the same source, now carrying a non-zero head: the
+    // exchange re-initiates (cancel + fresh send), the jack stays CONNECTING.
+    HelloPayload hello{};
+    memcpy(hello.source, peer, 6);
+    hello.deviceType = static_cast<uint8_t>(DeviceType::PDN);
+    hello.headMac[0] = 0xCC;
+    suite->deliverHello(suite->outJack, encodeFramed(hello));
+
+    EXPECT_EQ(contextSends, sendsAfterFirst + 1);
+    EXPECT_TRUE(suite->rdc.isContextSendPending(peer));
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
 }
 

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -450,6 +450,91 @@ inline void rdcCachedContextCompletesBoth2NodeRingJacks(RDCHelloTests* suite) {
     EXPECT_EQ(inCb, 1);
 }
 
+// Every link death must release the peer's ESP-NOW slot (the radio hard-fails past
+// its peer cap, so leaked slots eventually block all new connections): both the
+// Connected silent-link edge and the Connecting context-timeout edge.
+inline void rdcLinkDeathReleasesPeerSlot(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t secondPeer[6] = {0xC1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    int removed = 0;
+    std::array<uint8_t, 6> removedMac{};
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_))
+        .WillRepeatedly(testing::DoAll(
+            testing::Invoke([&](const uint8_t* mac) {
+                removed++;
+                memcpy(removedMac.data(), mac, 6);
+            }),
+            Return(0)));
+
+    // Connected -> Idle (silent link) releases the slot.
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    suite->rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_EQ(removed, 0);
+
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(removed, 1);
+    EXPECT_EQ(0, memcmp(removedMac.data(), peer, 6));
+
+    // Connecting -> Idle (context exchange never completes) releases too.
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xC1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+
+    suite->fakeClock->advance(RemoteDeviceCoordinator::CONTEXT_EXCHANGE_TIMEOUT_MS + 1);
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(removed, 2);
+    EXPECT_EQ(0, memcmp(removedMac.data(), secondPeer, 6));
+}
+
+// A 2-node ring has the same MAC on both jacks: dropping ONE cable must NOT release
+// the ESP-NOW slot the still-connected jack depends on; dropping the second one must.
+inline void rdc2NodeRingSingleJackDropKeepsPeerSlot(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    int removed = 0;
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_))
+        .WillRepeatedly(testing::DoAll(
+            testing::InvokeWithoutArgs([&removed]() { removed++; }), Return(0)));
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xB1));
+    suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
+    suite->rdc.sync(&suite->device);
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+
+    // One cable dies: only the INPUT jack keeps hearing HELLOs across the gap.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_EQ(removed, 0);  // the surviving link still needs the radio slot
+
+    // The second cable dies too: now the slot is released.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    EXPECT_EQ(removed, 1);
+}
+
 // (f) With a byte callback set the driver exec() routes RX bytes to it and does
 // NOT assemble strings; with no byte callback the legacy string path is intact.
 inline void rdcHelloByteModeSuppressesStringAssembly() {

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -338,6 +338,34 @@ inline void rdcContextInputJackReplies(RDCHelloTests* suite) {
     EXPECT_TRUE(suite->rdc.isContextSendPending(peer));  // reply was sent
 }
 
+// A 2-node ring cables the same peer to BOTH jacks. One received context must
+// complete BOTH links; if the un-matched one is left CONNECTING it silent-links to
+// IDLE and opens the ring.
+inline void rdcContextCompletesBothJacksForSamePeer(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xB1));
+    suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->rdc.getReliableTransport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+}
+
 // (d) A headMac change mid-exchange cancels the in-flight send and re-initiates.
 
 // (f) With a byte callback set the driver exec() routes RX bytes to it and does

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -535,6 +535,86 @@ inline void rdc2NodeRingSingleJackDropKeepsPeerSlot(RDCHelloTests* suite) {
     EXPECT_EQ(removed, 1);
 }
 
+// Link death must cancel the pending context send along with the radio slot: a
+// surviving retry re-registers its target inside the driver, re-adding (and thus
+// permanently leaking) the slot that was just released.
+inline void rdcLinkDeathCancelsPendingContextSend(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    int contextSends = 0;
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, PktType::kPdnConnectionContext, _, _))
+        .WillByDefault(testing::DoAll(
+            testing::InvokeWithoutArgs([&contextSends]() { contextSends++; }), Return(1)));
+
+    // Send goes out but is never acked, so it sits pending on the Resender.
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_TRUE(suite->rdc.isContextSendPending(peer));
+
+    // The exchange never completes; the link dies.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::CONTEXT_EXCHANGE_TIMEOUT_MS + 1);
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    EXPECT_FALSE(suite->rdc.isContextSendPending(peer));
+
+    // Pumping the retransmit timers after death must produce no further sends.
+    const int sendsAtDeath = contextSends;
+    for (int i = 0; i < 4; ++i) {
+        suite->fakeClock->advance(400);
+        suite->rdc.sync(&suite->device);
+    }
+    EXPECT_EQ(contextSends, sendsAtDeath);
+}
+
+// A replug right after a failed exchange must run a fresh full exchange: register
+// the slot again and send our context again (the dead attempt's pending entry must
+// not short-circuit the new one), ending CONNECTED.
+inline void rdcReplugAfterFailedExchangeRecovers(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    int adds = 0;
+    int removes = 0;
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_))
+        .WillRepeatedly(testing::DoAll(
+            testing::InvokeWithoutArgs([&adds]() { adds++; }), Return(0)));
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_))
+        .WillRepeatedly(testing::DoAll(
+            testing::InvokeWithoutArgs([&removes]() { removes++; }), Return(0)));
+    int contextSends = 0;
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, PktType::kPdnConnectionContext, _, _))
+        .WillByDefault(testing::DoAll(
+            testing::InvokeWithoutArgs([&contextSends]() { contextSends++; }), Return(1)));
+
+    // First exchange: send never acked, link dies with the send still un-acked.
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    suite->fakeClock->advance(RemoteDeviceCoordinator::CONTEXT_EXCHANGE_TIMEOUT_MS + 1);
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    ASSERT_EQ(removes, 1);
+    const int sendsBeforeReplug = contextSends;
+    const int addsBeforeReplug = adds;
+
+    // Replug: the fresh exchange must re-register and re-send, then complete.
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+    EXPECT_EQ(adds, addsBeforeReplug + 1);
+    EXPECT_EQ(contextSends, sendsBeforeReplug + 1);
+
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_EQ(removes, 1);
+}
+
 // Half-open recovery: we are CONNECTED but the peer never got our context (lost
 // app-side, or it rebooted). Its retry arrives from a MAC our CONNECTED jack already
 // tracks; we must resend our context so its cycle can complete, and stay CONNECTED.

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -345,6 +345,10 @@ inline void rdcContextCompletesBothJacksForSamePeer(RDCHelloTests* suite) {
 
     ON_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
     EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    int contextSends = 0;
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, PktType::kPdnConnectionContext, _, _))
+        .WillByDefault(testing::DoAll(
+            testing::InvokeWithoutArgs([&contextSends]() { contextSends++; }), Return(1)));
 
     suite->deliverHello(suite->outJack, suite->helloFrame(0xB1));
     suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
@@ -353,6 +357,8 @@ inline void rdcContextCompletesBothJacksForSamePeer(RDCHelloTests* suite) {
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
     ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+    // Both jacks face the same peer, but our context goes out ONCE, not twice.
+    EXPECT_EQ(contextSends, 1);
 
     std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
     suite->rdc.getReliableTransport()->deliverIncoming(

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -666,6 +666,59 @@ inline void rdcConnectedPeerRetryTriggersContextResend(RDCHelloTests* suite) {
     EXPECT_EQ(contextSends, 2);
 }
 
+// Two CONNECTED sides can answer each other's recovery resends forever (every send
+// stamps a fresh seqId, so dedup never brakes), so the resend is throttled to one
+// per exchange window, per jack.
+inline void rdcConnectedRetryResendThrottled(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    int contextSends = 0;
+    std::vector<uint8_t> sentPayload;
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, PktType::kPdnConnectionContext, _, _))
+        .WillByDefault(testing::DoAll(
+            testing::Invoke([&](const uint8_t*, PktType, const uint8_t* data, size_t len) {
+                contextSends++;
+                sentPayload.assign(data, data + len);
+            }),
+            Return(1)));
+
+    // Full connect, initial send acked.
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(contextSends, 1);
+    suite->transport()->onSendResult(
+        PktType::kPdnConnectionContext, peer, sentPayload.data(), sentPayload.size(), true);
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+
+    // First retry resends; ack it so pending cannot mask the throttle.
+    std::vector<uint8_t> retry1 = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/4);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, retry1.data(), retry1.size());
+    ASSERT_EQ(contextSends, 2);
+    suite->transport()->onSendResult(
+        PktType::kPdnConnectionContext, peer, sentPayload.data(), sentPayload.size(), true);
+    ASSERT_FALSE(suite->rdc.isContextSendPending(peer));
+
+    // Second retry inside the window: throttled, exactly one resend total.
+    std::vector<uint8_t> retry2 = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/5);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, retry2.data(), retry2.size());
+    EXPECT_EQ(contextSends, 2);
+
+    // Window expired: a genuine still-CONNECTING peer's next cycle resends again.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::CONTEXT_EXCHANGE_TIMEOUT_MS + 1);
+    std::vector<uint8_t> retry3 = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/6);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, retry3.data(), retry3.size());
+    EXPECT_EQ(contextSends, 3);
+}
+
 // (f) With a byte callback set the driver exec() routes RX bytes to it and does
 // NOT assemble strings; with no byte callback the legacy string path is intact.
 inline void rdcHelloByteModeSuppressesStringAssembly() {

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1316,6 +1316,18 @@ TEST_F(RDCHelloTests, outputJackInitiatesContext) {
     rdcHelloOutputJackInitiatesContext(this);
 }
 
+TEST_F(RDCHelloTests, contextSendClearedBySendSuccess) {
+    rdcContextSendClearedBySendSuccess(this);
+}
+
+TEST_F(RDCHelloTests, contextReceiveConnectsJack) {
+    rdcContextReceiveConnectsJack(this);
+}
+
+TEST_F(RDCHelloTests, contextHeadChangeReinitiates) {
+    rdcContextHeadChangeReinitiates(this);
+}
+
 TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {
     rdcHelloByteModeSuppressesStringAssembly();
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1345,6 +1345,12 @@ TEST_F(RDCHelloTests, twoNodeRingSingleJackDropKeepsPeerSlot) {
 TEST_F(RDCHelloTests, connectedPeerRetryTriggersContextResend) {
     rdcConnectedPeerRetryTriggersContextResend(this);
 }
+TEST_F(RDCHelloTests, linkDeathCancelsPendingContextSend) {
+    rdcLinkDeathCancelsPendingContextSend(this);
+}
+TEST_F(RDCHelloTests, replugAfterFailedExchangeRecovers) {
+    rdcReplugAfterFailedExchangeRecovers(this);
+}
 
 TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {
     rdcHelloByteModeSuppressesStringAssembly();

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1336,6 +1336,12 @@ TEST_F(RDCHelloTests, cachedContextCompletesBoth2NodeRingJacks) {
 TEST_F(RDCHelloTests, contextInputJackInitiates) {
     rdcContextInputJackInitiates(this);
 }
+TEST_F(RDCHelloTests, linkDeathReleasesPeerSlot) {
+    rdcLinkDeathReleasesPeerSlot(this);
+}
+TEST_F(RDCHelloTests, twoNodeRingSingleJackDropKeepsPeerSlot) {
+    rdc2NodeRingSingleJackDropKeepsPeerSlot(this);
+}
 
 TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {
     rdcHelloByteModeSuppressesStringAssembly();

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1354,6 +1354,9 @@ TEST_F(RDCHelloTests, replugAfterFailedExchangeRecovers) {
 TEST_F(RDCHelloTests, connectedRetryResendThrottled) {
     rdcConnectedRetryResendThrottled(this);
 }
+TEST_F(RDCHelloTests, linkDeathClearsPeerChainRole) {
+    rdcLinkDeathClearsPeerChainRole(this);
+}
 
 TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {
     rdcHelloByteModeSuppressesStringAssembly();

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1312,8 +1312,8 @@ TEST_F(RDCHelloTests, emitProducesFramesOnBothJacks) {
     rdcHelloEmitProducesFramesOnBothJacks(this);
 }
 
-TEST_F(RDCHelloTests, outputJackInitiatesContext) {
-    rdcHelloOutputJackInitiatesContext(this);
+TEST_F(RDCHelloTests, everyJackInitiatesContext) {
+    rdcHelloEveryJackInitiatesContext(this);
 }
 
 TEST_F(RDCHelloTests, contextSendClearedBySendSuccess) {
@@ -1327,8 +1327,8 @@ TEST_F(RDCHelloTests, contextReceiveConnectsJack) {
 TEST_F(RDCHelloTests, contextCompletesBothJacksForSamePeer) {
     rdcContextCompletesBothJacksForSamePeer(this);
 }
-TEST_F(RDCHelloTests, contextInputJackReplies) {
-    rdcContextInputJackReplies(this);
+TEST_F(RDCHelloTests, contextInputJackInitiates) {
+    rdcContextInputJackInitiates(this);
 }
 
 TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1342,6 +1342,9 @@ TEST_F(RDCHelloTests, linkDeathReleasesPeerSlot) {
 TEST_F(RDCHelloTests, twoNodeRingSingleJackDropKeepsPeerSlot) {
     rdc2NodeRingSingleJackDropKeepsPeerSlot(this);
 }
+TEST_F(RDCHelloTests, connectedPeerRetryTriggersContextResend) {
+    rdcConnectedPeerRetryTriggersContextResend(this);
+}
 
 TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {
     rdcHelloByteModeSuppressesStringAssembly();

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1327,6 +1327,9 @@ TEST_F(RDCHelloTests, contextReceiveConnectsJack) {
 TEST_F(RDCHelloTests, contextCompletesBothJacksForSamePeer) {
     rdcContextCompletesBothJacksForSamePeer(this);
 }
+TEST_F(RDCHelloTests, contextBeforeConnectingIsBufferedAndApplied) {
+    rdcContextBeforeConnectingIsBufferedAndApplied(this);
+}
 TEST_F(RDCHelloTests, contextInputJackInitiates) {
     rdcContextInputJackInitiates(this);
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1324,6 +1324,10 @@ TEST_F(RDCHelloTests, contextReceiveConnectsJack) {
     rdcContextReceiveConnectsJack(this);
 }
 
+TEST_F(RDCHelloTests, contextInputJackReplies) {
+    rdcContextInputJackReplies(this);
+}
+
 TEST_F(RDCHelloTests, contextHeadChangeReinitiates) {
     rdcContextHeadChangeReinitiates(this);
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1351,6 +1351,9 @@ TEST_F(RDCHelloTests, linkDeathCancelsPendingContextSend) {
 TEST_F(RDCHelloTests, replugAfterFailedExchangeRecovers) {
     rdcReplugAfterFailedExchangeRecovers(this);
 }
+TEST_F(RDCHelloTests, connectedRetryResendThrottled) {
+    rdcConnectedRetryResendThrottled(this);
+}
 
 TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {
     rdcHelloByteModeSuppressesStringAssembly();

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1324,6 +1324,9 @@ TEST_F(RDCHelloTests, contextReceiveConnectsJack) {
     rdcContextReceiveConnectsJack(this);
 }
 
+TEST_F(RDCHelloTests, contextCompletesBothJacksForSamePeer) {
+    rdcContextCompletesBothJacksForSamePeer(this);
+}
 TEST_F(RDCHelloTests, contextInputJackReplies) {
     rdcContextInputJackReplies(this);
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1328,10 +1328,6 @@ TEST_F(RDCHelloTests, contextInputJackReplies) {
     rdcContextInputJackReplies(this);
 }
 
-TEST_F(RDCHelloTests, contextHeadChangeReinitiates) {
-    rdcContextHeadChangeReinitiates(this);
-}
-
 TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {
     rdcHelloByteModeSuppressesStringAssembly();
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1357,6 +1357,9 @@ TEST_F(RDCHelloTests, connectedRetryResendThrottled) {
 TEST_F(RDCHelloTests, linkDeathClearsPeerChainRole) {
     rdcLinkDeathClearsPeerChainRole(this);
 }
+TEST_F(RDCHelloTests, duplicateContextSameTickFiresCallbackOnce) {
+    rdcDuplicateContextSameTickFiresCallbackOnce(this);
+}
 
 TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {
     rdcHelloByteModeSuppressesStringAssembly();

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1330,6 +1330,9 @@ TEST_F(RDCHelloTests, contextCompletesBothJacksForSamePeer) {
 TEST_F(RDCHelloTests, contextBeforeConnectingIsBufferedAndApplied) {
     rdcContextBeforeConnectingIsBufferedAndApplied(this);
 }
+TEST_F(RDCHelloTests, cachedContextCompletesBoth2NodeRingJacks) {
+    rdcCachedContextCompletesBoth2NodeRingJacks(this);
+}
 TEST_F(RDCHelloTests, contextInputJackInitiates) {
     rdcContextInputJackInitiates(this);
 }


### PR DESCRIPTION
# rdc: ESP-NOW context exchange over ReliableChannel (#157)

Closes #157. Re-integrated onto `comms-rewrite` now that #155 (#191, the `HelloLinkMachine` framework) and #152 (#190) have merged. The diff is now just the context-exchange work: the ESP-NOW exchange **redesigned onto the merged per-jack SM**, symmetric per-jack initiation, and a commit driving the exchange off the SM's deferred transitions. The `sim:` commit is CLI-test infrastructure for the test branch stacked above.

This is the **first consumer of the shared `ReliableChannel`**, which is the point: the context send runs through #152's SEND_SUCCESS ack (the tests drive it via `onSendResult`).

## Where to look
- **Redesign onto the framework.** The old enum `JackHelloLink` (its own `state`/`peerMac`/`headMac` fields) is gone; the struct is now `parser` + `machine` + two RDC-level records. Context initiation hangs off the framework's `onContextRequest` hook (fires for every jack on entering Connecting), not a hand-rolled "newSource → initiate". The one framework touch is a 4-line read-only `HelloLinkMachine::peer()` accessor so a received context can be matched back to its jack.
- **Deviation from #144: every jack initiates, not just OUT.** The design doc says output initiates and input replies. That pairing wedges the 2-node ring: both jacks track the same peer MAC, and a single reply can only complete one of them, so the straggler jack loops CONNECTING→IDLE. Symmetric initiation lets each jack complete off the peer's send, with per-MAC context retention collapsing the duplicate. If you'd rather keep the doc's asymmetry, the 2-node ring needs a different completion path — flagging rather than silently diverging.
- **Peer lifecycle closes both ways.** Every new HELLO peer registers an ESP-NOW slot, and the slot is now released on link death (silent-link and Connecting-timeout both converge on Idle-mount, which fires `onLinkDown`). Release is guarded per #144: not while the other jack or a daisy record still tracks the MAC, so a 2-node ring's one-cable drop keeps wireless alive. Without this the 20-slot driver table fills after 20 distinct partners since boot.
- **Half-open recovery.** SEND_SUCCESS is a MAC-level ack, so a context can be lost app-side (or a rebooted peer's fresh context can collide with the per-MAC seqId dedup). The CONNECTED side now treats a context arriving from a MAC it already tracks as peer re-initiation and resends its own context, throttled to one per exchange window so two CONNECTED sides answering each other can't livelock; the still-CONNECTING side stops cycling on completion. Recovery no longer requires a physical replug. Teardown cancels the pending context retries before releasing the radio slot — otherwise the channel's own retransmit re-adds the slot just removed — and `registerPeer` runs before both the drain and the pending-send check so a replug inside the stale window can't reach CONNECTED without a slot.
- **Transport pump ownership.** The RDC owns a `ReliableTransport` and pumps its `sync()` from `RDC::sync()` (platform-loop-owned), not a game manager.

## Known-deferred (not gaps in this PR)
- Peer-identity accessors (`getPeerMac`/`isDirectPeer`) still read the dormant handshake and return null under HELLO — resolved with the device chain SM (#156).
- The outgoing profile is zeroed until the game layer sets it; FDN context is a placeholder.

## Validation
Native core 323/323 + CLI 86/86; `esp32-s3_pdn_release` builds. Hardware-unvalidated. The full HELLO → context → SEND_SUCCESS-ack chain is exercised end-to-end by the CLI-sim test on the branch stacked above.
