### PR TITLE
game: ShootoutAwareState base for shootout-abort/idle cross-cut

### DIFF
--- a/src/pdn/game/quickdraw-states.hpp
+++ b/src/pdn/game/quickdraw-states.hpp
@@ -21,6 +21,7 @@
 #include "device/remote-device-coordinator.hpp"
 #include "game/chain-duel-manager.hpp"
 #include "game/shootout-manager.hpp"
+#include "game/shootout-aware-state.hpp"
 
 /// Bundle of the shared game-wide managers a state may need. Built once by
 /// Quickdraw::populateStateMap and handed to every state so a new manager is a
@@ -177,9 +178,7 @@ private:
     bool isAuxRequired() override;
 };
 
-
-
-class DuelCountdown : public ConnectState<PDN> {
+class DuelCountdown : public ConnectState<PDN>, public ShootoutAwareState {
 public:
     explicit DuelCountdown(const GameContext& ctx);
     ~DuelCountdown();
@@ -188,7 +187,6 @@ public:
     void onStateLoop(PDN* pdn) override;
     void onStateDismounted(PDN* pdn) override;
     bool shallWeBattle();
-    bool disconnectedBackToIdle();
 
     bool isPrimaryRequired() override;
     bool isAuxRequired() override;
@@ -276,7 +274,7 @@ private:
     const int DUEL_TIMEOUT = 4000;
 };
 
-class DuelPushed : public ConnectState<PDN> {
+class DuelPushed : public ConnectState<PDN>, public ShootoutAwareState {
 public:
     explicit DuelPushed(const GameContext& ctx);
     ~DuelPushed();
@@ -285,7 +283,6 @@ public:
     void onStateLoop(PDN* pdn) override;
     void onStateDismounted(PDN* pdn) override;
     bool transitionToDuelResult();
-    bool disconnectedBackToIdle();
 
     bool isPrimaryRequired() override;
     bool isAuxRequired() override;
@@ -297,7 +294,7 @@ private:
     const int DUEL_RESULT_GRACE_PERIOD = 900;
 };
 
-class DuelReceivedResult : public ConnectState<PDN> {
+class DuelReceivedResult : public ConnectState<PDN>, public ShootoutAwareState {
 public:
     explicit DuelReceivedResult(const GameContext& ctx);
     ~DuelReceivedResult();
@@ -306,7 +303,6 @@ public:
     void onStateLoop(PDN* pdn) override;
     void onStateDismounted(PDN* pdn) override;
     bool transitionToDuelResult();
-    bool disconnectedBackToIdle();
 
     bool isPrimaryRequired() override;
     bool isAuxRequired() override;
@@ -406,9 +402,7 @@ private:
     bool shouldRetryUpload = false;
 };
 
-static constexpr unsigned long kLoopBreakDebounceMs = 500;
-
-class ShootoutProposal : public TypedState<PDN> {
+class ShootoutProposal : public TypedState<PDN>, public ShootoutAwareState {
 public:
     explicit ShootoutProposal(const GameContext& ctx);
     void onStateMounted(PDN* pdn) override;
@@ -420,15 +414,13 @@ public:
     bool transitionToAborted();
 
 private:
-    ShootoutManager* shootout_;
     ChainDuelManager* chainDuelManager_;
     bool shouldGoToReveal_ = false;
     bool shouldGoToIdle_ = false;
     bool shouldGoToAborted_ = false;
-    DebouncedCondition loopBreakDebounce_;
 };
 
-class ShootoutBracketReveal : public TypedState<PDN> {
+class ShootoutBracketReveal : public TypedState<PDN>, public ShootoutAwareState {
 public:
     explicit ShootoutBracketReveal(const GameContext& ctx);
     void onStateMounted(PDN* pdn) override;
@@ -441,13 +433,11 @@ public:
     bool transitionToIdle();
 
 private:
-    ShootoutManager* shootout_;
     ChainDuelManager* chainDuelManager_;
     bool shouldGoToDuelCountdown_ = false;
     bool shouldGoToSpectator_ = false;
     bool shouldGoToAborted_ = false;
     bool shouldGoToIdle_ = false;
-    DebouncedCondition loopBreakDebounce_;
 };
 
 class ShootoutSpectator : public TypedState<PDN> {

--- a/src/pdn/game/quickdraw-states/duel-countdown-state.cpp
+++ b/src/pdn/game/quickdraw-states/duel-countdown-state.cpp
@@ -7,7 +7,8 @@
 #include "device/drivers/logger.hpp"
 
 DuelCountdown::DuelCountdown(const GameContext& ctx)
-    : ConnectState<PDN>(ctx.remoteDeviceCoordinator, DUEL_COUNTDOWN) {
+    : ConnectState<PDN>(ctx.remoteDeviceCoordinator, DUEL_COUNTDOWN)
+    , ShootoutAwareState(ctx.shootoutManager) {
     this->player = ctx.player;
     this->matchManager = ctx.matchManager;
     this->chainDuelManager = ctx.chainDuelManager;
@@ -105,10 +106,6 @@ void DuelCountdown::onStateDismounted(PDN* pdn) {
 
 bool DuelCountdown::shallWeBattle() {
     return doBattle;
-}
-
-bool DuelCountdown::disconnectedBackToIdle() {
-    return isPersistentlyDisconnected();
 }
 
 bool DuelCountdown::isPrimaryRequired() {

--- a/src/pdn/game/quickdraw-states/duel-pushed-state.cpp
+++ b/src/pdn/game/quickdraw-states/duel-pushed-state.cpp
@@ -5,7 +5,8 @@
 #define DUEL_PUSHED_TAG "DUEL_PUSHED"
 
 DuelPushed::DuelPushed(const GameContext& ctx)
-    : ConnectState<PDN>(ctx.remoteDeviceCoordinator, DUEL_PUSHED) {
+    : ConnectState<PDN>(ctx.remoteDeviceCoordinator, DUEL_PUSHED)
+    , ShootoutAwareState(ctx.shootoutManager) {
     this->player = ctx.player;
     this->matchManager = ctx.matchManager;
 }
@@ -47,10 +48,6 @@ bool DuelPushed::isPrimaryRequired() {
 
 bool DuelPushed::isAuxRequired() {
     return !player->isHunter();
-}
-
-bool DuelPushed::disconnectedBackToIdle() {
-    return isPersistentlyDisconnected();
 }
 
 bool DuelPushed::transitionToDuelResult() {

--- a/src/pdn/game/quickdraw-states/duel-result-received-state.cpp
+++ b/src/pdn/game/quickdraw-states/duel-result-received-state.cpp
@@ -7,7 +7,8 @@
 #define DUEL_RESULT_RECEIVED_TAG "DUEL_RESULT_RECEIVED"
 
 DuelReceivedResult::DuelReceivedResult(const GameContext& ctx)
-    : ConnectState<PDN>(ctx.remoteDeviceCoordinator, DUEL_RECEIVED_RESULT) {
+    : ConnectState<PDN>(ctx.remoteDeviceCoordinator, DUEL_RECEIVED_RESULT)
+    , ShootoutAwareState(ctx.shootoutManager) {
     this->player = ctx.player;
     this->matchManager = ctx.matchManager;
 }
@@ -60,10 +61,6 @@ void DuelReceivedResult::onStateDismounted(PDN* pdn) {
 
 bool DuelReceivedResult::transitionToDuelResult() {
     return matchManager->matchResultsAreIn() || transitionToDuelResultState;
-}
-
-bool DuelReceivedResult::disconnectedBackToIdle() {
-    return isPersistentlyDisconnected();
 }
 
 bool DuelReceivedResult::isPrimaryRequired() {

--- a/src/pdn/game/quickdraw-states/shootout-bracket-reveal-state.cpp
+++ b/src/pdn/game/quickdraw-states/shootout-bracket-reveal-state.cpp
@@ -3,7 +3,7 @@
 
 ShootoutBracketReveal::ShootoutBracketReveal(const GameContext& ctx)
     : TypedState<PDN>(SHOOTOUT_BRACKET_REVEAL)
-    , shootout_(ctx.shootoutManager)
+    , ShootoutAwareState(ctx.shootoutManager)
     , chainDuelManager_(ctx.chainDuelManager) {}
 
 void ShootoutBracketReveal::onStateMounted(PDN* pdn) {
@@ -19,10 +19,10 @@ void ShootoutBracketReveal::onStateMounted(PDN* pdn) {
 }
 
 void ShootoutBracketReveal::onStateLoop(PDN* pdn) {
-    shootout_->sync();
-    auto p = shootout_->getPhase();
+    shootoutManager->sync();
+    auto p = shootoutManager->getPhase();
     if (p == ShootoutManager::Phase::MATCH_IN_PROGRESS) {
-        if (shootout_->isLocalDuelist()) {
+        if (shootoutManager->isLocalDuelist()) {
             shouldGoToDuelCountdown_ = true;
         } else {
             shouldGoToSpectator_ = true;
@@ -30,10 +30,7 @@ void ShootoutBracketReveal::onStateLoop(PDN* pdn) {
     }
     if (p == ShootoutManager::Phase::ABORTED) shouldGoToAborted_ = true;
     bool loopBroken = chainDuelManager_ && !chainDuelManager_->isLoop();
-    if (loopBreakDebounce_.heldFor(loopBroken, kLoopBreakDebounceMs)) {
-        shootout_->resetToIdle();
-        shouldGoToIdle_ = true;
-    }
+    if (tickAbortGuard(loopBroken)) shouldGoToIdle_ = true;
 }
 
 void ShootoutBracketReveal::onStateDismounted(PDN* pdn) {
@@ -41,7 +38,7 @@ void ShootoutBracketReveal::onStateDismounted(PDN* pdn) {
     shouldGoToSpectator_ = false;
     shouldGoToAborted_ = false;
     shouldGoToIdle_ = false;
-    loopBreakDebounce_.reset();
+    resetAbortGuard();
 }
 
 bool ShootoutBracketReveal::transitionToDuelCountdown() { return shouldGoToDuelCountdown_; }

--- a/src/pdn/game/quickdraw-states/shootout-proposal-state.cpp
+++ b/src/pdn/game/quickdraw-states/shootout-proposal-state.cpp
@@ -3,11 +3,11 @@
 
 ShootoutProposal::ShootoutProposal(const GameContext& ctx)
     : TypedState<PDN>(SHOOTOUT_PROPOSAL)
-    , shootout_(ctx.shootoutManager)
+    , ShootoutAwareState(ctx.shootoutManager)
     , chainDuelManager_(ctx.chainDuelManager) {}
 
 void ShootoutProposal::onStateMounted(PDN* pdn) {
-    shootout_->startProposal();
+    shootoutManager->startProposal();
     auto* d = pdn->getDisplay();
     d->invalidateScreen()->setGlyphMode(FontMode::TEXT_INVERTED_LARGE);
     d->drawCenteredText("SHOOTOUT", 15);
@@ -16,24 +16,21 @@ void ShootoutProposal::onStateMounted(PDN* pdn) {
     d->drawCenteredText("confirm", 55);
     d->render();
 
-    parameterizedCallbackFunction confirmCb = [](void *ctx) {
-        static_cast<ShootoutProposal*>(ctx)->shootout_->confirmLocal();
+    parameterizedCallbackFunction confirmCb = [](void* ctx) {
+        static_cast<ShootoutProposal*>(ctx)->shootoutManager->confirmLocal();
     };
     pdn->getPrimaryButton()->setButtonPress(confirmCb, this, ButtonInteraction::CLICK);
     pdn->getSecondaryButton()->setButtonPress(confirmCb, this, ButtonInteraction::CLICK);
 }
 
 void ShootoutProposal::onStateLoop(PDN* pdn) {
-    shootout_->sync();
-    auto p = shootout_->getPhase();
+    shootoutManager->sync();
+    auto p = shootoutManager->getPhase();
     if (p == ShootoutManager::Phase::BRACKET_REVEAL) shouldGoToReveal_ = true;
     if (p == ShootoutManager::Phase::ABORTED) shouldGoToAborted_ = true;
     if (p == ShootoutManager::Phase::IDLE) shouldGoToIdle_ = true;
     bool loopBroken = chainDuelManager_ && !chainDuelManager_->isLoop();
-    if (loopBreakDebounce_.heldFor(loopBroken, kLoopBreakDebounceMs)) {
-        shootout_->resetToIdle();
-        shouldGoToIdle_ = true;
-    }
+    if (tickAbortGuard(loopBroken)) shouldGoToIdle_ = true;
 }
 
 void ShootoutProposal::onStateDismounted(PDN* pdn) {
@@ -42,7 +39,7 @@ void ShootoutProposal::onStateDismounted(PDN* pdn) {
     shouldGoToReveal_ = false;
     shouldGoToIdle_ = false;
     shouldGoToAborted_ = false;
-    loopBreakDebounce_.reset();
+    resetAbortGuard();
 }
 
 bool ShootoutProposal::transitionToBracketReveal() { return shouldGoToReveal_; }

--- a/src/pdn/game/quickdraw.cpp
+++ b/src/pdn/game/quickdraw.cpp
@@ -394,16 +394,13 @@ void Quickdraw::populateStateMap() {
             std::bind(&DuelCountdown::shallWeBattle, duelCountdown),
             duel));
 
-    {
-        ShootoutManager* shMgr = shootoutManager_;
-        duelCountdown->addTransition(
-            new StateTransition(
-                [duelCountdown, shMgr]() {
-                    if (shMgr && shMgr->active()) return false;
-                    return duelCountdown->disconnectedBackToIdle();
-                },
-                idle));
-    }
+    duelCountdown->addTransition(
+        new StateTransition(
+            [duelCountdown]() {
+                return duelCountdown->disconnectedBackToIdle(
+                    [duelCountdown] { return duelCountdown->isPersistentlyDisconnected(); });
+            },
+            idle));
 
     duel->addTransition(
         new StateTransition(
@@ -430,32 +427,26 @@ void Quickdraw::populateStateMap() {
             std::bind(&Duel::transitionToDuelPushed, duel),
             duelPushed));
 
-    {
-        ShootoutManager* shMgr = shootoutManager_;
-        duelPushed->addTransition(
-            new StateTransition(
-                [duelPushed, shMgr]() {
-                    if (shMgr && shMgr->active()) return false;
-                    return duelPushed->disconnectedBackToIdle();
-                },
-                idle));
-    }
+    duelPushed->addTransition(
+        new StateTransition(
+            [duelPushed]() {
+                return duelPushed->disconnectedBackToIdle(
+                    [duelPushed] { return duelPushed->isPersistentlyDisconnected(); });
+            },
+            idle));
 
     duelPushed->addTransition(
         new StateTransition(
             std::bind(&DuelPushed::transitionToDuelResult, duelPushed),
             duelResult));
 
-    {
-        ShootoutManager* shMgr = shootoutManager_;
-        duelReceivedResult->addTransition(
-            new StateTransition(
-                [duelReceivedResult, shMgr]() {
-                    if (shMgr && shMgr->active()) return false;
-                    return duelReceivedResult->disconnectedBackToIdle();
-                },
-                idle));
-    }
+    duelReceivedResult->addTransition(
+        new StateTransition(
+            [duelReceivedResult]() {
+                return duelReceivedResult->disconnectedBackToIdle(
+                    [duelReceivedResult] { return duelReceivedResult->isPersistentlyDisconnected(); });
+            },
+            idle));
 
     duelReceivedResult->addTransition(
         new StateTransition(

--- a/src/pdn/game/shootout-aware-state.hpp
+++ b/src/pdn/game/shootout-aware-state.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <functional>
+
+#include "utils/debounced-condition.hpp"
+#include "game/shootout-manager.hpp"
+
+/// Shared shootout-abort/idle policy mixed into game states that must
+/// coordinate with a live tournament. States compose this alongside
+/// ConnectState<PDN> (or TypedState<PDN>) so the debounce window and the two
+/// policy predicates live in one place instead of being copy-pasted across the
+/// duel and shootout states. Non-owning: holds only a borrowed ShootoutManager.
+class ShootoutAwareState {
+public:
+    /// Ring-break debounce window. A cable nudge flickers the loop state for a
+    /// tick or two on real hardware; act only once the break has settled.
+    static constexpr unsigned long kLoopBreakDebounceMs = 500;
+
+    explicit ShootoutAwareState(ShootoutManager* shootoutManager)
+        : shootoutManager(shootoutManager) {}
+
+    /// Idle-return is suppressed while a tournament is live: a mid-tournament
+    /// cable wiggle must not bail a duelist to Idle; the shootout's own
+    /// PEER_LOST/ABORT teardown owns that path. The persistence check is passed
+    /// as a predicate and only sampled when no tournament is active: sampling it
+    /// advances the caller's disconnect debounce, and doing so mid-shootout
+    /// would let a duelist bail to Idle the instant the shootout ends instead of
+    /// after a fresh window.
+    bool disconnectedBackToIdle(const std::function<bool()>& isPersistentlyDisconnected) {
+        if (isShootoutActive()) return false;
+        return isPersistentlyDisconnected();
+    }
+
+    /// Debounced ring-open guard. Once the ring has stayed open for the full
+    /// window, drop the tournament back to IDLE. Returns true on the tick the
+    /// guard fires so the caller can raise its own idle-transition flag.
+    bool tickAbortGuard(bool ringSettledOpen) {
+        if (!debounce.heldFor(ringSettledOpen, kLoopBreakDebounceMs)) return false;
+        shootoutManager->resetToIdle();
+        return true;
+    }
+
+    void resetAbortGuard() { debounce.reset(); }
+
+protected:
+    bool isShootoutActive() const {
+        return shootoutManager && shootoutManager->active();
+    }
+
+    ShootoutManager* shootoutManager = nullptr;
+
+private:
+    DebouncedCondition debounce;
+};

--- a/test/test_core/quickdraw-tests.hpp
+++ b/test/test_core/quickdraw-tests.hpp
@@ -1525,19 +1525,19 @@ inline void countdownDebouncesTransientDisconnect(StateCleanupTests* suite) {
     // Single-tick blip: should be absorbed by the debounce.
     suite->device.fakeRemoteDeviceCoordinator.setPortStatus(
         SerialIdentifier::OUTPUT_JACK, PortStatus::DISCONNECTED);
-    EXPECT_FALSE(countdown.disconnectedBackToIdle());
+    EXPECT_FALSE(countdown.disconnectedBackToIdle([&] { return countdown.isPersistentlyDisconnected(); }));
 
     // Recovery within the window clears the timer.
     suite->device.fakeRemoteDeviceCoordinator.setPortStatus(
         SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
-    EXPECT_FALSE(countdown.disconnectedBackToIdle());
+    EXPECT_FALSE(countdown.disconnectedBackToIdle([&] { return countdown.isPersistentlyDisconnected(); }));
 
     // Persistent loss past the debounce window: now the abort fires.
     suite->device.fakeRemoteDeviceCoordinator.setPortStatus(
         SerialIdentifier::OUTPUT_JACK, PortStatus::DISCONNECTED);
-    EXPECT_FALSE(countdown.disconnectedBackToIdle());  // start debounce
+    EXPECT_FALSE(countdown.disconnectedBackToIdle([&] { return countdown.isPersistentlyDisconnected(); }));  // start debounce
     suite->fakeClock->advance(2000);
-    EXPECT_TRUE(countdown.disconnectedBackToIdle());
+    EXPECT_TRUE(countdown.disconnectedBackToIdle([&] { return countdown.isPersistentlyDisconnected(); }));
 }
 
 // Same debounce contract on DuelPushed (between BATTLE press and result
@@ -1550,17 +1550,17 @@ inline void duelPushedDebouncesTransientDisconnect(StateCleanupTests* suite) {
 
     suite->device.fakeRemoteDeviceCoordinator.setPortStatus(
         SerialIdentifier::OUTPUT_JACK, PortStatus::DISCONNECTED);
-    EXPECT_FALSE(pushed.disconnectedBackToIdle());
+    EXPECT_FALSE(pushed.disconnectedBackToIdle([&] { return pushed.isPersistentlyDisconnected(); }));
 
     suite->device.fakeRemoteDeviceCoordinator.setPortStatus(
         SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
-    EXPECT_FALSE(pushed.disconnectedBackToIdle());
+    EXPECT_FALSE(pushed.disconnectedBackToIdle([&] { return pushed.isPersistentlyDisconnected(); }));
 
     suite->device.fakeRemoteDeviceCoordinator.setPortStatus(
         SerialIdentifier::OUTPUT_JACK, PortStatus::DISCONNECTED);
-    EXPECT_FALSE(pushed.disconnectedBackToIdle());
+    EXPECT_FALSE(pushed.disconnectedBackToIdle([&] { return pushed.isPersistentlyDisconnected(); }));
     suite->fakeClock->advance(2000);
-    EXPECT_TRUE(pushed.disconnectedBackToIdle());
+    EXPECT_TRUE(pushed.disconnectedBackToIdle([&] { return pushed.isPersistentlyDisconnected(); }));
 }
 
 // Same debounce contract on DuelReceivedResult.
@@ -1571,17 +1571,53 @@ inline void duelReceivedResultDebouncesTransientDisconnect(StateCleanupTests* su
 
     suite->device.fakeRemoteDeviceCoordinator.setPortStatus(
         SerialIdentifier::OUTPUT_JACK, PortStatus::DISCONNECTED);
-    EXPECT_FALSE(received.disconnectedBackToIdle());
+    EXPECT_FALSE(received.disconnectedBackToIdle([&] { return received.isPersistentlyDisconnected(); }));
 
     suite->device.fakeRemoteDeviceCoordinator.setPortStatus(
         SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
-    EXPECT_FALSE(received.disconnectedBackToIdle());
+    EXPECT_FALSE(received.disconnectedBackToIdle([&] { return received.isPersistentlyDisconnected(); }));
 
     suite->device.fakeRemoteDeviceCoordinator.setPortStatus(
         SerialIdentifier::OUTPUT_JACK, PortStatus::DISCONNECTED);
-    EXPECT_FALSE(received.disconnectedBackToIdle());
+    EXPECT_FALSE(received.disconnectedBackToIdle([&] { return received.isPersistentlyDisconnected(); }));
     suite->fakeClock->advance(2000);
-    EXPECT_TRUE(received.disconnectedBackToIdle());
+    EXPECT_TRUE(received.disconnectedBackToIdle([&] { return received.isPersistentlyDisconnected(); }));
+}
+
+// Regression: while a shootout is live, disconnectedBackToIdle must both
+// suppress the idle-return and leave the disconnect debounce frozen. Sampling
+// persistence advances that debounce, so sampling it mid-tournament aged the
+// timer and let a duelist snap to Idle the instant the shootout ended instead
+// of after a fresh window. The predicate must not be sampled while active.
+inline void countdownFreezesDisconnectDebounceDuringShootout(StateCleanupTests* suite) {
+    ShootoutManager shootout(suite->player, suite->device.wirelessManager,
+                             &suite->device.fakeRemoteDeviceCoordinator,
+                             suite->chainDuelManager);
+    shootout.startProposal();
+    ASSERT_TRUE(shootout.active());
+    suite->ctx.shootoutManager = &shootout;
+
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(
+        SerialIdentifier::OUTPUT_JACK, PortStatus::CONNECTED);
+    DuelCountdown countdown(suite->ctx);
+
+    // Persistent loss during the tournament: suppressed, and the debounce must
+    // not age even as wall-clock time passes.
+    suite->device.fakeRemoteDeviceCoordinator.setPortStatus(
+        SerialIdentifier::OUTPUT_JACK, PortStatus::DISCONNECTED);
+    EXPECT_FALSE(countdown.disconnectedBackToIdle([&] { return countdown.isPersistentlyDisconnected(); }));
+    suite->fakeClock->advance(2000);
+    EXPECT_FALSE(countdown.disconnectedBackToIdle([&] { return countdown.isPersistentlyDisconnected(); }));
+
+    // Tournament ends. A frozen debounce means one tick does not bail; a fresh
+    // full window is still required.
+    shootout.resetToIdle();
+    ASSERT_FALSE(shootout.active());
+    EXPECT_FALSE(countdown.disconnectedBackToIdle([&] { return countdown.isPersistentlyDisconnected(); }));
+    suite->fakeClock->advance(2000);
+    EXPECT_TRUE(countdown.disconnectedBackToIdle([&] { return countdown.isPersistentlyDisconnected(); }));
+
+    suite->ctx.shootoutManager = nullptr;
 }
 
 inline void receivedResultClearsMatchOnDisconnect(StateCleanupTests* suite) {

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1043,6 +1043,10 @@ TEST_F(StateCleanupTests, duelReceivedResultDebouncesTransientDisconnect) {
     duelReceivedResultDebouncesTransientDisconnect(this);
 }
 
+TEST_F(StateCleanupTests, countdownFreezesDisconnectDebounceDuringShootout) {
+    countdownFreezesDisconnectDebounceDuringShootout(this);
+}
+
 // ============================================
 // QUICKDRAW STATE TESTS - CONNECTION SUCCESSFUL
 // ============================================


### PR DESCRIPTION
Closes #164. Collapses the shootout-abort / idle-return cross-cut into a `ShootoutAwareState` mixin instead of duplicating the policy across the duel and shootout states.

**Divergence from the issue text — please read.** Issue #164 was written against the reliable-duel-delivery fork, which had a standalone `LoopBreakAbort` class and a `tickAbortGuard` that called `abortTournament()`. comms-rewrite has neither, so this PR keeps the proven comms-rewrite behavior rather than the issue's literal steps:

- There is no `LoopBreakAbort` to delete here.
- The 6 `phaseIsAborted -> ShootoutAborted` edges in `populateStateMap` stay: on comms-rewrite they route *remote* aborts (peer-loss / `onAbortReceived`) to the aborted screen, so they are load-bearing, not the manual cross-cut the issue describes.
- `tickAbortGuard` preserves `resetToIdle` -> IDLE (pinned by `shootoutProposalDebouncesTransientLoopBreak` and `shootoutBracketRevealDebouncesTransientLoopBreak`, which assert IDLE, not ABORTED); `abortTournament` stays private.

**Where to look / what's fragile.** `disconnectedBackToIdle` takes the persistence check as a predicate and samples it only when no tournament is active. That's deliberate: sampling persistence advances the caller's disconnect debounce, so sampling it mid-shootout would age the timer and let a duelist snap to Idle the instant the shootout ends instead of after a fresh 500ms window. `countdownFreezesDisconnectDebounceDuringShootout` pins this — it fails if the predicate is sampled eagerly.

Native suite 300/300. Game-layer only; no driver code touched.
