### PR TITLE
rdc: device chain state machine, head inheritance, ring detection

### DIFF
--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -52,7 +52,13 @@ class HelloIdleState : public State {
 public:
     explicit HelloIdleState(HelloLinkContext* context) : State(HELLO_LINK_IDLE), context(context) {}
 
-    void onStateMounted(Device*) override { transitionToConnectingState = false; }
+    void onStateMounted(Device*) override {
+        transitionToConnectingState = false;
+        // Entering Idle means the link is down (init, silent-link/context timeout, or
+        // a peer swap): drop any half-read frame so the next device's bytes can't
+        // merge into a stale partial left by the peer that just left.
+        if (context->resetParser) context->resetParser();
+    }
 
     void arm() { transitionToConnectingState = true; }
     bool transitionToConnecting() { return transitionToConnectingState; }
@@ -104,12 +110,10 @@ public:
         if (context->onJackChange) context->onJackChange(context->jack, true);
     }
 
-    // Leaving Connected means the link died: fire the disconnect and reset the
-    // parser so a half-read frame from the dying peer cannot merge into the next
-    // device that plugs in.
+    // Leaving Connected means the link died: fire the disconnect. The parser reset
+    // for a dropped link lives in HelloIdleState (every teardown enters Idle).
     void onStateDismounted(Device*) override {
         if (context->onJackChange) context->onJackChange(context->jack, false);
-        if (context->resetParser) context->resetParser();
     }
 
     bool transitionToIdle() { return context->sinceHello() > context->silentLinkMs; }
@@ -163,6 +167,20 @@ public:
     int currentStateId() const {
         return currentState ? currentState->getStateId() : HELLO_LINK_IDLE;
     }
+
+    // True when a live (non-Idle) link hears a HELLO from a MAC other than the
+    // peer it is tracking: the peer was physically swapped before the silent-link
+    // watchdog could fire.
+    bool tracksDifferentPeer(const uint8_t* source) const {
+        return currentState && currentState->getStateId() != HELLO_LINK_IDLE &&
+               memcmp(context.peerMac.data(), source, 6) != 0;
+    }
+
+    // Tear the link down to Idle immediately: dismounts the live state (so leaving
+    // Connected fires the disconnect + parser reset) then mounts Idle. Used on a
+    // peer swap so the new peer opens a fresh link within the same HELLO, keeping
+    // the teardown-before-readopt order that ring/head clearing depends on.
+    void forceIdle() { skipToState(nullptr, 0); }
 
 private:
     HelloLinkContext context;

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -50,8 +50,10 @@ struct HelloLinkContext {
 
 class HelloIdleState : public State {
 public:
+    /// Binds the shared per-jack context; the machine owns the state.
     explicit HelloIdleState(HelloLinkContext* context) : State(HELLO_LINK_IDLE), context(context) {}
 
+    /// Idle mount = link down: resets the parser and releases the tracked peer.
     void onStateMounted(Device*) override {
         transitionToConnectingState = false;
         // Entering Idle means the link is down (init, silent-link/context timeout, or

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -33,6 +33,7 @@ struct HelloLinkContext {
     std::function<void(SerialIdentifier)> onContextRequest;   // OUT jack only
     std::function<void(SerialIdentifier, bool)> onJackChange;  // connect / disconnect
     std::function<void()> resetParser;                         // on link death
+    std::function<void()> onLinkDown;                          // fires on every Idle mount
 
     unsigned long silentLinkMs = 100;
     unsigned long contextTimeoutMs = 500;
@@ -56,8 +57,10 @@ public:
         transitionToConnectingState = false;
         // Entering Idle means the link is down (init, silent-link/context timeout, or
         // a peer swap): drop any half-read frame so the next device's bytes can't
-        // merge into a stale partial left by the peer that just left.
+        // merge into a stale partial left by the peer that just left, and let the
+        // owner tear down any chain state hanging off the dead link.
         if (context->resetParser) context->resetParser();
+        if (context->onLinkDown) context->onLinkDown();
     }
 
     void arm() { transitionToConnectingState = true; }

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -152,6 +152,14 @@ public:
     // A HELLO stamps liveness on every state; it only opens a new link while Idle.
     // The self-echo / all-zero reject happens upstream in the RDC (it owns selfMac).
     void onHelloReceived(const HelloPayload& hello) {
+        // A live link hearing a different source MAC means the peer was swapped
+        // before the silent-link watchdog fired. Tear down to Idle first — its
+        // mount resets the parser and fires onLinkDown — so the old link's chain
+        // state is gone before this same HELLO opens the fresh link below.
+        if (currentState && currentState->getStateId() != HELLO_LINK_IDLE &&
+            memcmp(context.peerMac.data(), hello.source, 6) != 0) {
+            skipToState(nullptr, 0);
+        }
         context.lastHelloMs = context.nowMs();
         memcpy(context.peerMac.data(), hello.source, 6);
         if (currentState && currentState->getStateId() == HELLO_LINK_IDLE) {
@@ -170,20 +178,6 @@ public:
     int currentStateId() const {
         return currentState ? currentState->getStateId() : HELLO_LINK_IDLE;
     }
-
-    // True when a live (non-Idle) link hears a HELLO from a MAC other than the
-    // peer it is tracking: the peer was physically swapped before the silent-link
-    // watchdog could fire.
-    bool tracksDifferentPeer(const uint8_t* source) const {
-        return currentState && currentState->getStateId() != HELLO_LINK_IDLE &&
-               memcmp(context.peerMac.data(), source, 6) != 0;
-    }
-
-    // Tear the link down to Idle immediately: dismounts the live state (leaving
-    // Connected fires the disconnect) then mounts Idle, whose onStateMounted resets
-    // the parser. Used on a peer swap so the new peer opens a fresh link within the
-    // same HELLO, keeping the teardown-before-readopt order ring/head clearing needs.
-    void forceIdle() { skipToState(nullptr, 0); }
 
 private:
     HelloLinkContext context;

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -32,7 +32,6 @@ struct HelloLinkContext {
     std::function<unsigned long()> nowMs;
     std::function<void(SerialIdentifier)> onContextRequest;   // OUT jack only
     std::function<void(SerialIdentifier, bool)> onJackChange;  // connect / disconnect
-    std::function<void()> resetParser;                         // on link death
     std::function<void()> onLinkDown;                          // fires on every Idle mount
 
     unsigned long silentLinkMs = 100;
@@ -56,10 +55,9 @@ public:
     void onStateMounted(Device*) override {
         transitionToConnectingState = false;
         // Entering Idle means the link is down (init, silent-link/context timeout, or
-        // a peer swap): drop any half-read frame so the next device's bytes can't
-        // merge into a stale partial left by the peer that just left, and let the
-        // owner tear down any chain state hanging off the dead link.
-        if (context->resetParser) context->resetParser();
+        // a peer swap): the owner drops any half-read frame so the next device's
+        // bytes can't merge into a stale partial left by the peer that just left,
+        // and tears down any chain state hanging off the dead link.
         if (context->onLinkDown) context->onLinkDown();
     }
 
@@ -113,8 +111,8 @@ public:
         if (context->onJackChange) context->onJackChange(context->jack, true);
     }
 
-    // Leaving Connected means the link died: fire the disconnect. The parser reset
-    // for a dropped link lives in HelloIdleState (every teardown enters Idle).
+    // Leaving Connected means the link died: fire the disconnect. Teardown itself
+    // (onLinkDown) lives in HelloIdleState — every link-death path enters Idle.
     void onStateDismounted(Device*) override {
         if (context->onJackChange) context->onJackChange(context->jack, false);
     }
@@ -154,8 +152,8 @@ public:
     void onHelloReceived(const HelloPayload& hello) {
         // A live link hearing a different source MAC means the peer was swapped
         // before the silent-link watchdog fired. Tear down to Idle first — its
-        // mount resets the parser and fires onLinkDown — so the old link's chain
-        // state is gone before this same HELLO opens the fresh link below.
+        // mount fires onLinkDown — so the old link's parser and chain state are
+        // gone before this same HELLO opens the fresh link below.
         if (currentState && currentState->getStateId() != HELLO_LINK_IDLE &&
             memcmp(context.peerMac.data(), hello.source, 6) != 0) {
             skipToState(nullptr, 0);

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -176,10 +176,10 @@ public:
                memcmp(context.peerMac.data(), source, 6) != 0;
     }
 
-    // Tear the link down to Idle immediately: dismounts the live state (so leaving
-    // Connected fires the disconnect + parser reset) then mounts Idle. Used on a
-    // peer swap so the new peer opens a fresh link within the same HELLO, keeping
-    // the teardown-before-readopt order that ring/head clearing depends on.
+    // Tear the link down to Idle immediately: dismounts the live state (leaving
+    // Connected fires the disconnect) then mounts Idle, whose onStateMounted resets
+    // the parser. Used on a peer swap so the new peer opens a fresh link within the
+    // same HELLO, keeping the teardown-before-readopt order ring/head clearing needs.
     void forceIdle() { skipToState(nullptr, 0); }
 
 private:

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -308,11 +308,11 @@ private:
         SerialFrameParser parser;  // non-copyable; default-constructed in place
         HelloLinkMachine* machine = nullptr;  // per-jack link SM; owned, deleted in dtor
     };
-    std::array<JackHelloLink, kNumPorts> helloByPort_;
+    std::array<JackHelloLink, kNumPorts> helloByPort;
     bool helloConnectivityEnabled = false;
     bool externalConnectivityTask = false;
     ContextRequestCallback contextRequestCallback;
-    std::array<uint8_t, 6> selfMac_{};
+    std::array<uint8_t, 6> selfMac{};
     DeviceType selfDeviceType = DeviceType::UNKNOWN;
 #ifndef NATIVE_BUILD
     TaskHandle_t connectivityTaskHandle = nullptr;

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -134,6 +134,11 @@ public:
     static constexpr unsigned long HELLO_SILENT_LINK_MS = 100;
     // A link stuck mid-context-exchange past this falls back to IDLE (#157).
     static constexpr unsigned long CONTEXT_EXCHANGE_TIMEOUT_MS = 500;
+    // A ring latch is evidence-based: it survives a higher-MAC head claim only
+    // while this device's own MAC keeps returning on INPUT within this window.
+    // Sized above the worst-case claim-propagation transient (~18 hops at the
+    // 20ms HELLO cadence).
+    static constexpr unsigned long RING_EVIDENCE_TIMEOUT_MS = 500;
 
     enum class HelloLinkState { IDLE,
                                 CONNECTING,
@@ -334,6 +339,9 @@ private:
     // Latched when this structural head sees its own MAC return on the INPUT jack;
     // cleared when any ring link drops. Dominates getChainRole().
     bool ringLatched = false;
+    // Last time the own-MAC head returned on INPUT while latched (seeded at
+    // closure): the ring-latch evidence stamp checked against RING_EVIDENCE_TIMEOUT_MS.
+    unsigned long lastSelfHeadReturnMs = 0;
     // Stable storage backing getHeadMac()'s returned pointer.
     mutable std::array<uint8_t, 6> headMacScratch{};
     // Last role reported to chainRoleChangeCallback, for edge-triggered firing.

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -107,12 +107,12 @@ public:
     // machines land (#155-#159): they return the standalone defaults so the
     // game layer can compile and wire against the final shape now. ----
 
-    /// This device's chain role. STUB: always STANDALONE.
-    virtual ChainRole getChainRole() const { return ChainRole::STANDALONE; }
+    /// This device's chain role, derived from jack presence plus the ring latch.
+    virtual ChainRole getChainRole() const;
 
     /// The chain head's MAC, or nullptr when this device is the head or
-    /// standalone. STUB: always nullptr.
-    virtual const uint8_t* getHeadMac() const { return nullptr; }
+    /// standalone.
+    virtual const uint8_t* getHeadMac() const;
 
     /// Head-only chain member roster; empty for a child or standalone device.
     /// STUB: always empty.
@@ -323,4 +323,26 @@ private:
     void onHelloReceived(SerialIdentifier jack, const HelloPayload& hello);
     PortStatus mapHelloLinkToStatus(SerialIdentifier port) const;
     static unsigned long nowMs();
+
+    // ---- Device-level chain state machine (#156) ----
+    // headMac (48 bits) + a confirmed bit packed into one atomic: the emit task
+    // reads it while the main loop writes it. confirmed is wired but always 0
+    // until #157's context exchange populates it.
+    static constexpr uint64_t HEAD_MAC_MASK = 0xFFFFFFFFFFFFULL;
+    static constexpr uint64_t CONFIRMED_BIT = 1ULL << 48;
+    std::atomic<uint64_t> chainHeadState{0};
+    // Latched when this structural head sees its own MAC return on the INPUT jack;
+    // cleared when any ring link drops. Dominates getChainRole().
+    bool ringLatched = false;
+    // Stable storage backing getHeadMac()'s returned pointer.
+    mutable std::array<uint8_t, 6> headMacScratch{};
+    // Last role reported to chainRoleChangeCallback, for edge-triggered firing.
+    ChainRole lastChainRole = ChainRole::STANDALONE;
+
+    static uint64_t packHead(const uint8_t* mac, bool confirmed);
+    static void unpackMac(uint64_t value, uint8_t* out);
+    std::array<uint8_t, 6> effectiveHead() const;
+    void applyUpstreamHead(const HelloPayload& hello);
+    void onLinkLost(SerialIdentifier port);
+    void maybeFireChainRoleChange();
 };

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -341,7 +341,6 @@ private:
 
     static uint64_t packHead(const uint8_t* mac, bool confirmed);
     static void unpackMac(uint64_t value, uint8_t* out);
-    std::array<uint8_t, 6> effectiveHead() const;
     void applyUpstreamHead(const HelloPayload& hello);
     void onLinkLost(SerialIdentifier port);
     void maybeFireChainRoleChange();

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -103,22 +103,24 @@ public:
     /// Reachable via either jack (direct peer or daisy-chained).
     virtual bool canReachPeer(const uint8_t* mac) const;
 
-    // ---- Chain-level surface (#154). Stubs until the connection-state
-    // machines land (#155-#159): they return the standalone defaults so the
-    // game layer can compile and wire against the final shape now. ----
+    // ---- Chain-level surface (#154) ----
 
     /// This device's chain role, derived from jack presence plus the ring latch.
     virtual ChainRole getChainRole() const;
 
     /// The chain head's MAC, or nullptr when this device is the head or
-    /// standalone.
+    /// standalone. Also nullptr for a CHILD during re-convergence: after an
+    /// OUTPUT-side ring break the latch clears while INPUT stays connected, and
+    /// no replacement head has propagated yet.
     virtual const uint8_t* getHeadMac() const;
 
     /// Head-only chain member roster; empty for a child or standalone device.
     /// STUB: always empty.
     virtual std::vector<std::array<uint8_t, 6>> getChainMembers() const { return {}; }
 
-    /// Registers the per-jack connect/disconnect observer.
+    /// Registers the per-jack connect/disconnect observer. The disconnect fires
+    /// before chain-state teardown, so handlers must not read chain state here;
+    /// consistent chain facts arrive via setOnChainRoleChange.
     void setOnJackChange(JackChangeCallback callback) {
         jackChangeCallback = std::move(callback);
     }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -766,6 +766,14 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     const bool peerHeadIsSelf =
         memcmp(peerEffectiveHead.data(), selfMac_.data(), 6) == 0;
 
+    // A latched ring hears its own seeded head return on INPUT every cycle. When
+    // INPUT instead delivers a different head, the loop no longer closes through
+    // us — an upstream link broke, possibly one not adjacent to this device — so
+    // open the ring and fall through to adopt the new upstream head.
+    if (ringLatched && !peerHeadIsSelf) {
+        ringLatched = false;
+    }
+
     // Ring: a structural head sees its own MAC return on its INPUT jack, so the
     // head it seeded traveled the whole loop back. Because inheritance carries
     // that MAC unchallenged, this latches for ANY head regardless of MAC value.
@@ -787,9 +795,12 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
 }
 
 void RemoteDeviceCoordinator::onLinkLost(SerialIdentifier port) {
-    // Any ring-link drop opens the ring for this device: a closed loop is broken
-    // whether the break is upstream (INPUT) or downstream (OUTPUT). Clearing this
-    // only on INPUT drop left an OUTPUT-side break reporting RING forever.
+    // The FDN secondary input jack is a symbol link, not part of the INPUT/OUTPUT
+    // chain, so its teardown must not open the ring or clear the inherited head.
+    if (port == SerialIdentifier::INPUT_JACK_SECONDARY) return;
+
+    // A ring closes through both this device's chain links; losing either the
+    // upstream (INPUT) or downstream (OUTPUT) one breaks the loop, so open the ring.
     ringLatched = false;
 
     // Only the upstream (INPUT) peer supplies our inherited head, so only its loss

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -774,10 +774,13 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
         ringLatched = false;
     }
 
-    // Ring: a structural head sees its own MAC return on its INPUT jack, so the
-    // head it seeded traveled the whole loop back. Because inheritance carries
-    // that MAC unchallenged, this latches for ANY head regardless of MAC value.
-    if (!ringLatched && peerHeadIsSelf && getChainRole() == ChainRole::HEAD) {
+    // Ring: this device's own MAC returns on its INPUT jack, so the head it seeded
+    // traveled the whole loop back. Gate on OUTPUT being connected (a downstream
+    // exists), NOT on role==HEAD — two already-connected sub-chains merging into a
+    // ring deliver our head back on an INPUT that is already CONNECTED, where
+    // role==HEAD (which demands INPUT be un-connected) would miss the closure.
+    if (!ringLatched && peerHeadIsSelf &&
+        getHelloLinkState(SerialIdentifier::OUTPUT_JACK) == HelloLinkState::CONNECTED) {
         ringLatched = true;
         if (ringClosedCallback) ringClosedCallback();
         return;

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -782,6 +782,9 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     if (!ringLatched && peerHeadIsSelf &&
         getHelloLinkState(SerialIdentifier::OUTPUT_JACK) == HelloLinkState::CONNECTED) {
         ringLatched = true;
+        // Our own MAC came back, so we ARE the head: drop any head adopted while the
+        // ring was forming, or we would sit in RING advertising a stale foreign head.
+        chainHeadState.store(0);
         if (ringClosedCallback) ringClosedCallback();
         return;
     }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -60,8 +60,8 @@ RemoteDeviceCoordinator::~RemoteDeviceCoordinator() {
         for (SerialIdentifier port : HELLO_JACKS) {
             HWSerialWrapper* hw = jackWrapper(port);
             if (hw != nullptr) hw->setByteCallback(nullptr);
-            delete helloByPort_[portIndex(port)].machine;
-            helloByPort_[portIndex(port)].machine = nullptr;
+            delete helloByPort[portIndex(port)].machine;
+            helloByPort[portIndex(port)].machine = nullptr;
         }
     }
     delete inputPortHandshake;
@@ -209,7 +209,7 @@ void RemoteDeviceCoordinator::sync(Device* PDN) {
         // chain-announcement machinery below rides handshake CONNECTED state, so
         // it stays dormant here too until HELLO drives its own peer identity (#157).
         for (SerialIdentifier port : HELLO_JACKS) {
-            HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+            HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
             if (machine) machine->onStateLoop(PDN);
         }
         maybeFireChainRoleChange();
@@ -577,18 +577,18 @@ void RemoteDeviceCoordinator::enableHelloConnectivity() {
 
     if (wirelessManager_ != nullptr) {
         const uint8_t* mac = wirelessManager_->getMacAddress();
-        if (mac != nullptr) memcpy(selfMac_.data(), mac, 6);
+        if (mac != nullptr) memcpy(selfMac.data(), mac, 6);
     }
 
     for (SerialIdentifier port : HELLO_JACKS) {
         HWSerialWrapper* hw = jackWrapper(port);
         if (hw == nullptr) continue;
-        JackHelloLink& link = helloByPort_[portIndex(port)];
+        JackHelloLink& link = helloByPort[portIndex(port)];
         link.parser.setHelloFrameHandler(
             [this, port](const HelloPayload& hello) { onHelloReceived(port, hello); });
         // exec() runs on the main loop, so the parser is fed single-threaded.
         hw->setByteCallback([this, port](uint8_t b) {
-            helloByPort_[portIndex(port)].parser.feed(&b, 1);
+            helloByPort[portIndex(port)].parser.feed(&b, 1);
         });
 
         HelloLinkContext context;
@@ -603,7 +603,7 @@ void RemoteDeviceCoordinator::enableHelloConnectivity() {
         // Every link-death path mounts Idle; the initial mount fires this too,
         // a no-op on zero state.
         context.onLinkDown = [this, port] {
-            helloByPort_[portIndex(port)].parser.requestReset();
+            helloByPort[portIndex(port)].parser.requestReset();
             onLinkLost(port);
         };
         context.silentLinkMs = HELLO_SILENT_LINK_MS;
@@ -624,7 +624,7 @@ void RemoteDeviceCoordinator::emitHello() {
     if (!helloConnectivityEnabled) return;
 
     HelloPayload hello{};
-    memcpy(hello.source, selfMac_.data(), 6);
+    memcpy(hello.source, selfMac.data(), 6);
     hello.deviceType = static_cast<uint8_t>(selfDeviceType);
     // Single atomic load: the main loop is the sole writer, so one snapshot of the
     // packed head/confirmed word is internally consistent. All-zero headMac means
@@ -649,9 +649,9 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
     // self-HELLO must never keep a dead cable "alive" or fake a peer. The RDC owns
     // selfMac, so this guard stays here rather than in the link SM.
     if (MacToUInt64(hello.source) == 0) return;
-    if (memcmp(hello.source, selfMac_.data(), 6) == 0) return;
+    if (memcmp(hello.source, selfMac.data(), 6) == 0) return;
 
-    HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
+    HelloLinkMachine* machine = helloByPort[portIndex(jack)].machine;
     if (machine) machine->onHelloReceived(hello);
 
     // Head inheritance + ring detection are directional: only the upstream (INPUT)
@@ -664,13 +664,13 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
 }
 
 void RemoteDeviceCoordinator::onContextExchangeComplete(SerialIdentifier jack) {
-    HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
+    HelloLinkMachine* machine = helloByPort[portIndex(jack)].machine;
     if (machine) machine->onContextExchangeComplete();
 }
 
 RemoteDeviceCoordinator::HelloLinkState
 RemoteDeviceCoordinator::getHelloLinkState(SerialIdentifier jack) const {
-    const HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
+    const HelloLinkMachine* machine = helloByPort[portIndex(jack)].machine;
     if (machine == nullptr) return HelloLinkState::IDLE;
     switch (machine->currentStateId()) {
         case HELLO_LINK_CONNECTED:  return HelloLinkState::CONNECTED;
@@ -680,7 +680,7 @@ RemoteDeviceCoordinator::getHelloLinkState(SerialIdentifier jack) const {
 }
 
 PortStatus RemoteDeviceCoordinator::mapHelloLinkToStatus(SerialIdentifier port) const {
-    const HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+    const HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
     if (machine == nullptr) return PortStatus::DISCONNECTED;
     switch (machine->currentStateId()) {
         case HELLO_LINK_CONNECTED:  return PortStatus::CONNECTED;
@@ -735,7 +735,7 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
         MacToUInt64(hello.headMac) != 0 ? hello.headMac : hello.source;
 
     const bool peerHeadIsSelf =
-        memcmp(peerEffectiveHead, selfMac_.data(), 6) == 0;
+        memcmp(peerEffectiveHead, selfMac.data(), 6) == 0;
 
     // A latched ring hears its own seeded head return on INPUT every cycle; that
     // return IS the evidence the loop still closes through us, so stamp it.
@@ -752,7 +752,7 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     // break it can no longer complete the loop, so the evidence times out and
     // the new head must be adopted.
     if (ringLatched && !peerHeadIsSelf) {
-        if (MacToUInt64(peerEffectiveHead) > MacToUInt64(selfMac_.data()) &&
+        if (MacToUInt64(peerEffectiveHead) > MacToUInt64(selfMac.data()) &&
             nowMs() - lastSelfHeadReturnMs <= RING_EVIDENCE_TIMEOUT_MS) {
             return;
         }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -766,11 +766,14 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     const bool peerHeadIsSelf =
         memcmp(peerEffectiveHead.data(), selfMac_.data(), 6) == 0;
 
-    // A latched ring hears its own seeded head return on INPUT every cycle. When
-    // INPUT instead delivers a different head, the loop no longer closes through
-    // us — an upstream link broke, possibly one not adjacent to this device — so
-    // open the ring and fall through to adopt the new upstream head.
+    // A latched ring hears its own seeded head return on INPUT every cycle. A
+    // different head arriving there is a head conflict: an upstream break, or a
+    // second latched head (symmetric 2-ring boot, two heads merging). Lower MAC
+    // wins (#144): stand down only for a lower head — a higher one self-corrects
+    // off our HELLO. Unlatching unconditionally lets two latched heads depose
+    // each other and re-latch in lockstep, re-firing ringClosed every cycle.
     if (ringLatched && !peerHeadIsSelf) {
+        if (MacToUInt64(peerEffectiveHead.data()) > MacToUInt64(selfMac_.data())) return;
         ringLatched = false;
     }
 

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -210,18 +210,7 @@ void RemoteDeviceCoordinator::sync(Device* PDN) {
         // it stays dormant here too until HELLO drives its own peer identity (#157).
         for (SerialIdentifier port : HELLO_JACKS) {
             HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
-            if (!machine) continue;
-            const int before = machine->currentStateId();
-            machine->onStateLoop(PDN);
-            // A link falling back to Idle (silent-link or context-exchange timeout)
-            // opens the ring and severs an inherited head. onLinkLost clears that
-            // chain state on the teardown edge; the machine's disconnect callback
-            // only fires from Connected, so a Connecting-side drop would otherwise
-            // leave a stale ring latched.
-            if (before != HELLO_LINK_IDLE &&
-                machine->currentStateId() == HELLO_LINK_IDLE) {
-                onLinkLost(port);
-            }
+            if (machine) machine->onStateLoop(PDN);
         }
         maybeFireChainRoleChange();
         return;
@@ -614,6 +603,11 @@ void RemoteDeviceCoordinator::enableHelloConnectivity() {
         context.resetParser = [this, port] {
             helloByPort_[portIndex(port)].parser.requestReset();
         };
+        // Idle is the single teardown point: every link-death path (silent link,
+        // context timeout, peer swap) mounts Idle, so the chain state hanging off
+        // the link — ring latch, inherited head — is cleared exactly there. The
+        // initial mount fires it too, a no-op on zero state.
+        context.onLinkDown = [this, port] { onLinkLost(port); };
         context.silentLinkMs = HELLO_SILENT_LINK_MS;
         context.contextTimeoutMs = CONTEXT_EXCHANGE_TIMEOUT_MS;
         link.machine = new HelloLinkMachine(std::move(context));
@@ -667,7 +661,6 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
         // peer opens a fresh link below; teardown must precede re-adoption.
         if (machine->tracksDifferentPeer(hello.source)) {
             machine->forceIdle();
-            onLinkLost(jack);
         }
         machine->onHelloReceived(hello);
     }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -728,17 +728,14 @@ const uint8_t* RemoteDeviceCoordinator::getHeadMac() const {
 
 void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     // The upstream peer's effective head: its advertised headMac if it has one,
-    // else its own MAC (meaning the peer is itself the head). No MAC comparison,
-    // no min-election — the head's MAC flows down the chain unchallenged.
-    std::array<uint8_t, 6> peerEffectiveHead{};
-    if (MacToUInt64(hello.headMac) != 0) {
-        memcpy(peerEffectiveHead.data(), hello.headMac, 6);
-    } else {
-        memcpy(peerEffectiveHead.data(), hello.source, 6);
-    }
+    // else its own MAC (meaning the peer is itself the head). Inheritance is not
+    // an election — the head's MAC flows down the chain unchallenged; MACs are
+    // compared only to break the latched-head conflict below.
+    const uint8_t* peerEffectiveHead =
+        MacToUInt64(hello.headMac) != 0 ? hello.headMac : hello.source;
 
     const bool peerHeadIsSelf =
-        memcmp(peerEffectiveHead.data(), selfMac_.data(), 6) == 0;
+        memcmp(peerEffectiveHead, selfMac_.data(), 6) == 0;
 
     // A latched ring hears its own seeded head return on INPUT every cycle; that
     // return IS the evidence the loop still closes through us, so stamp it.
@@ -755,7 +752,7 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     // break it can no longer complete the loop, so the evidence times out and
     // the new head must be adopted.
     if (ringLatched && !peerHeadIsSelf) {
-        if (MacToUInt64(peerEffectiveHead.data()) > MacToUInt64(selfMac_.data()) &&
+        if (MacToUInt64(peerEffectiveHead) > MacToUInt64(selfMac_.data()) &&
             nowMs() - lastSelfHeadReturnMs <= RING_EVIDENCE_TIMEOUT_MS) {
             return;
         }
@@ -784,11 +781,11 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     // encodes as an absent head_mac); the ring case above already handled it.
     if (peerHeadIsSelf) return;
 
-    if ((chainHeadState.load() & HEAD_MAC_MASK) == MacToUInt64(peerEffectiveHead.data())) return;
+    if ((chainHeadState.load() & HEAD_MAC_MASK) == MacToUInt64(peerEffectiveHead)) return;
 
     // Adopt the upstream head, dropping to confirmed=0 until re-confirmed under
     // it. The new head then propagates in our own HELLO.
-    chainHeadState.store(packHead(peerEffectiveHead.data(), false));
+    chainHeadState.store(packHead(peerEffectiveHead, false));
 }
 
 void RemoteDeviceCoordinator::onLinkLost(SerialIdentifier port) {

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -210,8 +210,20 @@ void RemoteDeviceCoordinator::sync(Device* PDN) {
         // it stays dormant here too until HELLO drives its own peer identity (#157).
         for (SerialIdentifier port : HELLO_JACKS) {
             HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
-            if (machine) machine->onStateLoop(PDN);
+            if (!machine) continue;
+            const int before = machine->currentStateId();
+            machine->onStateLoop(PDN);
+            // A link falling back to Idle (silent-link or context-exchange timeout)
+            // opens the ring and severs an inherited head. onLinkLost clears that
+            // chain state on the teardown edge; the machine's disconnect callback
+            // only fires from Connected, so a Connecting-side drop would otherwise
+            // leave a stale ring latched.
+            if (before != HELLO_LINK_IDLE &&
+                machine->currentStateId() == HELLO_LINK_IDLE) {
+                onLinkLost(port);
+            }
         }
+        maybeFireChainRoleChange();
         return;
     }
 
@@ -622,9 +634,13 @@ void RemoteDeviceCoordinator::emitHello() {
     HelloPayload hello{};
     memcpy(hello.source, selfMac_.data(), 6);
     hello.deviceType = static_cast<uint8_t>(selfDeviceType);
-    // headMac stays zero and confirmed stays 0 until the device chain SM (#156)
-    // learns the head and completes its context exchange.
-    hello.confirmed = 0;
+    // Single atomic load: the main loop is the sole writer, so one snapshot of the
+    // packed head/confirmed word is internally consistent. All-zero headMac means
+    // "I am the head/standalone". confirmed stays 0 until #157's context exchange.
+    const uint64_t head = chainHeadState.load();
+    const uint64_t mac48 = head & HEAD_MAC_MASK;
+    if (mac48 != 0) unpackMac(mac48, hello.headMac);
+    hello.confirmed = (head & CONFIRMED_BIT) != 0 ? 1 : 0;
 
     const std::vector<uint8_t> frame = encodeFramed(hello);
     for (SerialIdentifier port : HELLO_JACKS) {
@@ -644,7 +660,25 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
     if (memcmp(hello.source, selfMac_.data(), 6) == 0) return;
 
     HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
-    if (machine) machine->onHelloReceived(hello);
+    if (machine) {
+        // A live link hearing a different source MAC means the peer swapped before
+        // the silent-link watchdog fired. Tear the old link down now (opening a
+        // stale ring, clearing a head inherited from the vanished peer) so the new
+        // peer opens a fresh link below; teardown must precede re-adoption.
+        if (machine->tracksDifferentPeer(hello.source)) {
+            machine->forceIdle();
+            onLinkLost(jack);
+        }
+        machine->onHelloReceived(hello);
+    }
+
+    // Head inheritance + ring detection are directional: only the upstream (INPUT)
+    // jack drives them, so the head's MAC cascades downstream. The FDN secondary
+    // input jack is a symbol link and takes no part in the chain.
+    if (jack == SerialIdentifier::INPUT_JACK) {
+        applyUpstreamHead(hello);
+    }
+    maybeFireChainRoleChange();
 }
 
 void RemoteDeviceCoordinator::onContextExchangeComplete(SerialIdentifier jack) {
@@ -671,4 +705,106 @@ PortStatus RemoteDeviceCoordinator::mapHelloLinkToStatus(SerialIdentifier port) 
         case HELLO_LINK_CONNECTING: return PortStatus::CONNECTING;
         default:                    return PortStatus::DISCONNECTED;
     }
+}
+
+// ---- Device-level chain state machine (#156) ----
+
+uint64_t RemoteDeviceCoordinator::packHead(const uint8_t* mac, bool confirmed) {
+    uint64_t value = MacToUInt64(mac) & HEAD_MAC_MASK;
+    if (confirmed) value |= CONFIRMED_BIT;
+    return value;
+}
+
+void RemoteDeviceCoordinator::unpackMac(uint64_t value, uint8_t* out) {
+    for (int i = 5; i >= 0; --i) {
+        out[i] = static_cast<uint8_t>(value & 0xFF);
+        value >>= 8;
+    }
+}
+
+std::array<uint8_t, 6> RemoteDeviceCoordinator::effectiveHead() const {
+    const uint64_t mac48 = chainHeadState.load() & HEAD_MAC_MASK;
+    std::array<uint8_t, 6> out{};
+    // No inherited head means this device is its own head: advertise own MAC.
+    if (mac48 == 0) {
+        memcpy(out.data(), selfMac_.data(), 6);
+    } else {
+        unpackMac(mac48, out.data());
+    }
+    return out;
+}
+
+ChainRole RemoteDeviceCoordinator::getChainRole() const {
+    if (ringLatched) return ChainRole::RING;
+    if (getHelloLinkState(SerialIdentifier::INPUT_JACK) == HelloLinkState::CONNECTED) {
+        return ChainRole::CHILD;
+    }
+    if (getHelloLinkState(SerialIdentifier::OUTPUT_JACK) == HelloLinkState::CONNECTED) {
+        return ChainRole::HEAD;
+    }
+    return ChainRole::STANDALONE;
+}
+
+const uint8_t* RemoteDeviceCoordinator::getHeadMac() const {
+    const uint64_t mac48 = chainHeadState.load() & HEAD_MAC_MASK;
+    if (mac48 == 0) return nullptr;
+    unpackMac(mac48, headMacScratch.data());
+    return headMacScratch.data();
+}
+
+void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
+    // The upstream peer's effective head: its advertised headMac if it has one,
+    // else its own MAC (meaning the peer is itself the head). No MAC comparison,
+    // no min-election — the head's MAC flows down the chain unchallenged.
+    std::array<uint8_t, 6> peerEffectiveHead{};
+    if (MacToUInt64(hello.headMac) != 0) {
+        memcpy(peerEffectiveHead.data(), hello.headMac, 6);
+    } else {
+        memcpy(peerEffectiveHead.data(), hello.source, 6);
+    }
+
+    const bool peerHeadIsSelf =
+        memcmp(peerEffectiveHead.data(), selfMac_.data(), 6) == 0;
+
+    // Ring: a structural head sees its own MAC return on its INPUT jack, so the
+    // head it seeded traveled the whole loop back. Because inheritance carries
+    // that MAC unchallenged, this latches for ANY head regardless of MAC value.
+    if (!ringLatched && peerHeadIsSelf && getChainRole() == ChainRole::HEAD) {
+        ringLatched = true;
+        if (ringClosedCallback) ringClosedCallback();
+        return;
+    }
+
+    // A device never inherits its own MAC as a head (that is what "I am head"
+    // encodes as an absent head_mac); the ring case above already handled it.
+    if (peerHeadIsSelf) return;
+
+    if (memcmp(peerEffectiveHead.data(), effectiveHead().data(), 6) == 0) return;
+
+    // Adopt the upstream head, dropping to confirmed=0 until re-confirmed under
+    // it. The new head then propagates in our own HELLO.
+    chainHeadState.store(packHead(peerEffectiveHead.data(), false));
+}
+
+void RemoteDeviceCoordinator::onLinkLost(SerialIdentifier port) {
+    // Any ring-link drop opens the ring for this device: a closed loop is broken
+    // whether the break is upstream (INPUT) or downstream (OUTPUT). Clearing this
+    // only on INPUT drop left an OUTPUT-side break reporting RING forever.
+    ringLatched = false;
+
+    // Only the upstream (INPUT) peer supplies our inherited head, so only its loss
+    // severs the head supply and must clear the inherited head (the phantom-head
+    // bug), re-deriving the effective head to our own MAC. A downstream (OUTPUT)
+    // drop leaves the upstream head supply intact.
+    if (port == SerialIdentifier::INPUT_JACK &&
+        (chainHeadState.load() & HEAD_MAC_MASK) != 0) {
+        chainHeadState.store(0);
+    }
+}
+
+void RemoteDeviceCoordinator::maybeFireChainRoleChange() {
+    const ChainRole role = getChainRole();
+    if (role == lastChainRole) return;
+    lastChainRole = role;
+    if (chainRoleChangeCallback) chainRoleChangeCallback(role);
 }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -742,14 +742,25 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     const bool peerHeadIsSelf =
         memcmp(peerEffectiveHead.data(), selfMac_.data(), 6) == 0;
 
-    // A latched ring hears its own seeded head return on INPUT every cycle. A
-    // different head arriving there is a head conflict: an upstream break, or a
-    // second latched head (symmetric 2-ring boot, two heads merging). Lower MAC
-    // wins (#144): stand down only for a lower head — a higher one self-corrects
-    // off our HELLO. Unlatching unconditionally lets two latched heads depose
-    // each other and re-latch in lockstep, re-firing ringClosed every cycle.
+    // A latched ring hears its own seeded head return on INPUT every cycle; that
+    // return IS the evidence the loop still closes through us, so stamp it.
+    if (ringLatched && peerHeadIsSelf) lastSelfHeadReturnMs = nowMs();
+
+    // A different head on INPUT while latched is a head conflict: a second
+    // latched head (symmetric 2-ring boot, two heads merging) or a replacement
+    // head propagating hop-by-hop after a break elsewhere in the loop. Lower MAC
+    // wins (#144): stand down at once for a lower head — unlatching
+    // unconditionally lets two latched heads depose each other and re-latch in
+    // lockstep, re-firing ringClosed every cycle. For a higher head, hold the
+    // latch only while self-returns are fresh: in a merge transient our own
+    // claim keeps circulating and refreshing the stamp, but after a physical
+    // break it can no longer complete the loop, so the evidence times out and
+    // the new head must be adopted.
     if (ringLatched && !peerHeadIsSelf) {
-        if (MacToUInt64(peerEffectiveHead.data()) > MacToUInt64(selfMac_.data())) return;
+        if (MacToUInt64(peerEffectiveHead.data()) > MacToUInt64(selfMac_.data()) &&
+            nowMs() - lastSelfHeadReturnMs <= RING_EVIDENCE_TIMEOUT_MS) {
+            return;
+        }
         ringLatched = false;
     }
 
@@ -761,6 +772,9 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     if (!ringLatched && peerHeadIsSelf &&
         getHelloLinkState(SerialIdentifier::OUTPUT_JACK) == HelloLinkState::CONNECTED) {
         ringLatched = true;
+        // Seed the evidence stamp at closure so a break immediately after still
+        // has a valid baseline to time out from.
+        lastSelfHeadReturnMs = nowMs();
         // Our own MAC came back, so we ARE the head: drop any head adopted while the
         // ring was forming, or we would sit in RING advertising a stale foreign head.
         chainHeadState.store(0);

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -654,16 +654,7 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
     if (memcmp(hello.source, selfMac_.data(), 6) == 0) return;
 
     HelloLinkMachine* machine = helloByPort_[portIndex(jack)].machine;
-    if (machine) {
-        // A live link hearing a different source MAC means the peer swapped before
-        // the silent-link watchdog fired. Tear the old link down now (opening a
-        // stale ring, clearing a head inherited from the vanished peer) so the new
-        // peer opens a fresh link below; teardown must precede re-adoption.
-        if (machine->tracksDifferentPeer(hello.source)) {
-            machine->forceIdle();
-        }
-        machine->onHelloReceived(hello);
-    }
+    if (machine) machine->onHelloReceived(hello);
 
     // Head inheritance + ring detection are directional: only the upstream (INPUT)
     // jack drives them, so the head's MAC cascades downstream. The FDN secondary
@@ -715,18 +706,6 @@ void RemoteDeviceCoordinator::unpackMac(uint64_t value, uint8_t* out) {
     }
 }
 
-std::array<uint8_t, 6> RemoteDeviceCoordinator::effectiveHead() const {
-    const uint64_t mac48 = chainHeadState.load() & HEAD_MAC_MASK;
-    std::array<uint8_t, 6> out{};
-    // No inherited head means this device is its own head: advertise own MAC.
-    if (mac48 == 0) {
-        memcpy(out.data(), selfMac_.data(), 6);
-    } else {
-        unpackMac(mac48, out.data());
-    }
-    return out;
-}
-
 ChainRole RemoteDeviceCoordinator::getChainRole() const {
     if (ringLatched) return ChainRole::RING;
     if (getHelloLinkState(SerialIdentifier::INPUT_JACK) == HelloLinkState::CONNECTED) {
@@ -739,6 +718,10 @@ ChainRole RemoteDeviceCoordinator::getChainRole() const {
 }
 
 const uint8_t* RemoteDeviceCoordinator::getHeadMac() const {
+    // A head adopted from a first HELLO whose link never finished connecting must
+    // not leak through the role: HEAD and STANDALONE promise "no head above us".
+    const ChainRole role = getChainRole();
+    if (role == ChainRole::HEAD || role == ChainRole::STANDALONE) return nullptr;
     const uint64_t mac48 = chainHeadState.load() & HEAD_MAC_MASK;
     if (mac48 == 0) return nullptr;
     unpackMac(mac48, headMacScratch.data());
@@ -789,7 +772,7 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     // encodes as an absent head_mac); the ring case above already handled it.
     if (peerHeadIsSelf) return;
 
-    if (memcmp(peerEffectiveHead.data(), effectiveHead().data(), 6) == 0) return;
+    if ((chainHeadState.load() & HEAD_MAC_MASK) == MacToUInt64(peerEffectiveHead.data())) return;
 
     // Adopt the upstream head, dropping to confirmed=0 until re-confirmed under
     // it. The new head then propagates in our own HELLO.
@@ -805,12 +788,9 @@ void RemoteDeviceCoordinator::onLinkLost(SerialIdentifier port) {
     // upstream (INPUT) or downstream (OUTPUT) one breaks the loop, so open the ring.
     ringLatched = false;
 
-    // Only the upstream (INPUT) peer supplies our inherited head, so only its loss
-    // severs the head supply and must clear the inherited head (the phantom-head
-    // bug), re-deriving the effective head to our own MAC. A downstream (OUTPUT)
-    // drop leaves the upstream head supply intact.
-    if (port == SerialIdentifier::INPUT_JACK &&
-        (chainHeadState.load() & HEAD_MAC_MASK) != 0) {
+    // Only the upstream (INPUT) peer supplies the inherited head; its loss makes
+    // this device its own head again.
+    if (port == SerialIdentifier::INPUT_JACK) {
         chainHeadState.store(0);
     }
 }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -600,14 +600,12 @@ void RemoteDeviceCoordinator::enableHelloConnectivity() {
         context.onJackChange = [this](SerialIdentifier j, bool connected) {
             if (jackChangeCallback) jackChangeCallback(j, connected);
         };
-        context.resetParser = [this, port] {
+        // Every link-death path mounts Idle; the initial mount fires this too,
+        // a no-op on zero state.
+        context.onLinkDown = [this, port] {
             helloByPort_[portIndex(port)].parser.requestReset();
+            onLinkLost(port);
         };
-        // Idle is the single teardown point: every link-death path (silent link,
-        // context timeout, peer swap) mounts Idle, so the chain state hanging off
-        // the link — ring latch, inherited head — is cleared exactly there. The
-        // initial mount fires it too, a no-op on zero state.
-        context.onLinkDown = [this, port] { onLinkLost(port); };
         context.silentLinkMs = HELLO_SILENT_LINK_MS;
         context.contextTimeoutMs = CONTEXT_EXCHANGE_TIMEOUT_MS;
         link.machine = new HelloLinkMachine(std::move(context));

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -25,6 +25,33 @@ using ::testing::Return;
 // into the SerialFrameParser. Single-threaded via setExternalConnectivityTask —
 // the test calls emitHello()/sync() itself instead of the FreeRTOS task.
 
+// Radio mock defaults shared by the fixture and the standalone ring nodes:
+// sends and peer-table ops succeed, the device reports `mac` as its own.
+inline void wireRadioDefaults(MockDevice& device, uint8_t* mac) {
+    ON_CALL(*device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+    ON_CALL(*device.mockPeerComms, getMacAddress()).WillByDefault(Return(mac));
+    ON_CALL(*device.mockPeerComms, addEspNowPeer(_)).WillByDefault(Return(0));
+    ON_CALL(*device.mockPeerComms, removeEspNowPeer(_)).WillByDefault(Return(0));
+    ON_CALL(*device.mockPeerComms, getPeerCommsState())
+        .WillByDefault(Return(PeerCommsState::CONNECTED));
+}
+
+// One direction of a cable: drains `from`'s emitted bytes into `to`'s RX and
+// runs the real exec() pump.
+inline void pumpCable(NativeSerialDriver& from, NativeSerialDriver& to) {
+    const std::string bytes = from.getOutput();
+    from.clearOutput();
+    if (bytes.empty()) return;
+    to.injectBytes(std::vector<uint8_t>(bytes.begin(), bytes.end()));
+    to.exec();
+}
+
+// Pushes a frame into a jack's RX and drains it via the real exec() pump.
+inline void deliverFrame(NativeSerialDriver& jack, const std::vector<uint8_t>& frame) {
+    jack.injectBytes(frame);
+    jack.exec();
+}
+
 class RDCHelloTests : public testing::Test {
 public:
     /// Fake clock, mocked radio, native jacks swapped in, RDC in HELLO mode with
@@ -34,12 +61,7 @@ public:
         SimpleTimer::setPlatformClock(fakeClock);
         fakeClock->setTime(1000);
 
-        ON_CALL(*device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
-        ON_CALL(*device.mockPeerComms, getMacAddress()).WillByDefault(Return(localMac));
-        ON_CALL(*device.mockPeerComms, addEspNowPeer(_)).WillByDefault(Return(0));
-        ON_CALL(*device.mockPeerComms, removeEspNowPeer(_)).WillByDefault(Return(0));
-        ON_CALL(*device.mockPeerComms, getPeerCommsState())
-            .WillByDefault(Return(PeerCommsState::CONNECTED));
+        wireRadioDefaults(device, localMac);
 
         device.serialManager->setOutputJack(&outJack);
         device.serialManager->setInputJack(&inJack);
@@ -80,8 +102,7 @@ public:
 
     /// Pushes a frame into a jack's RX and drains it via the real exec() pump.
     void deliverHello(NativeSerialDriver& jack, const std::vector<uint8_t>& frame) {
-        jack.injectBytes(frame);
-        jack.exec();
+        deliverFrame(jack, frame);
     }
 
     MockDevice device;
@@ -607,12 +628,7 @@ inline void rdcChainRingYieldsToHigherHeadAfterEvidenceTimeout(RDCHelloTests* su
 struct ChainRingNode {
     explicit ChainRingNode(const uint8_t m[6]) {
         memcpy(mac, m, 6);
-        ON_CALL(*device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
-        ON_CALL(*device.mockPeerComms, getMacAddress()).WillByDefault(Return(mac));
-        ON_CALL(*device.mockPeerComms, addEspNowPeer(_)).WillByDefault(Return(0));
-        ON_CALL(*device.mockPeerComms, removeEspNowPeer(_)).WillByDefault(Return(0));
-        ON_CALL(*device.mockPeerComms, getPeerCommsState())
-            .WillByDefault(Return(PeerCommsState::CONNECTED));
+        wireRadioDefaults(device, mac);
         device.serialManager->setOutputJack(&out);
         device.serialManager->setInputJack(&in);
         rdc.setExternalConnectivityTask(true);
@@ -642,23 +658,15 @@ inline void rdcChainTwoNodeRingCloses() {
     ChainRingNode A(macA);
     ChainRingNode B(macB);
 
-    auto pump = [](NativeSerialDriver& from, NativeSerialDriver& to) {
-        const std::string bytes = from.getOutput();
-        from.clearOutput();
-        if (bytes.empty()) return;
-        to.injectBytes(std::vector<uint8_t>(bytes.begin(), bytes.end()));
-        to.exec();
-    };
-
     // Cable 1: A.out -> B.in. B inherits A as its head.
     A.rdc.emitHello();
-    pump(A.out, B.in);
+    pumpCable(A.out, B.in);
     B.rdc.sync(&B.device);
 
     // A.out hears B on the return leg; bring both ends to Connected so A is the
     // structural HEAD and B a CHILD.
     B.rdc.emitHello();
-    pump(B.in, A.out);
+    pumpCable(B.in, A.out);
     A.rdc.sync(&A.device);
     A.rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);
     A.rdc.sync(&A.device);
@@ -672,7 +680,7 @@ inline void rdcChainTwoNodeRingCloses() {
     // Cable 2 closes the ring: B.out -> A.in carries B's HELLO advertising head=A.
     B.out.clearOutput();
     B.rdc.emitHello();
-    pump(B.out, A.in);
+    pumpCable(B.out, A.in);
 
     EXPECT_EQ(A.ringClosedCount, 1);
     EXPECT_EQ(A.rdc.getChainRole(), ChainRole::RING);
@@ -694,27 +702,15 @@ inline void rdcChainDualLatchSettlesByLowerMac() {
     ChainRingNode A(macA);
     ChainRingNode B(macB);
 
-    auto pump = [](NativeSerialDriver& from, NativeSerialDriver& to) {
-        const std::string bytes = from.getOutput();
-        from.clearOutput();
-        if (bytes.empty()) return;
-        to.injectBytes(std::vector<uint8_t>(bytes.begin(), bytes.end()));
-        to.exec();
-    };
-    auto deliver = [](NativeSerialDriver& jack, const std::vector<uint8_t>& frame) {
-        jack.injectBytes(frame);
-        jack.exec();
-    };
-
     // Bring both OUTPUT jacks to Connected: each hears the other's HELLO on the
     // return leg of its own out-cable.
     B.rdc.emitHello();
-    pump(B.in, A.out);
+    pumpCable(B.in, A.out);
     A.rdc.sync(&A.device);
     A.rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);
     A.rdc.sync(&A.device);
     A.rdc.emitHello();
-    pump(A.in, B.out);
+    pumpCable(A.in, B.out);
     B.rdc.sync(&B.device);
     B.rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);
     B.rdc.sync(&B.device);
@@ -725,8 +721,8 @@ inline void rdcChainDualLatchSettlesByLowerMac() {
 
     // Both latch in one exchange: each INPUT delivers the device's own MAC as
     // the returned head while the other side is doing the same.
-    deliver(A.in, chainHelloFrame(macB, macA));
-    deliver(B.in, chainHelloFrame(macA, macB));
+    deliverFrame(A.in, chainHelloFrame(macB, macA));
+    deliverFrame(B.in, chainHelloFrame(macA, macB));
     ASSERT_EQ(A.rdc.getChainRole(), ChainRole::RING);
     ASSERT_EQ(B.rdc.getChainRole(), ChainRole::RING);
     ASSERT_EQ(A.ringClosedCount, 1);
@@ -749,10 +745,10 @@ inline void rdcChainDualLatchSettlesByLowerMac() {
         clock.advance(RemoteDeviceCoordinator::HELLO_CADENCE_MS);
         A.rdc.emitHello();
         B.rdc.emitHello();
-        pump(A.out, B.in);
-        pump(B.out, A.in);
-        pump(A.in, B.out);  // reverse legs keep the OUT jacks alive
-        pump(B.in, A.out);
+        pumpCable(A.out, B.in);
+        pumpCable(B.out, A.in);
+        pumpCable(A.in, B.out);  // reverse legs keep the OUT jacks alive
+        pumpCable(B.in, A.out);
         A.rdc.sync(&A.device);
         B.rdc.sync(&B.device);
     }

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -350,7 +350,8 @@ inline void rdcChainInheritsAndReadvertisesHead(RDCHelloTests* suite) {
     const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
     const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
 
-    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, head));
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(upstream, head));
     ASSERT_NE(suite->rdc.getHeadMac(), nullptr);
     EXPECT_EQ(0, memcmp(suite->rdc.getHeadMac(), head, 6));
 
@@ -366,8 +367,8 @@ inline void rdcChainInheritsAndReadvertisesHead(RDCHelloTests* suite) {
     EXPECT_EQ(0, memcmp(suite->rdc.getHeadMac(), upstream, 6));
 }
 
-// KEY REGRESSION: a structural head whose MAC is NOT the lowest still latches the
-// ring, because inheritance carries its own MAC around the loop unchallenged.
+// A structural head whose MAC is NOT the lowest still latches the ring, because
+// inheritance carries its own MAC around the loop unchallenged.
 inline void rdcChainNonLowestHeadDetectsRing(RDCHelloTests* suite) {
     int ringClosedCount = 0;
     suite->rdc.setOnRingClosed([&]() { ringClosedCount++; });
@@ -478,8 +479,8 @@ inline void rdcChainRingOpensWhenReturnedHeadChanges(RDCHelloTests* suite) {
     connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
                 suite->helloFrame(0xB1));
     const uint8_t upstream[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
-    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, suite->localMac));
-    suite->rdc.sync(&suite->device);
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(upstream, suite->localMac));
     ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
 
     // Same upstream source, now advertising itself as head (absent head_mac).
@@ -551,8 +552,12 @@ inline void rdcChainPeerSwapClearsStaleRing(RDCHelloTests* suite) {
     const uint8_t peerB[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x02};
     const uint8_t foreignHead[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
     suite->deliverHello(suite->inJack, chainHelloFrame(peerB, foreignHead));
-
     EXPECT_NE(suite->rdc.getChainRole(), ChainRole::RING);
+
+    // getHeadMac only surfaces the adopted head once the fresh link completes.
+    suite->rdc.sync(&suite->device);
+    suite->rdc.onContextExchangeComplete(SerialIdentifier::INPUT_JACK);
+    suite->rdc.sync(&suite->device);
     ASSERT_NE(suite->rdc.getHeadMac(), nullptr);
     EXPECT_EQ(0, memcmp(suite->rdc.getHeadMac(), foreignHead, 6));
 }
@@ -607,8 +612,6 @@ inline void rdcChainTwoNodeRingCloses() {
     // Cable 1: A.out -> B.in. B inherits A as its head.
     A.rdc.emitHello();
     pump(A.out, B.in);
-    ASSERT_NE(B.rdc.getHeadMac(), nullptr);
-    EXPECT_EQ(0, memcmp(B.rdc.getHeadMac(), macA, 6));
     B.rdc.sync(&B.device);
 
     // A.out hears B on the return leg; bring both ends to Connected so A is the
@@ -622,6 +625,8 @@ inline void rdcChainTwoNodeRingCloses() {
     B.rdc.sync(&B.device);
     ASSERT_EQ(A.rdc.getChainRole(), ChainRole::HEAD);
     ASSERT_EQ(B.rdc.getChainRole(), ChainRole::CHILD);
+    ASSERT_NE(B.rdc.getHeadMac(), nullptr);
+    EXPECT_EQ(0, memcmp(B.rdc.getHeadMac(), macA, 6));
 
     // Cable 2 closes the ring: B.out -> A.in carries B's HELLO advertising head=A.
     B.out.clearOutput();

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -562,6 +562,47 @@ inline void rdcChainPeerSwapClearsStaleRing(RDCHelloTests* suite) {
     EXPECT_EQ(0, memcmp(suite->rdc.getHeadMac(), foreignHead, 6));
 }
 
+// Non-adjacent break where the replacement head has a HIGHER MAC than ours:
+// lower-MAC stand-down alone would hold the latch forever. The latch is
+// evidence-based — once our own MAC stops returning on INPUT for the evidence
+// window, the device must stand down and adopt the propagated head.
+inline void rdcChainRingYieldsToHigherHeadAfterEvidenceTimeout(RDCHelloTests* suite) {
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                suite->helloFrame(0xB1));
+    const uint8_t upstream[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(upstream, suite->localMac));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
+
+    const uint8_t higherHead[6] = {0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE};
+
+    // Inside the evidence window a higher claim reads as a merge transient:
+    // the latch holds.
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, higherHead));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
+
+    // Both links stay alive at HELLO cadence but no self-return ever arrives;
+    // past the window the latch must yield.
+    unsigned long elapsed = 0;
+    while (elapsed <= RemoteDeviceCoordinator::RING_EVIDENCE_TIMEOUT_MS) {
+        suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_CADENCE_MS);
+        elapsed += RemoteDeviceCoordinator::HELLO_CADENCE_MS;
+        suite->deliverHello(suite->outJack, suite->helloFrame(0xB1));
+        suite->deliverHello(suite->inJack, chainHelloFrame(upstream, higherHead));
+        suite->rdc.sync(&suite->device);
+    }
+
+    EXPECT_NE(suite->rdc.getChainRole(), ChainRole::RING);
+    ASSERT_NE(suite->rdc.getHeadMac(), nullptr);
+    EXPECT_EQ(0, memcmp(suite->rdc.getHeadMac(), higherHead, 6));
+
+    suite->outJack.clearOutput();
+    suite->rdc.emitHello();
+    HelloPayload emitted = parseEmittedHello(suite->outJack.getOutput());
+    EXPECT_EQ(0, memcmp(emitted.headMac, higherHead, 6));
+}
+
 // One node bundling an RDC, its device and jacks, for the two-live-RDC ring test.
 struct ChainRingNode {
     explicit ChainRingNode(const uint8_t m[6]) {
@@ -691,25 +732,35 @@ inline void rdcChainDualLatchSettlesByLowerMac() {
     ASSERT_EQ(A.ringClosedCount, 1);
     ASSERT_EQ(B.ringClosedCount, 1);
 
+    // Complete both INPUT links so advancing time below exercises only the ring
+    // evidence window, not the context-exchange timeout.
+    A.rdc.sync(&A.device);
+    A.rdc.onContextExchangeComplete(SerialIdentifier::INPUT_JACK);
+    A.rdc.sync(&A.device);
+    B.rdc.sync(&B.device);
+    B.rdc.onContextExchangeComplete(SerialIdentifier::INPUT_JACK);
+    B.rdc.sync(&B.device);
+
     // Emit-before-deliver models the real concurrency: both HELLOs are in
-    // flight before either side processes one. Must converge, not oscillate.
-    for (int i = 0; i < 20; ++i) {
+    // flight before either side processes one. Must converge, not oscillate,
+    // and running past the evidence window pins that the survivor's own
+    // self-returns keep its latch alive.
+    for (int i = 0; i < 40; ++i) {
+        clock.advance(RemoteDeviceCoordinator::HELLO_CADENCE_MS);
         A.rdc.emitHello();
         B.rdc.emitHello();
         pump(A.out, B.in);
         pump(B.out, A.in);
+        pump(A.in, B.out);  // reverse legs keep the OUT jacks alive
+        pump(B.in, A.out);
         A.rdc.sync(&A.device);
         B.rdc.sync(&B.device);
-        A.in.clearOutput();
-        A.out.clearOutput();
-        B.in.clearOutput();
-        B.out.clearOutput();
     }
 
     EXPECT_EQ(A.ringClosedCount, 1);
     EXPECT_EQ(B.ringClosedCount, 1);
     EXPECT_EQ(A.rdc.getChainRole(), ChainRole::RING);
-    EXPECT_NE(B.rdc.getChainRole(), ChainRole::RING);
+    EXPECT_EQ(B.rdc.getChainRole(), ChainRole::CHILD);
 
     SimpleTimer::setPlatformClock(nullptr);
 }

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -468,6 +468,27 @@ inline void rdcChainRingOpensOnOutputDrop(RDCHelloTests* suite) {
     EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
 }
 
+// Non-adjacent break: the INPUT peer stays put but, having lost ITS own upstream,
+// stops echoing our head and advertises itself. The head returning on INPUT no
+// longer matches ours, so the ring must open even though neither of our links
+// dropped — the break was further around the loop.
+inline void rdcChainRingOpensWhenReturnedHeadChanges(RDCHelloTests* suite) {
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                suite->helloFrame(0xB1));
+    const uint8_t upstream[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, suite->localMac));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
+
+    // Same upstream source, now advertising itself as head (absent head_mac).
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, nullptr));
+    suite->rdc.sync(&suite->device);
+
+    EXPECT_NE(suite->rdc.getChainRole(), ChainRole::RING);
+    ASSERT_NE(suite->rdc.getHeadMac(), nullptr);
+    EXPECT_EQ(0, memcmp(suite->rdc.getHeadMac(), upstream, 6));
+}
+
 // A different source MAC on a still-live INPUT jack (peer swapped before the
 // silent-link watchdog fired) tears the link down and re-derives: the stale ring
 // latch and the head inherited from the vanished peer cannot survive.

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -633,3 +633,78 @@ inline void rdcChainTwoNodeRingCloses() {
 
     SimpleTimer::setPlatformClock(nullptr);
 }
+
+// Symmetric double-latch: both devices of a 2-ring latch RING in the same
+// exchange (each hears its own MAC return before reading the other's claim).
+// Lower MAC wins the head conflict: only the higher-MAC device stands down, the
+// lower keeps its latch, and ringClosed never re-fires once settled.
+inline void rdcChainDualLatchSettlesByLowerMac() {
+    FakePlatformClock clock;
+    SimpleTimer::setPlatformClock(&clock);
+    clock.setTime(1000);
+
+    const uint8_t macA[6] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x02};  // lower: keeps latch
+    const uint8_t macB[6] = {0xAA, 0x00, 0x00, 0x00, 0x00, 0x03};
+    ChainRingNode A(macA);
+    ChainRingNode B(macB);
+
+    auto pump = [](NativeSerialDriver& from, NativeSerialDriver& to) {
+        const std::string bytes = from.getOutput();
+        from.clearOutput();
+        if (bytes.empty()) return;
+        to.injectBytes(std::vector<uint8_t>(bytes.begin(), bytes.end()));
+        to.exec();
+    };
+    auto deliver = [](NativeSerialDriver& jack, const std::vector<uint8_t>& frame) {
+        jack.injectBytes(frame);
+        jack.exec();
+    };
+
+    // Bring both OUTPUT jacks to Connected: each hears the other's HELLO on the
+    // return leg of its own out-cable.
+    B.rdc.emitHello();
+    pump(B.in, A.out);
+    A.rdc.sync(&A.device);
+    A.rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);
+    A.rdc.sync(&A.device);
+    A.rdc.emitHello();
+    pump(A.in, B.out);
+    B.rdc.sync(&B.device);
+    B.rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);
+    B.rdc.sync(&B.device);
+    A.out.clearOutput();
+    A.in.clearOutput();
+    B.out.clearOutput();
+    B.in.clearOutput();
+
+    // Both latch in one exchange: each INPUT delivers the device's own MAC as
+    // the returned head while the other side is doing the same.
+    deliver(A.in, chainHelloFrame(macB, macA));
+    deliver(B.in, chainHelloFrame(macA, macB));
+    ASSERT_EQ(A.rdc.getChainRole(), ChainRole::RING);
+    ASSERT_EQ(B.rdc.getChainRole(), ChainRole::RING);
+    ASSERT_EQ(A.ringClosedCount, 1);
+    ASSERT_EQ(B.ringClosedCount, 1);
+
+    // Emit-before-deliver models the real concurrency: both HELLOs are in
+    // flight before either side processes one. Must converge, not oscillate.
+    for (int i = 0; i < 20; ++i) {
+        A.rdc.emitHello();
+        B.rdc.emitHello();
+        pump(A.out, B.in);
+        pump(B.out, A.in);
+        A.rdc.sync(&A.device);
+        B.rdc.sync(&B.device);
+        A.in.clearOutput();
+        A.out.clearOutput();
+        B.in.clearOutput();
+        B.out.clearOutput();
+    }
+
+    EXPECT_EQ(A.ringClosedCount, 1);
+    EXPECT_EQ(B.ringClosedCount, 1);
+    EXPECT_EQ(A.rdc.getChainRole(), ChainRole::RING);
+    EXPECT_NE(B.rdc.getChainRole(), ChainRole::RING);
+
+    SimpleTimer::setPlatformClock(nullptr);
+}

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -43,6 +43,7 @@ public:
 
         device.serialManager->setOutputJack(&outJack);
         device.serialManager->setInputJack(&inJack);
+        device.serialManager->setSecondaryInputJack(&secondaryJack);
 
         rdc.setExternalConnectivityTask(true);
         rdc.initialize(device.wirelessManager, device.serialManager, &device);
@@ -87,6 +88,7 @@ public:
     FakePlatformClock* fakeClock = nullptr;
     NativeSerialDriver outJack{"hello-out"};
     NativeSerialDriver inJack{"hello-in"};
+    NativeSerialDriver secondaryJack{"hello-sec"};
     // Declared after the jacks so it is destroyed FIRST: the RDC dtor clears the
     // byte callbacks on the jacks, which must still be alive (mirrors production,
     // where the serial drivers outlive the RDC).
@@ -510,6 +512,29 @@ inline void rdcChainRingLatchesOnMergeWithConnectedInput(RDCHelloTests* suite) {
     // Latching means we are the head: the head adopted while the ring was forming
     // must be dropped, not advertised on into the closed ring.
     EXPECT_EQ(suite->rdc.getHeadMac(), nullptr);
+}
+
+// The FDN secondary input jack is a symbol link, not part of the chain, so its
+// loss must not open a ring closed over the INPUT/OUTPUT jacks.
+inline void rdcChainSecondaryJackLossKeepsRing(RDCHelloTests* suite) {
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                suite->helloFrame(0xB1));
+    const uint8_t upstream[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, suite->localMac));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
+
+    connectJack(suite, suite->secondaryJack, SerialIdentifier::INPUT_JACK_SECONDARY,
+                suite->helloFrame(0xD1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
+
+    // Let ONLY the secondary jack silent-link out; keep the two chain jacks alive.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xB1));
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, suite->localMac));
+    suite->rdc.sync(&suite->device);
+
+    EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
 }
 
 // A different source MAC on a still-live INPUT jack (peer swapped before the

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -626,6 +626,7 @@ inline void rdcChainRingYieldsToHigherHeadAfterEvidenceTimeout(RDCHelloTests* su
 
 // One node bundling an RDC, its device and jacks, for the two-live-RDC ring test.
 struct ChainRingNode {
+    /// Wires the node's RDC to its own jacks under the given MAC.
     explicit ChainRingNode(const uint8_t m[6]) {
         memcpy(mac, m, 6);
         wireRadioDefaults(device, mac);

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -507,6 +507,9 @@ inline void rdcChainRingLatchesOnMergeWithConnectedInput(RDCHelloTests* suite) {
     suite->rdc.sync(&suite->device);
 
     EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
+    // Latching means we are the head: the head adopted while the ring was forming
+    // must be dropped, not advertised on into the closed ring.
+    EXPECT_EQ(suite->rdc.getHeadMac(), nullptr);
 }
 
 // A different source MAC on a still-live INPUT jack (peer swapped before the

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -489,6 +489,26 @@ inline void rdcChainRingOpensWhenReturnedHeadChanges(RDCHelloTests* suite) {
     EXPECT_EQ(0, memcmp(suite->rdc.getHeadMac(), upstream, 6));
 }
 
+// Merge-in-the-middle: two already-connected sub-chains join into a ring, so our
+// own head first returns on an INPUT jack that is ALREADY connected. Latching must
+// gate on OUTPUT presence, not role==HEAD (which demands a disconnected INPUT).
+inline void rdcChainRingLatchesOnMergeWithConnectedInput(RDCHelloTests* suite) {
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                suite->helloFrame(0xB1));
+    const uint8_t upstream[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    const uint8_t foreignHead[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+    // INPUT fully connects first, under some other head (role CHILD).
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(upstream, foreignHead));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
+
+    // The far side of the merge now carries our own MAC back around.
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, suite->localMac));
+    suite->rdc.sync(&suite->device);
+
+    EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
+}
+
 // A different source MAC on a still-live INPUT jack (peer swapped before the
 // silent-link watchdog fired) tears the link down and re-derives: the stale ring
 // latch and the head inherited from the vanished peer cannot survive.

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -294,3 +294,273 @@ inline void rdcHelloSyncSkipsHandshakeOnStateLoop() {
     subjectRdc.sync(&subject);
     EXPECT_EQ(subjectSends, 0);
 }
+
+// ============================================
+// Device-level chain state machine (#156)
+// ============================================
+
+// A framed HELLO carrying a source MAC and, optionally, an advertised head.
+inline std::vector<uint8_t> chainHelloFrame(const uint8_t* source, const uint8_t* head) {
+    HelloPayload hello{};
+    memcpy(hello.source, source, 6);
+    hello.deviceType = static_cast<uint8_t>(DeviceType::PDN);
+    if (head != nullptr) memcpy(hello.headMac, head, 6);
+    return encodeFramed(hello);
+}
+
+// Decodes a jack's emitted output back into a single HelloPayload.
+inline HelloPayload parseEmittedHello(const std::string& out) {
+    SerialFrameParser parser;
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; });
+    std::vector<uint8_t> bytes(out.begin(), out.end());
+    parser.feed(bytes.data(), bytes.size());
+    return got;
+}
+
+// Drives a jack Idle -> Connecting -> Connected. Each transition commits on a
+// sync() tick, and the context exchange only advances a Connecting link.
+inline void connectJack(RDCHelloTests* suite, NativeSerialDriver& jack,
+                        SerialIdentifier id, const std::vector<uint8_t>& firstHello) {
+    suite->deliverHello(jack, firstHello);
+    suite->rdc.sync(&suite->device);
+    suite->rdc.onContextExchangeComplete(id);
+    suite->rdc.sync(&suite->device);
+}
+
+// Chain role is a local read of jack presence: OUTPUT connected = HEAD, INPUT
+// connected = CHILD (dominates), neither = STANDALONE.
+inline void rdcChainRoleReadsJackPresence(RDCHelloTests* suite) {
+    EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::STANDALONE);
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                suite->helloFrame(0xB1));
+    EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                suite->helloFrame(0xA1));
+    EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
+}
+
+// Downstream inheritance: adopt the upstream peer's effective head and
+// re-advertise it. Head inheritance is synchronous on HELLO receipt.
+inline void rdcChainInheritsAndReadvertisesHead(RDCHelloTests* suite) {
+    const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, head));
+    ASSERT_NE(suite->rdc.getHeadMac(), nullptr);
+    EXPECT_EQ(0, memcmp(suite->rdc.getHeadMac(), head, 6));
+
+    suite->outJack.clearOutput();
+    suite->rdc.emitHello();
+    HelloPayload emitted = parseEmittedHello(suite->outJack.getOutput());
+    EXPECT_EQ(0, memcmp(emitted.headMac, head, 6));
+    EXPECT_EQ(0, memcmp(emitted.source, suite->localMac, 6));
+
+    const uint8_t zero[6] = {0, 0, 0, 0, 0, 0};
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, zero));
+    ASSERT_NE(suite->rdc.getHeadMac(), nullptr);
+    EXPECT_EQ(0, memcmp(suite->rdc.getHeadMac(), upstream, 6));
+}
+
+// KEY REGRESSION: a structural head whose MAC is NOT the lowest still latches the
+// ring, because inheritance carries its own MAC around the loop unchallenged.
+inline void rdcChainNonLowestHeadDetectsRing(RDCHelloTests* suite) {
+    int ringClosedCount = 0;
+    suite->rdc.setOnRingClosed([&]() { ringClosedCount++; });
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    const uint8_t lowNeighbour[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    suite->deliverHello(suite->inJack, chainHelloFrame(lowNeighbour, suite->localMac));
+
+    EXPECT_EQ(ringClosedCount, 1);
+    EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
+}
+
+// Head transfer: when the INPUT peer drops while an OUTPUT peer remains, this
+// device becomes the new head and clears its inherited (now phantom) head.
+inline void rdcChainHeadTransferClearsInheritedHead(RDCHelloTests* suite) {
+    const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+    const uint8_t downstream[6] = {0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6};
+
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(upstream, head));
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                chainHelloFrame(downstream, nullptr));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
+    ASSERT_NE(suite->rdc.getHeadMac(), nullptr);
+
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->deliverHello(suite->outJack, chainHelloFrame(downstream, nullptr));
+    suite->rdc.sync(&suite->device);
+
+    EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+    EXPECT_EQ(suite->rdc.getHeadMac(), nullptr);
+
+    suite->outJack.clearOutput();
+    suite->rdc.emitHello();
+    HelloPayload emitted = parseEmittedHello(suite->outJack.getOutput());
+    const uint8_t zero[6] = {0, 0, 0, 0, 0, 0};
+    EXPECT_EQ(0, memcmp(emitted.headMac, zero, 6));
+}
+
+// Phantom-head clear: a pure child whose upstream vanishes falls back to
+// STANDALONE and stops advertising the vanished head.
+inline void rdcChainPhantomHeadClearedOnSupplierLoss(RDCHelloTests* suite) {
+    const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(upstream, head));
+    ASSERT_NE(suite->rdc.getHeadMac(), nullptr);
+
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->rdc.sync(&suite->device);
+
+    EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::STANDALONE);
+    EXPECT_EQ(suite->rdc.getHeadMac(), nullptr);
+
+    suite->outJack.clearOutput();
+    suite->rdc.emitHello();
+    HelloPayload emitted = parseEmittedHello(suite->outJack.getOutput());
+    const uint8_t zero[6] = {0, 0, 0, 0, 0, 0};
+    EXPECT_EQ(0, memcmp(emitted.headMac, zero, 6));
+}
+
+// Ring opens when the INPUT peer drops: the latch clears and the role falls back
+// to a plain read of jack presence.
+inline void rdcChainRingOpensOnInputDrop(RDCHelloTests* suite) {
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                suite->helloFrame(0xB1));
+    const uint8_t lowNeighbour[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    suite->deliverHello(suite->inJack, chainHelloFrame(lowNeighbour, suite->localMac));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
+
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xB1));
+    suite->rdc.sync(&suite->device);
+
+    EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+}
+
+// Ring opens when the peer drops on the OUTPUT side, not just the INPUT side: a
+// closed loop breaks whichever link fails.
+inline void rdcChainRingOpensOnOutputDrop(RDCHelloTests* suite) {
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                suite->helloFrame(0xB1));
+    const uint8_t lowNeighbour[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    suite->deliverHello(suite->inJack, chainHelloFrame(lowNeighbour, suite->localMac));
+    suite->rdc.sync(&suite->device);
+    suite->rdc.onContextExchangeComplete(SerialIdentifier::INPUT_JACK);
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
+
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->deliverHello(suite->inJack, chainHelloFrame(lowNeighbour, suite->localMac));
+    suite->rdc.sync(&suite->device);
+
+    EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
+}
+
+// A different source MAC on a still-live INPUT jack (peer swapped before the
+// silent-link watchdog fired) tears the link down and re-derives: the stale ring
+// latch and the head inherited from the vanished peer cannot survive.
+inline void rdcChainPeerSwapClearsStaleRing(RDCHelloTests* suite) {
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                suite->helloFrame(0xB1));
+    const uint8_t peerA[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    suite->deliverHello(suite->inJack, chainHelloFrame(peerA, suite->localMac));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
+
+    const uint8_t peerB[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x02};
+    const uint8_t foreignHead[6] = {0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+    suite->deliverHello(suite->inJack, chainHelloFrame(peerB, foreignHead));
+
+    EXPECT_NE(suite->rdc.getChainRole(), ChainRole::RING);
+    ASSERT_NE(suite->rdc.getHeadMac(), nullptr);
+    EXPECT_EQ(0, memcmp(suite->rdc.getHeadMac(), foreignHead, 6));
+}
+
+// One node bundling an RDC, its device and jacks, for the two-live-RDC ring test.
+struct ChainRingNode {
+    explicit ChainRingNode(const uint8_t m[6]) {
+        memcpy(mac, m, 6);
+        ON_CALL(*device.mockPeerComms, sendData(_, _, _, _)).WillByDefault(Return(1));
+        ON_CALL(*device.mockPeerComms, getMacAddress()).WillByDefault(Return(mac));
+        ON_CALL(*device.mockPeerComms, addEspNowPeer(_)).WillByDefault(Return(0));
+        ON_CALL(*device.mockPeerComms, removeEspNowPeer(_)).WillByDefault(Return(0));
+        ON_CALL(*device.mockPeerComms, getPeerCommsState())
+            .WillByDefault(Return(PeerCommsState::CONNECTED));
+        device.serialManager->setOutputJack(&out);
+        device.serialManager->setInputJack(&in);
+        rdc.setExternalConnectivityTask(true);
+        rdc.initialize(device.wirelessManager, device.serialManager, &device);
+        rdc.setOnRingClosed([this]() { ringClosedCount++; });
+        rdc.enableHelloConnectivity();
+    }
+
+    MockDevice device;
+    NativeSerialDriver out{"ring-out"};
+    NativeSerialDriver in{"ring-in"};
+    RemoteDeviceCoordinator rdc;
+    uint8_t mac[6] = {};
+    int ringClosedCount = 0;
+};
+
+// Two live RDCs cross-wired into a 2-device ring (A.out<->B.in, B.out<->A.in). A's
+// head MAC propagates to B by inheritance, returns on A's INPUT jack, and latches
+// the ring on A with no coordination message and no MAC election.
+inline void rdcChainTwoNodeRingCloses() {
+    FakePlatformClock clock;
+    SimpleTimer::setPlatformClock(&clock);
+    clock.setTime(1000);
+
+    const uint8_t macA[6] = {0xAA, 0x00, 0x00, 0x00, 0x00, 0x02};
+    const uint8_t macB[6] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x03};
+    ChainRingNode A(macA);
+    ChainRingNode B(macB);
+
+    auto pump = [](NativeSerialDriver& from, NativeSerialDriver& to) {
+        const std::string bytes = from.getOutput();
+        from.clearOutput();
+        if (bytes.empty()) return;
+        to.injectBytes(std::vector<uint8_t>(bytes.begin(), bytes.end()));
+        to.exec();
+    };
+
+    // Cable 1: A.out -> B.in. B inherits A as its head.
+    A.rdc.emitHello();
+    pump(A.out, B.in);
+    ASSERT_NE(B.rdc.getHeadMac(), nullptr);
+    EXPECT_EQ(0, memcmp(B.rdc.getHeadMac(), macA, 6));
+    B.rdc.sync(&B.device);
+
+    // A.out hears B on the return leg; bring both ends to Connected so A is the
+    // structural HEAD and B a CHILD.
+    B.rdc.emitHello();
+    pump(B.in, A.out);
+    A.rdc.sync(&A.device);
+    A.rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);
+    A.rdc.sync(&A.device);
+    B.rdc.onContextExchangeComplete(SerialIdentifier::INPUT_JACK);
+    B.rdc.sync(&B.device);
+    ASSERT_EQ(A.rdc.getChainRole(), ChainRole::HEAD);
+    ASSERT_EQ(B.rdc.getChainRole(), ChainRole::CHILD);
+
+    // Cable 2 closes the ring: B.out -> A.in carries B's HELLO advertising head=A.
+    B.out.clearOutput();
+    B.rdc.emitHello();
+    pump(B.out, A.in);
+
+    EXPECT_EQ(A.ringClosedCount, 1);
+    EXPECT_EQ(A.rdc.getChainRole(), ChainRole::RING);
+
+    SimpleTimer::setPlatformClock(nullptr);
+}

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1363,6 +1363,9 @@ TEST(RDCHelloStandalone, chainTwoNodeRingCloses) {
 TEST(RDCHelloStandalone, chainDualLatchSettlesByLowerMac) {
     rdcChainDualLatchSettlesByLowerMac();
 }
+TEST_F(RDCHelloTests, chainRingYieldsToHigherHeadAfterEvidenceTimeout) {
+    rdcChainRingYieldsToHigherHeadAfterEvidenceTimeout(this);
+}
 
 // ============================================
 // CHAIN DUEL MANAGER TESTS

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1345,6 +1345,9 @@ TEST_F(RDCHelloTests, chainRingOpensOnInputDrop) {
 TEST_F(RDCHelloTests, chainRingOpensOnOutputDrop) {
     rdcChainRingOpensOnOutputDrop(this);
 }
+TEST_F(RDCHelloTests, chainRingOpensWhenReturnedHeadChanges) {
+    rdcChainRingOpensWhenReturnedHeadChanges(this);
+}
 TEST_F(RDCHelloTests, chainPeerSwapClearsStaleRing) {
     rdcChainPeerSwapClearsStaleRing(this);
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1360,6 +1360,9 @@ TEST_F(RDCHelloTests, chainPeerSwapClearsStaleRing) {
 TEST(RDCHelloStandalone, chainTwoNodeRingCloses) {
     rdcChainTwoNodeRingCloses();
 }
+TEST(RDCHelloStandalone, chainDualLatchSettlesByLowerMac) {
+    rdcChainDualLatchSettlesByLowerMac();
+}
 
 // ============================================
 // CHAIN DUEL MANAGER TESTS

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1351,6 +1351,9 @@ TEST_F(RDCHelloTests, chainRingOpensWhenReturnedHeadChanges) {
 TEST_F(RDCHelloTests, chainRingLatchesOnMergeWithConnectedInput) {
     rdcChainRingLatchesOnMergeWithConnectedInput(this);
 }
+TEST_F(RDCHelloTests, chainSecondaryJackLossKeepsRing) {
+    rdcChainSecondaryJackLossKeepsRing(this);
+}
 TEST_F(RDCHelloTests, chainPeerSwapClearsStaleRing) {
     rdcChainPeerSwapClearsStaleRing(this);
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1348,6 +1348,9 @@ TEST_F(RDCHelloTests, chainRingOpensOnOutputDrop) {
 TEST_F(RDCHelloTests, chainRingOpensWhenReturnedHeadChanges) {
     rdcChainRingOpensWhenReturnedHeadChanges(this);
 }
+TEST_F(RDCHelloTests, chainRingLatchesOnMergeWithConnectedInput) {
+    rdcChainRingLatchesOnMergeWithConnectedInput(this);
+}
 TEST_F(RDCHelloTests, chainPeerSwapClearsStaleRing) {
     rdcChainPeerSwapClearsStaleRing(this);
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1324,6 +1324,34 @@ TEST(RDCHelloStandalone, syncSkipsHandshakeOnStateLoop) {
     rdcHelloSyncSkipsHandshakeOnStateLoop();
 }
 
+TEST_F(RDCHelloTests, chainRoleReadsJackPresence) {
+    rdcChainRoleReadsJackPresence(this);
+}
+TEST_F(RDCHelloTests, chainInheritsAndReadvertisesHead) {
+    rdcChainInheritsAndReadvertisesHead(this);
+}
+TEST_F(RDCHelloTests, chainNonLowestHeadDetectsRing) {
+    rdcChainNonLowestHeadDetectsRing(this);
+}
+TEST_F(RDCHelloTests, chainHeadTransferClearsInheritedHead) {
+    rdcChainHeadTransferClearsInheritedHead(this);
+}
+TEST_F(RDCHelloTests, chainPhantomHeadClearedOnSupplierLoss) {
+    rdcChainPhantomHeadClearedOnSupplierLoss(this);
+}
+TEST_F(RDCHelloTests, chainRingOpensOnInputDrop) {
+    rdcChainRingOpensOnInputDrop(this);
+}
+TEST_F(RDCHelloTests, chainRingOpensOnOutputDrop) {
+    rdcChainRingOpensOnOutputDrop(this);
+}
+TEST_F(RDCHelloTests, chainPeerSwapClearsStaleRing) {
+    rdcChainPeerSwapClearsStaleRing(this);
+}
+TEST(RDCHelloStandalone, chainTwoNodeRingCloses) {
+    rdcChainTwoNodeRingCloses();
+}
+
 // ============================================
 // CHAIN DUEL MANAGER TESTS
 // ============================================


### PR DESCRIPTION
# rdc: device chain state machine, head inheritance, ring detection

Closes #156. Implements the device-level chain state machine on the corrected model (`specs/rdc-chain.allium` was updated to match), re-integrated onto `comms-rewrite` now that #155 (#191) has merged — the diff is just the chain-SM work.

**Model — structural head, downstream inheritance, no MAC election.** Chain role is a purely local read of jack presence plus a ring latch (RING / CHILD / HEAD / STANDALONE). `headMac` propagates strictly downstream by inheritance: a device adopts its INPUT peer's advertised effective head (its `headMac`, else its own MAC) and re-advertises it, so a structural head's own MAC flows down the chain unchallenged. There is deliberately no lowest-MAC election for inheritance. The one place MAC order matters is a **head conflict at a latched device**: when a latched ring hears a foreign head on INPUT, #144's lower-MAC-wins rule decides who stands down. Unlatching unconditionally instead lets two simultaneously-latched heads (symmetric 2-ring boot, merging heads) depose each other and re-latch in lockstep, re-firing `ringClosed` every cycle — which matters because that callback is #169's coordinator claim point. `rdcChainDualLatchSettlesByLowerMac` drives two live RDCs into the symmetric latch and pins convergence at one `ringClosed` per device.

**Ring detection is close-ordering-independent.** RingDetected latches when a HELLO returns on the INPUT jack whose effective head equals this device's own MAC. Because that MAC is carried unchallenged, it makes exactly one lap and returns regardless of MAC value or how the ring formed — pinned by regression tests:
- `chainNonLowestHeadDetectsRing` — the head is not the chain minimum (the case the old lower-MAC-wins model broke).
- `chainRingLatchesOnMergeWithConnectedInput` — two already-connected sub-chains merge, so our own MAC first returns on an INPUT jack that is *already* CONNECTED. The latch gates on **OUTPUT connected, not `role==HEAD`** (which demands a disconnected INPUT and would miss every merge/symmetric closure).
- `chainRingOpensWhenReturnedHeadChanges` — a non-adjacent break: the INPUT peer stays but stops echoing our head, so the latch must re-validate and open even though neither of our own links dropped.
- `chainRingYieldsToHigherHeadAfterEvidenceTimeout` — the latch is evidence-based: own-MAC returns stamp a timestamp, and a *higher* foreign head only wins after self-returns have been absent past `RING_EVIDENCE_TIMEOUT_MS` (500ms, sized above the ~18-hop claim-propagation transient). Lower heads stand us down immediately; higher heads during a merge transient are outlived (our claim is still circulating); higher heads after a real break are adopted once the evidence expires.

**Where it's fragile / what to look at.**
- The emit task reads `headMac`+`confirmed` off the main loop, packed into one `std::atomic<uint64_t>` (48-bit MAC + confirmed bit); the main loop stores on every change, `emitHello` loads once. That single atomic boundary is the whole cross-thread contract.
- **Idle-mount is the single teardown point.** The Idle state's mount fires `onLinkDown`, which drives `onLinkLost` — silent-link, context timeout, and peer swap all converge there. `sync()` no longer diffs state ids around the tick, and the swap path (a live INPUT hearing a *different* source MAC before the watchdog fires) is handled inside `HelloLinkMachine::onHelloReceived` itself, so teardown-before-readopt is structural rather than caller-ordered.
- Ring latch clears on a peer loss on *either* chain jack (an OUTPUT-side break otherwise leaves the device stuck reporting RING); INPUT loss additionally clears the inherited head. The **FDN secondary input jack is excluded** — it's a symbol link, not part of the chain, so its teardown must not open the ring (`onLinkLost` early-returns for it).
- `getHeadMac()` now enforces its header contract: nullptr while role is HEAD or STANDALONE, so a consumer branching on role can't read a contradictory leading head during bring-up. Inheritance-before-connect is still pinned via the emitted HELLO assertions.

Native 323/323; ESP32-S3 release firmware compiles. The `confirmed` bit is wired but always 0 here — #157's context exchange populates it.
