### PR TITLE
New Types for Display Driver

### DIFF
--- a/lib/core/include/device/drivers/display-types.hpp
+++ b/lib/core/include/device/drivers/display-types.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "image.hpp"
+
+constexpr int DISPLAY_INSTRUCTION_CAPACITY = 20;
+constexpr int DISPLAY_TEXT_CAPACITY = 32;
+
+enum class Anchor {
+    LEADING,
+    CENTER,
+    TRAILING,
+};
+
+enum class DrawType {
+    TEXT,
+    GLYPH,
+    IMAGE,
+};
+
+struct Cursor {
+    int x = 0;
+    int y = 0;
+};
+
+enum class FontMode {
+    TEXT,
+    NUMBER_GLYPH,
+    LOADING_GLYPH,
+    TEXT_INVERTED_SMALL,
+    TEXT_INVERTED_LARGE,
+    SYMBOL_GLYPH
+};
+
+struct DrawCoordinates {
+    int x = 0;
+    int y = 0;
+    Anchor xAnchor = Anchor::LEADING;
+    Anchor yAnchor = Anchor::LEADING;
+};
+
+struct ImagePayload {
+    Image image;
+    DrawCoordinates coordinates;
+};
+
+struct TextPayload {
+    const char* text;
+    DrawCoordinates coordinates;
+    FontMode fontMode;
+};
+
+struct GlyphPayload {
+    const char* unicodeForGlyph;
+    DrawCoordinates coordinates;
+};
+
+struct DrawInstruction {
+    DrawType drawType;
+    union {
+        ImagePayload imagePayload;
+        TextPayload textPayload;
+        GlyphPayload glyphPayload;
+    };
+};

--- a/lib/core/include/device/drivers/display-types.hpp
+++ b/lib/core/include/device/drivers/display-types.hpp
@@ -15,6 +15,7 @@ enum class DrawType {
     TEXT,
     GLYPH,
     IMAGE,
+    RAW
 };
 
 struct Cursor {
@@ -54,11 +55,17 @@ struct GlyphPayload {
     DrawCoordinates coordinates;
 };
 
+struct RawPayload {
+    const uint8_t* data;
+    DrawCoordinates coordinates;
+};
+
 struct DrawInstruction {
     DrawType drawType;
     union {
         ImagePayload imagePayload;
         TextPayload textPayload;
         GlyphPayload glyphPayload;
+        RawPayload rawPayload;
     };
 };

--- a/lib/core/include/device/drivers/display.hpp
+++ b/lib/core/include/device/drivers/display.hpp
@@ -1,20 +1,7 @@
 #pragma once
 
 #include "image.hpp"
-
-struct Cursor {
-    int x = 0;
-    int y = 0;
-};
-
-enum class FontMode {
-    TEXT,
-    NUMBER_GLYPH,
-    LOADING_GLYPH,
-    TEXT_INVERTED_SMALL,
-    TEXT_INVERTED_LARGE,
-    SYMBOL_GLYPH
-};
+#include "display-types.hpp"
 
 class Display {
 public:


### PR DESCRIPTION
This PR closes #196, #197, #198, #199, #200, #201 and #202.

Created display-types.hpp

Created constants for new display driver framework, and new types for sending more formally structured commands to the Display driver.