### PR TITLE
rdc: head roster — announce, disconnect report, head transfer (#158)

### DIFF
--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -21,6 +21,9 @@ enum class PktType : uint8_t {
     kFdnConnect = 14,
     kPdnConnectionContext = 15,
     kFdnConnectionContext = 16,
+    kConnectionAnnounce = 17,
+    kDisconnectReport = 18,
+    kHeadTransfer = 19,
     kNumPacketTypes  // Not a real packet type, DO NOT USE
 };
 
@@ -110,4 +113,32 @@ struct ShootoutAckPayload
 {
     ShootoutCmd cmd;
     uint8_t     seqId;
+} __attribute__((packed));
+
+// ---- Head roster management (#158) ----
+// Point-to-point ReliableChannel payloads; the chain head is the sole consumer.
+// seqId is stamped by the channel on send.
+
+constexpr uint8_t kMaxChainMembers = 18;
+
+// Sent by a newly joined member directly to the head it read from its upstream
+// neighbour's HELLO. upstreamMac names the sender's direct upstream (INPUT) peer.
+struct ConnectionAnnouncePayload {
+    uint8_t seqId;
+    uint8_t upstreamMac[6];
+} __attribute__((packed));
+
+// Sent to the head by the upstream neighbour of a departed member — the only
+// node that observes the HELLO timeout of a non-adjacent (to the head) link.
+struct DisconnectReportPayload {
+    uint8_t seqId;
+    uint8_t disconnectedMac[6];
+} __attribute__((packed));
+
+// Sent once by a demoted head to its successor; the only place a member list
+// ever travels, and it is a single unicast.
+struct HeadTransferPayload {
+    uint8_t seqId;
+    uint8_t memberCount;
+    uint8_t memberMacs[kMaxChainMembers][6];
 } __attribute__((packed));

--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -119,7 +119,7 @@ struct ShootoutAckPayload
 // Point-to-point ReliableChannel payloads; the chain head is the sole consumer.
 // seqId is stamped by the channel on send.
 
-constexpr uint8_t kMaxChainMembers = 18;
+constexpr uint8_t MAX_CHAIN_MEMBERS = 18;
 
 // Sent by a newly joined member directly to the head it read from its upstream
 // neighbour's HELLO. upstreamMac names the sender's direct upstream (INPUT) peer.
@@ -140,5 +140,5 @@ struct DisconnectReportPayload {
 struct HeadTransferPayload {
     uint8_t seqId;
     uint8_t memberCount;
-    uint8_t memberMacs[kMaxChainMembers][6];
+    uint8_t memberMacs[MAX_CHAIN_MEMBERS][6];
 } __attribute__((packed));

--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -136,9 +136,16 @@ struct DisconnectReportPayload {
 } __attribute__((packed));
 
 // Sent once by a demoted head to its successor; the only place a member list
-// ever travels, and it is a single unicast.
+// ever travels, and it is a single unicast. Entries are (member, upstream)
+// pairs — memberMacs[i]'s recorded direct upstream is upstreamMacs[i] — so the
+// receiver keeps the chain's true order instead of flattening every
+// transferred member onto the demoted head. At MAX_CHAIN_MEMBERS=18 this is
+// 218 bytes. The ceiling is the driver's reliable-payload budget
+// (MAX_PKT_DATA_SIZE, the uint8_t length header, ~253 bytes), asserted where
+// the driver includes this header; raising MAX_CHAIN_MEMBERS past ~20 trips it.
 struct HeadTransferPayload {
     uint8_t seqId;
     uint8_t memberCount;
     uint8_t memberMacs[MAX_CHAIN_MEMBERS][6];
+    uint8_t upstreamMacs[MAX_CHAIN_MEMBERS][6];
 } __attribute__((packed));

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <optional>
 #include <vector>
 #include "device/serial-manager.hpp"
@@ -121,8 +122,7 @@ public:
     virtual const uint8_t* getHeadMac() const;
 
     /// Head-only chain member roster; empty for a child or standalone device.
-    /// STUB: always empty.
-    virtual std::vector<std::array<uint8_t, 6>> getChainMembers() const { return {}; }
+    virtual std::vector<std::array<uint8_t, 6>> getChainMembers() const;
 
     /// Registers the per-jack connect/disconnect observer. The disconnect fires
     /// before chain-state teardown, so handlers must not read chain state here;
@@ -351,6 +351,9 @@ private:
     ReliableTransport* transport = nullptr;
     ReliableChannel<PdnConnectionContext>* pdnContextChannel = nullptr;
     ReliableChannel<FdnConnectionContext>* fdnContextChannel = nullptr;
+    ReliableChannel<ConnectionAnnouncePayload>* connectionAnnounceChannel = nullptr;
+    ReliableChannel<DisconnectReportPayload>* disconnectReportChannel = nullptr;
+    ReliableChannel<HeadTransferPayload>* headTransferChannel = nullptr;
 
     // A context (ESP-NOW) can beat its own HELLO (serial) and arrive before any jack
     // is CONNECTING for that MAC. Rather than drop it, hold it here and apply it when
@@ -442,4 +445,22 @@ private:
     void applyUpstreamHead(const HelloPayload& hello);
     void onLinkLost(SerialIdentifier port);
     void maybeFireChainRoleChange();
+
+    // ---- Head roster (#158) ----
+    // member MAC -> its direct upstream MAC. Head-only by construction: every
+    // receive handler drops roster traffic while an upstream head is held.
+    std::map<std::array<uint8_t, 6>, std::array<uint8_t, 6>> chainRoster;
+    // Send ConnectionAnnounce{INPUT peer} to the held head, once the upstream
+    // context exchange has completed. No-op for a head/ring/standalone device.
+    void maybeAnnounceToHead();
+    // OUTPUT (downstream) link death: report to the head, or edit the roster in
+    // place when this device IS the head (never a packet to self).
+    void reportDownstreamLoss(const uint8_t* lostMac);
+    // Drop `mac` and every member whose upstream chain passes through it.
+    void removeChainMemberSubtree(const uint8_t* mac);
+    // Demotion handoff: unicast the roster to the successor head, then clear it.
+    void transferRosterTo(const uint8_t* newHeadMac);
+    void onConnectionAnnounce(const uint8_t* fromMac, const ConnectionAnnouncePayload& announce);
+    void onDisconnectReport(const DisconnectReportPayload& report);
+    void onHeadTransfer(const uint8_t* fromMac, const HeadTransferPayload& transfer);
 };

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -445,16 +445,23 @@ private:
     void applyUpstreamHead(const HelloPayload& hello);
     void onLinkLost(SerialIdentifier port);
     void maybeFireChainRoleChange();
+    // Drops a former head's radio slot (and its dead roster retries) unless an
+    // adjacent link or daisy record still uses the MAC.
+    void releaseHeadPeer(uint64_t headMac48);
 
     // ---- Head roster (#158) ----
-    // member MAC -> its direct upstream MAC. Head-only by construction: every
-    // receive handler drops roster traffic while an upstream head is held.
+    // member MAC -> its direct upstream MAC. Only the roster authority (see
+    // isRosterAuthority) accepts roster traffic or serves getChainMembers.
     std::map<std::array<uint8_t, 6>, std::array<uint8_t, 6>> chainRoster;
+    // seqId of the announce most recently sent; delivery of any earlier one is
+    // stale and must not raise the confirmed bit.
+    uint8_t pendingAnnounceSeqId = 0;
+    bool isRosterAuthority() const;
     // Send ConnectionAnnounce{INPUT peer} to the held head, once the upstream
     // context exchange has completed. No-op for a head/ring/standalone device.
     void maybeAnnounceToHead();
-    // OUTPUT (downstream) link death: report to the head, or edit the roster in
-    // place when this device IS the head (never a packet to self).
+    // OUTPUT (downstream) link death: report to the head (unless the lost link
+    // IS the head), or clear the roster when this device is the head.
     void reportDownstreamLoss(const uint8_t* lostMac);
     // Drop `mac` and every member whose upstream chain passes through it.
     void removeChainMemberSubtree(const uint8_t* mac);

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -482,8 +482,8 @@ private:
                                     const std::array<uint8_t, 6>& upstream);
     // True when some member other than `member` already holds `upstream`. The
     // transfer path queries this to skip (not evict) a colliding insert.
-    bool upstreamHeldByOther(const std::array<uint8_t, 6>& upstream,
-                             const std::array<uint8_t, 6>& member) const;
+    bool isUpstreamHeldByOther(const std::array<uint8_t, 6>& upstream,
+                               const std::array<uint8_t, 6>& member) const;
     // Demotion handoff: unicast the roster to the successor head, then clear it.
     void transferRosterTo(const uint8_t* newHeadMac);
     void onConnectionAnnounce(const uint8_t* fromMac, const ConnectionAnnouncePayload& announce);

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -475,6 +475,15 @@ private:
     void sendDisconnectReport(const uint8_t* headMac, const uint8_t* lostMac);
     // Drop `mac` and every member whose upstream chain passes through it.
     void removeChainMemberSubtree(const uint8_t* mac);
+    // One OUTPUT jack means one downstream: when `member` announces `upstream`,
+    // any OTHER member still recorded on that upstream is stale — remove it
+    // and its subtree before the new claim lands.
+    void evictStaleUpstreamClaimant(const std::array<uint8_t, 6>& member,
+                                    const std::array<uint8_t, 6>& upstream);
+    // True when some member other than `member` already holds `upstream`. The
+    // transfer path queries this to skip (not evict) a colliding insert.
+    bool upstreamHeldByOther(const std::array<uint8_t, 6>& upstream,
+                             const std::array<uint8_t, 6>& member) const;
     // Demotion handoff: unicast the roster to the successor head, then clear it.
     void transferRosterTo(const uint8_t* newHeadMac);
     void onConnectionAnnounce(const uint8_t* fromMac, const ConnectionAnnouncePayload& announce);

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -456,6 +456,13 @@ private:
     // seqId of the announce most recently sent; delivery of any earlier one is
     // stale and must not raise the confirmed bit.
     uint8_t pendingAnnounceSeqId = 0;
+    // disconnectedMac of the report most recently sent whose delivery is not yet
+    // confirmed (all-zero = none). A head change cancels the in-flight report to
+    // the old head, and unlike the announce path nothing re-triggers it, so
+    // applyUpstreamHead re-sends it to the successor — otherwise the departed
+    // member stays a phantom in the new head's roster.
+    std::array<uint8_t, 6> pendingReportMac{};
+    uint8_t pendingReportSeqId = 0;
     bool isRosterAuthority() const;
     // Send ConnectionAnnounce{INPUT peer} to the held head, once the upstream
     // context exchange has completed. No-op for a head/ring/standalone device.
@@ -463,11 +470,14 @@ private:
     // OUTPUT (downstream) link death: report to the head (unless the lost link
     // IS the head), or clear the roster when this device is the head.
     void reportDownstreamLoss(const uint8_t* lostMac);
+    // Reliable-send a DisconnectReport naming `lostMac` to `headMac`, tracking
+    // it as the pending report until its delivery is confirmed.
+    void sendDisconnectReport(const uint8_t* headMac, const uint8_t* lostMac);
     // Drop `mac` and every member whose upstream chain passes through it.
     void removeChainMemberSubtree(const uint8_t* mac);
     // Demotion handoff: unicast the roster to the successor head, then clear it.
     void transferRosterTo(const uint8_t* newHeadMac);
     void onConnectionAnnounce(const uint8_t* fromMac, const ConnectionAnnouncePayload& announce);
-    void onDisconnectReport(const DisconnectReportPayload& report);
+    void onDisconnectReport(const uint8_t* fromMac, const DisconnectReportPayload& report);
     void onHeadTransfer(const uint8_t* fromMac, const HeadTransferPayload& transfer);
 };

--- a/lib/core/include/wireless/reliable-channel.hpp
+++ b/lib/core/include/wireless/reliable-channel.hpp
@@ -103,6 +103,7 @@ template <class P>
 class ReliableChannel : public ReliableChannelBase {
 public:
     using OnReceive = std::function<void(const uint8_t* fromMac, const P&)>;
+    using OnDelivered = std::function<void(uint8_t seqId, const uint8_t* toMac)>;
 
     /// See ReliableChannelBase; the payload struct P is the wire format.
     ReliableChannel(WirelessManager* wirelessManager,
@@ -163,6 +164,9 @@ public:
         std::memcpy(&p, data, sizeof(P));
         if (p.seqId == 0) return;  // fire-and-forget, no pending entry to clear
         resender->onAck(packetType, p.seqId, toMac);
+        // SEND_SUCCESS is this design's delivery signal (no ack round-trip). A
+        // late radio duplicate can re-fire it, so handlers must be idempotent.
+        if (onDeliveredCallback) onDeliveredCallback(p.seqId, toMac);
     }
 
     /// This channel's payload struct size, for the transport's claim guard.
@@ -171,6 +175,10 @@ public:
     /// Registers the decoded-payload handler.
     void onReceive(OnReceive cb) { onReceiveCallback = std::move(cb); }
 
+    /// Registers the SEND_SUCCESS observer (see onSendResult).
+    void setOnDelivered(OnDelivered cb) { onDeliveredCallback = std::move(cb); }
+
 private:
     OnReceive onReceiveCallback;
+    OnDelivered onDeliveredCallback;
 };

--- a/lib/core/include/wireless/reliable-transport.hpp
+++ b/lib/core/include/wireless/reliable-transport.hpp
@@ -47,7 +47,7 @@ public:
     /// The returned pointer stays owned by the transport.
     template <class P>
     ReliableChannel<P>* channel(PktType type,
-                                ReliableChannelBase::OnAbandon onAbandon,
+                                ReliableChannelBase::OnAbandon onAbandon = {},
                                 Resender::SendMode sendMode = Resender::SendMode::SUPERSEDE_PER_TARGET) {
         std::map<PktType, ReliableChannelBase*>::iterator it = registry.find(type);
         if (it != registry.end()) {

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -173,8 +173,8 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
         // SEND_SUCCESS on the announce IS its delivery signal (#144): only then
         // may the HELLO confirmed bit rise. A head change mid-flight makes an
         // older announce's delivery stale — the re-announce to the current head
-        // is what gates confirmed — so both the seqId and the destination must
-        // still match the announce most recently sent.
+        // is what gates confirmed — so the seqId must match the latest announce
+        // sent AND the destination must still be the head currently held.
         connectionAnnounceChannel->setOnDelivered([this](uint8_t seqId, const uint8_t* toMac) {
             if (seqId != pendingAnnounceSeqId) return;
             const uint64_t head = chainHeadState.load();
@@ -1150,8 +1150,7 @@ bool RemoteDeviceCoordinator::isRosterAuthority() const {
 
 std::vector<std::array<uint8_t, 6>> RemoteDeviceCoordinator::getChainMembers() const {
     // A RING device is its own head, so it serves its roster like a HEAD does.
-    const ChainRole role = getChainRole();
-    if (role == ChainRole::CHILD || role == ChainRole::STANDALONE) return {};
+    if (!isRosterAuthority()) return {};
     std::vector<std::array<uint8_t, 6>> members;
     members.reserve(chainRoster.size());
     for (const auto& entry : chainRoster)
@@ -1238,8 +1237,8 @@ void RemoteDeviceCoordinator::transferRosterTo(const uint8_t* newHeadMac) {
     if (chainRoster.empty() || headTransferChannel == nullptr) return;
     HeadTransferPayload transfer{};
     for (const auto& entry : chainRoster) {
-        // Cannot trip while both insert paths cap at MAX_CHAIN_MEMBERS; kept as
-        // the payload array's hard bound.
+        // Both insert paths cap at MAX_CHAIN_MEMBERS; this bounds the payload
+        // array regardless.
         if (transfer.memberCount >= MAX_CHAIN_MEMBERS) break;
         memcpy(transfer.memberMacs[transfer.memberCount], entry.first.data(), 6);
         transfer.memberCount++;
@@ -1276,7 +1275,10 @@ void RemoteDeviceCoordinator::onDisconnectReport(const uint8_t* fromMac,
     // Trust boundary: no report may name this device. A member that lost the
     // link to its own head sends nothing, so a self-referential report is
     // bogus — and honoring it would erase the whole roster via the subtree walk.
-    if (memcmp(report.disconnectedMac, selfMac.data(), 6) == 0) return;
+    if (memcmp(report.disconnectedMac, selfMac.data(), 6) == 0) {
+        LOG_W("RDC", "dropping self-referential disconnect report");
+        return;
+    }
     if (!isRosterAuthority()) {
         // Head propagation is hop-by-hop, so a just-demoted head can still be
         // addressed under the old regime; forward the edit to the head now
@@ -1305,6 +1307,12 @@ void RemoteDeviceCoordinator::onHeadTransfer(const uint8_t* fromMac,
     // which names its true upstream and must not be flattened onto fromMac.
     std::array<uint8_t, 6> upstream;
     memcpy(upstream.data(), fromMac, 6);
+    if (transfer.memberCount > MAX_CHAIN_MEMBERS) {
+        // Every sender caps at MAX_CHAIN_MEMBERS, so an oversized count means a
+        // corrupt frame; the clamp bounds the array walk either way.
+        LOG_W("RDC", "head transfer memberCount %u exceeds cap %u; clamping",
+              (unsigned)transfer.memberCount, (unsigned)MAX_CHAIN_MEMBERS);
+    }
     const uint8_t count =
         transfer.memberCount <= MAX_CHAIN_MEMBERS ? transfer.memberCount : MAX_CHAIN_MEMBERS;
     bool changed = false;

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -158,6 +158,44 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
                                   sizeof(ctx.fdn));
             });
     }
+
+    // Head-roster channels (#158). Abandons are no-ops: an unreachable head means
+    // the member simply stays unconfirmed (or the roster edit is lost) until the
+    // chain state changes and re-triggers the send — the accepted residual of the
+    // no-ack design.
+    connectionAnnounceChannel = transport->channel<ConnectionAnnouncePayload>(
+        PktType::kConnectionAnnounce, [](uint8_t, const uint8_t*) {});
+    if (connectionAnnounceChannel != nullptr) {
+        connectionAnnounceChannel->onReceive(
+            [this](const uint8_t* fromMac, const ConnectionAnnouncePayload& announce) {
+                onConnectionAnnounce(fromMac, announce);
+            });
+        // SEND_SUCCESS on the announce IS its delivery signal (#144): only then
+        // may the HELLO confirmed bit rise — and only if the head it was sent to
+        // is still the head this device holds.
+        connectionAnnounceChannel->setOnDelivered([this](uint8_t, const uint8_t* toMac) {
+            const uint64_t head = chainHeadState.load();
+            const uint64_t headMac48 = head & HEAD_MAC_MASK;
+            if (headMac48 == 0 || headMac48 != MacToUInt64(toMac)) return;
+            chainHeadState.store(head | CONFIRMED_BIT);
+        });
+    }
+    disconnectReportChannel = transport->channel<DisconnectReportPayload>(
+        PktType::kDisconnectReport, [](uint8_t, const uint8_t*) {});
+    if (disconnectReportChannel != nullptr) {
+        disconnectReportChannel->onReceive(
+            [this](const uint8_t*, const DisconnectReportPayload& report) {
+                onDisconnectReport(report);
+            });
+    }
+    headTransferChannel = transport->channel<HeadTransferPayload>(
+        PktType::kHeadTransfer, [](uint8_t, const uint8_t*) {});
+    if (headTransferChannel != nullptr) {
+        headTransferChannel->onReceive(
+            [this](const uint8_t* fromMac, const HeadTransferPayload& transfer) {
+                onHeadTransfer(fromMac, transfer);
+            });
+    }
 }
 
 std::vector<SerialIdentifier> RemoteDeviceCoordinator::activePorts() const {
@@ -637,7 +675,12 @@ void RemoteDeviceCoordinator::enableHelloConnectivity() {
         // no-op on zero state.
         context.onLinkDown = [this, port](SerialIdentifier j, const std::array<uint8_t, 6>& mac) {
             helloByPort[portIndex(port)].parser.requestReset();
-            if (MacToUInt64(mac.data()) != 0) releaseHelloPeer(j, mac.data());
+            if (MacToUInt64(mac.data()) != 0) {
+                releaseHelloPeer(j, mac.data());
+                // Downstream (OUTPUT) departures are this device's to report: it
+                // is the only node that sees that HELLO go silent (#158).
+                if (j == SerialIdentifier::OUTPUT_JACK) reportDownstreamLoss(mac.data());
+            }
             onLinkLost(port);
         };
         context.silentLinkMs = HELLO_SILENT_LINK_MS;
@@ -809,6 +852,9 @@ void RemoteDeviceCoordinator::completeJackContext(SerialIdentifier jack, DeviceT
     helloByPort[portIndex(jack)].peerChainRole = chainRole;
     if (contextReceivedCallback) contextReceivedCallback(jack, peerType, profile, len);
     onContextExchangeComplete(jack);
+    // The upstream exchange completing is the join moment: announce to the head
+    // (#158). The head itself carries no upstream head, so this no-ops there.
+    if (jack == SerialIdentifier::INPUT_JACK) maybeAnnounceToHead();
 }
 
 void RemoteDeviceCoordinator::bufferContext(const uint8_t* fromMac, DeviceType peerType,
@@ -1003,6 +1049,11 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     // Adopt the upstream head, dropping to confirmed=0 until re-confirmed under
     // it. The new head then propagates in our own HELLO.
     chainHeadState.store(packHead(peerEffectiveHead, false));
+    // A demoted head hands its roster to the successor (#158); for a plain child
+    // the roster is empty and this no-ops. Then announce under the new head so
+    // confirmed can rise again.
+    transferRosterTo(peerEffectiveHead);
+    maybeAnnounceToHead();
 }
 
 void RemoteDeviceCoordinator::onLinkLost(SerialIdentifier port) {
@@ -1026,4 +1077,136 @@ void RemoteDeviceCoordinator::maybeFireChainRoleChange() {
     if (role == lastChainRole) return;
     lastChainRole = role;
     if (chainRoleChangeCallback) chainRoleChangeCallback(role);
+}
+
+// ---- Head roster (#158) ----
+
+std::vector<std::array<uint8_t, 6>> RemoteDeviceCoordinator::getChainMembers() const {
+    // A RING device is its own head, so it serves its roster like a HEAD does.
+    const ChainRole role = getChainRole();
+    if (role == ChainRole::CHILD || role == ChainRole::STANDALONE) return {};
+    std::vector<std::array<uint8_t, 6>> members;
+    members.reserve(chainRoster.size());
+    for (const auto& entry : chainRoster)
+        members.push_back(entry.first);
+    return members;
+}
+
+void RemoteDeviceCoordinator::maybeAnnounceToHead() {
+    if (connectionAnnounceChannel == nullptr) return;
+    const uint64_t headMac48 = chainHeadState.load() & HEAD_MAC_MASK;
+    // No upstream head held: this device IS its chain's head (or standalone, or a
+    // latched ring, which stores no head). Nothing to announce, no self-sends.
+    if (headMac48 == 0) return;
+    const HelloLinkMachine* upstream =
+        helloByPort_[portIndex(SerialIdentifier::INPUT_JACK)].machine;
+    if (upstream == nullptr) return;
+    // The announce names the upstream neighbour, so it is only meaningful once
+    // the upstream exchange completed (#144 ordering: announce, then confirmed).
+    if (upstream->currentStateId() != HELLO_LINK_CONNECTED &&
+        !upstream->didMarkContextComplete()) {
+        return;
+    }
+    uint8_t headMac[6];
+    unpackMac(headMac48, headMac);
+    ConnectionAnnouncePayload announce{};
+    memcpy(announce.upstreamMac, upstream->peer().data(), 6);
+    connectionAnnounceChannel->sendReliable(headMac, announce);
+}
+
+void RemoteDeviceCoordinator::reportDownstreamLoss(const uint8_t* lostMac) {
+    const uint64_t headMac48 = chainHeadState.load() & HEAD_MAC_MASK;
+    if (headMac48 == 0) {
+        // This device is the head (incl. a latched ring): edit in place.
+        removeChainMemberSubtree(lostMac);
+        return;
+    }
+    if (disconnectReportChannel == nullptr) return;
+    uint8_t headMac[6];
+    unpackMac(headMac48, headMac);
+    DisconnectReportPayload report{};
+    memcpy(report.disconnectedMac, lostMac, 6);
+    disconnectReportChannel->sendReliable(headMac, report);
+}
+
+void RemoteDeviceCoordinator::removeChainMemberSubtree(const uint8_t* mac) {
+    // Everything downstream of the departed MAC is unreachable too: walk the
+    // upstream links to a fixpoint. `gone` doubles as the BFS frontier.
+    std::vector<std::array<uint8_t, 6>> gone;
+    gone.emplace_back();
+    memcpy(gone.back().data(), mac, 6);
+    bool changed = chainRoster.erase(gone.back()) > 0;
+    for (size_t i = 0; i < gone.size(); ++i) {
+        for (auto it = chainRoster.begin(); it != chainRoster.end();) {
+            if (it->second == gone[i]) {
+                gone.push_back(it->first);
+                it = chainRoster.erase(it);
+                changed = true;
+            } else {
+                ++it;
+            }
+        }
+    }
+    if (changed && membershipChangeCallback) membershipChangeCallback();
+}
+
+void RemoteDeviceCoordinator::transferRosterTo(const uint8_t* newHeadMac) {
+    if (chainRoster.empty() || headTransferChannel == nullptr) return;
+    HeadTransferPayload transfer{};
+    for (const auto& entry : chainRoster) {
+        if (transfer.memberCount >= kMaxChainMembers) break;  // roster is capped; belt only
+        memcpy(transfer.memberMacs[transfer.memberCount], entry.first.data(), 6);
+        transfer.memberCount++;
+    }
+    headTransferChannel->sendReliable(newHeadMac, transfer);
+    chainRoster.clear();
+    if (membershipChangeCallback) membershipChangeCallback();
+}
+
+void RemoteDeviceCoordinator::onConnectionAnnounce(const uint8_t* fromMac,
+                                                   const ConnectionAnnouncePayload& announce) {
+    // Only the head keeps a roster. A stale announce reaching a demoted head is
+    // dropped; the member re-announces once the new head propagates via HELLO.
+    if ((chainHeadState.load() & HEAD_MAC_MASK) != 0) return;
+    std::array<uint8_t, 6> member;
+    std::array<uint8_t, 6> upstream;
+    memcpy(member.data(), fromMac, 6);
+    memcpy(upstream.data(), announce.upstreamMac, 6);
+    const bool isNew = chainRoster.count(member) == 0;
+    if (isNew && chainRoster.size() >= kMaxChainMembers) {
+        LOG_W("RDC", "chain roster full (%u); dropping announce", kMaxChainMembers);
+        return;
+    }
+    if (!isNew && chainRoster[member] == upstream) return;  // resend duplicate
+    chainRoster[member] = upstream;
+    if (membershipChangeCallback) membershipChangeCallback();
+}
+
+void RemoteDeviceCoordinator::onDisconnectReport(const DisconnectReportPayload& report) {
+    if ((chainHeadState.load() & HEAD_MAC_MASK) != 0) return;
+    removeChainMemberSubtree(report.disconnectedMac);
+}
+
+void RemoteDeviceCoordinator::onHeadTransfer(const uint8_t* fromMac,
+                                             const HeadTransferPayload& transfer) {
+    if ((chainHeadState.load() & HEAD_MAC_MASK) != 0) return;
+    // The demoted head now sits between this head and its old subtree, so it is
+    // every transferred member's effective upstream here; transitive removal then
+    // drops that subtree if the demoted head itself departs.
+    std::array<uint8_t, 6> upstream;
+    memcpy(upstream.data(), fromMac, 6);
+    const uint8_t count =
+        transfer.memberCount <= kMaxChainMembers ? transfer.memberCount : kMaxChainMembers;
+    bool changed = false;
+    for (uint8_t i = 0; i < count; ++i) {
+        std::array<uint8_t, 6> member;
+        memcpy(member.data(), transfer.memberMacs[i], 6);
+        if (memcmp(member.data(), selfMac_.data(), 6) == 0) continue;  // never roster self
+        const bool isNew = chainRoster.count(member) == 0;
+        if (isNew && chainRoster.size() >= kMaxChainMembers) break;
+        if (!isNew && chainRoster[member] == upstream) continue;
+        chainRoster[member] = upstream;
+        changed = true;
+    }
+    if (changed && membershipChangeCallback) membershipChangeCallback();
 }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -1131,8 +1131,11 @@ void RemoteDeviceCoordinator::releaseHeadPeer(uint64_t headMac48) {
             if (memcmp(m.data(), mac, 6) == 0) return;
         }
     }
-    // Roster retries to a departed head are dead traffic; drop them with the
-    // slot so a retransmit can't re-register it inside the driver.
+    // Past the keep-slot guards: the head truly departed (no adjacent link or
+    // daisy record still names it). Only on this actual-release path are its
+    // roster retries dead traffic; drop them with the slot so a retransmit can't
+    // re-register it inside the driver. When a keep-slot guard retained the slot
+    // above, the retries are left to self-heal (a seqId bump ignores late acks).
     if (connectionAnnounceChannel != nullptr) connectionAnnounceChannel->cancel(mac);
     if (disconnectReportChannel != nullptr) disconnectReportChannel->cancel(mac);
     if (headTransferChannel != nullptr) headTransferChannel->cancel(mac);
@@ -1226,8 +1229,9 @@ void RemoteDeviceCoordinator::sendDisconnectReport(const uint8_t* headMac,
 
 void RemoteDeviceCoordinator::removeChainMemberSubtree(const uint8_t* mac) {
     // Everything downstream of the departed MAC is unreachable too. Forks are
-    // impossible by construction (transfers carry true upstreams, announces
-    // evict stale claimants), so this walk is a list traversal that finds at
+    // impossible by construction (transfers skip a member whose upstream slot is
+    // already held via isUpstreamHeldByOther, announces evict stale claimants),
+    // so this walk is a list traversal that finds at
     // most one child per step by scanning — no reverse index kept. Tolerating
     // multiple children anyway is cheap defense. `gone` doubles as the frontier.
     std::vector<std::array<uint8_t, 6>> gone;
@@ -1277,12 +1281,15 @@ void RemoteDeviceCoordinator::onConnectionAnnounce(const uint8_t* fromMac,
     memcpy(member.data(), fromMac, 6);
     memcpy(upstream.data(), announce.upstreamMac, 6);
     const bool isNew = chainRoster.count(member) == 0;
+    if (!isNew && chainRoster[member] == upstream) return;  // resend duplicate
+    // Evict before the capacity check: a new member claiming an upstream a stale
+    // claimant still occupies would otherwise be dropped at a full roster even
+    // though eviction frees the slot. Re-read size after the eviction.
+    evictStaleUpstreamClaimant(member, upstream);
     if (isNew && chainRoster.size() >= MAX_CHAIN_MEMBERS) {
         LOG_W("RDC", "chain roster full (%u); dropping announce", MAX_CHAIN_MEMBERS);
         return;
     }
-    if (!isNew && chainRoster[member] == upstream) return;  // resend duplicate
-    evictStaleUpstreamClaimant(member, upstream);
     chainRoster[member] = upstream;
     if (membershipChangeCallback) membershipChangeCallback();
 }
@@ -1305,7 +1312,7 @@ void RemoteDeviceCoordinator::evictStaleUpstreamClaimant(
     }
 }
 
-bool RemoteDeviceCoordinator::upstreamHeldByOther(
+bool RemoteDeviceCoordinator::isUpstreamHeldByOther(
     const std::array<uint8_t, 6>& upstream, const std::array<uint8_t, 6>& member) const {
     for (const auto& entry : chainRoster) {
         if (entry.second == upstream && entry.first != member) return true;
@@ -1366,7 +1373,7 @@ void RemoteDeviceCoordinator::onHeadTransfer(const uint8_t* /*fromMac*/,
         memcpy(upstream.data(), transfer.upstreamMacs[i], 6);
         if (memcmp(member.data(), selfMac.data(), 6) == 0) continue;  // never roster self
         if (chainRoster.count(member) != 0) continue;
-        if (upstreamHeldByOther(upstream, member)) continue;
+        if (isUpstreamHeldByOther(upstream, member)) continue;
         if (chainRoster.size() >= MAX_CHAIN_MEMBERS) break;
         chainRoster[member] = upstream;
         changed = true;

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -1094,7 +1094,7 @@ void RemoteDeviceCoordinator::releaseHeadPeer(uint64_t headMac48) {
     // Same keep-slot guards as releaseHelloPeer: an adjacent link or a daisy
     // record still using this MAC keeps the radio slot alive.
     for (SerialIdentifier port : HELLO_JACKS) {
-        const HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+        const HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
         if (machine == nullptr || machine->currentStateId() == HELLO_LINK_IDLE) continue;
         if (memcmp(machine->peer().data(), mac, 6) == 0) return;
     }
@@ -1148,7 +1148,7 @@ void RemoteDeviceCoordinator::maybeAnnounceToHead() {
     // latched ring, which stores no head). Nothing to announce, no self-sends.
     if (headMac48 == 0) return;
     const HelloLinkMachine* upstream =
-        helloByPort_[portIndex(SerialIdentifier::INPUT_JACK)].machine;
+        helloByPort[portIndex(SerialIdentifier::INPUT_JACK)].machine;
     if (upstream == nullptr) return;
     // The announce names the upstream neighbour, so it is only meaningful once
     // the upstream exchange completed (#144 ordering: announce, then confirmed).
@@ -1250,7 +1250,7 @@ void RemoteDeviceCoordinator::onDisconnectReport(const DisconnectReportPayload& 
     // Trust boundary: no report may name this device. A member that lost the
     // link to its own head sends nothing, so a self-referential report is
     // bogus — and honoring it would erase the whole roster via the subtree walk.
-    if (memcmp(report.disconnectedMac, selfMac_.data(), 6) == 0) return;
+    if (memcmp(report.disconnectedMac, selfMac.data(), 6) == 0) return;
     if (!isRosterAuthority()) {
         // Head propagation is hop-by-hop, so a just-demoted head can still be
         // addressed under the old regime. Unlike the announce path there is no
@@ -1283,7 +1283,7 @@ void RemoteDeviceCoordinator::onHeadTransfer(const uint8_t* fromMac,
     for (uint8_t i = 0; i < count; ++i) {
         std::array<uint8_t, 6> member;
         memcpy(member.data(), transfer.memberMacs[i], 6);
-        if (memcmp(member.data(), selfMac_.data(), 6) == 0) continue;  // never roster self
+        if (memcmp(member.data(), selfMac.data(), 6) == 0) continue;  // never roster self
         if (chainRoster.count(member) != 0) continue;
         if (chainRoster.size() >= kMaxChainMembers) break;
         chainRoster[member] = upstream;

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -1213,9 +1213,9 @@ void RemoteDeviceCoordinator::transferRosterTo(const uint8_t* newHeadMac) {
     if (chainRoster.empty() || headTransferChannel == nullptr) return;
     HeadTransferPayload transfer{};
     for (const auto& entry : chainRoster) {
-        // Cannot trip while both insert paths cap at kMaxChainMembers; kept as
+        // Cannot trip while both insert paths cap at MAX_CHAIN_MEMBERS; kept as
         // the payload array's hard bound.
-        if (transfer.memberCount >= kMaxChainMembers) break;
+        if (transfer.memberCount >= MAX_CHAIN_MEMBERS) break;
         memcpy(transfer.memberMacs[transfer.memberCount], entry.first.data(), 6);
         transfer.memberCount++;
     }
@@ -1237,8 +1237,8 @@ void RemoteDeviceCoordinator::onConnectionAnnounce(const uint8_t* fromMac,
     memcpy(member.data(), fromMac, 6);
     memcpy(upstream.data(), announce.upstreamMac, 6);
     const bool isNew = chainRoster.count(member) == 0;
-    if (isNew && chainRoster.size() >= kMaxChainMembers) {
-        LOG_W("RDC", "chain roster full (%u); dropping announce", kMaxChainMembers);
+    if (isNew && chainRoster.size() >= MAX_CHAIN_MEMBERS) {
+        LOG_W("RDC", "chain roster full (%u); dropping announce", MAX_CHAIN_MEMBERS);
         return;
     }
     if (!isNew && chainRoster[member] == upstream) return;  // resend duplicate
@@ -1278,14 +1278,14 @@ void RemoteDeviceCoordinator::onHeadTransfer(const uint8_t* fromMac,
     std::array<uint8_t, 6> upstream;
     memcpy(upstream.data(), fromMac, 6);
     const uint8_t count =
-        transfer.memberCount <= kMaxChainMembers ? transfer.memberCount : kMaxChainMembers;
+        transfer.memberCount <= MAX_CHAIN_MEMBERS ? transfer.memberCount : MAX_CHAIN_MEMBERS;
     bool changed = false;
     for (uint8_t i = 0; i < count; ++i) {
         std::array<uint8_t, 6> member;
         memcpy(member.data(), transfer.memberMacs[i], 6);
         if (memcmp(member.data(), selfMac.data(), 6) == 0) continue;  // never roster self
         if (chainRoster.count(member) != 0) continue;
-        if (chainRoster.size() >= kMaxChainMembers) break;
+        if (chainRoster.size() >= MAX_CHAIN_MEMBERS) break;
         chainRoster[member] = upstream;
         changed = true;
     }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -183,13 +183,22 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
             chainHeadState.store(head | CONFIRMED_BIT);
         });
     }
+    // KEEP_DISTINCT: each report is a distinct event, not current state. A
+    // demoted device routinely forwards two children's reports to the same head
+    // in one tick; per-target supersede would erase the first one's retry slot.
     disconnectReportChannel = transport->channel<DisconnectReportPayload>(
-        PktType::kDisconnectReport);
+        PktType::kDisconnectReport, {}, Resender::SendMode::KEEP_DISTINCT);
     if (disconnectReportChannel != nullptr) {
         disconnectReportChannel->onReceive(
-            [this](const uint8_t*, const DisconnectReportPayload& report) {
-                onDisconnectReport(report);
+            [this](const uint8_t* fromMac, const DisconnectReportPayload& report) {
+                onDisconnectReport(fromMac, report);
             });
+        // Only the newest report is tracked for the head-change re-send; an
+        // older report's late delivery must not clear the newer pending one.
+        disconnectReportChannel->setOnDelivered([this](uint8_t seqId, const uint8_t*) {
+            if (seqId != pendingReportSeqId) return;
+            pendingReportMac.fill(0);
+        });
     }
     headTransferChannel = transport->channel<HeadTransferPayload>(
         PktType::kHeadTransfer);
@@ -922,14 +931,16 @@ void RemoteDeviceCoordinator::releaseHelloPeer(SerialIdentifier jack, const uint
             if (memcmp(m.data(), mac, 6) == 0) return;
         }
     }
+    // A peer past the other-jack scan has left this jack entirely, so its
+    // context retries are dead regardless of whether the slot survives below: a
+    // retransmit re-registers its target inside the driver (EnsurePeerIsRegistered),
+    // which would re-add a released slot and leak it. cancel() is silent — no
+    // abandon callback fires.
+    if (pdnContextChannel != nullptr) pdnContextChannel->cancel(mac);
+    if (fdnContextChannel != nullptr) fdnContextChannel->cancel(mac);
     // The held head keeps its slot: it stays the roster unicast target even
     // when it is no longer adjacent (adjacency is what just ended here).
     if ((chainHeadState.load() & HEAD_MAC_MASK) == MacToUInt64(mac)) return;
-    // Drop the context retries with the slot: a retransmit re-registers its target
-    // inside the driver (EnsurePeerIsRegistered), which would re-add the slot just
-    // removed and leak it. cancel() is silent — no abandon callback fires.
-    if (pdnContextChannel != nullptr) pdnContextChannel->cancel(mac);
-    if (fdnContextChannel != nullptr) fdnContextChannel->cancel(mac);
     unregisterPeer(mac);
 }
 
@@ -1066,6 +1077,13 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     // confirmed can rise again.
     transferRosterTo(peerEffectiveHead);
     maybeAnnounceToHead();
+    // releaseHeadPeer below cancels the report channel to the old head, and
+    // nothing else re-triggers a report (the announce path re-announces, the
+    // report path has no equivalent), so an undelivered report must chase the
+    // successor head or its member stays a phantom in that roster.
+    if (MacToUInt64(pendingReportMac.data()) != 0) {
+        sendDisconnectReport(peerEffectiveHead, pendingReportMac.data());
+    }
     releaseHeadPeer(previousHead);
 }
 
@@ -1177,15 +1195,22 @@ void RemoteDeviceCoordinator::reportDownstreamLoss(const uint8_t* lostMac) {
         return;
     }
     // Losing the cable to our own head (a ring's closing link) strands nobody:
-    // every member is still chained beneath the head, and a report naming the
-    // head's own MAC would make it prune its entire roster.
+    // every member is still chained beneath the head. Suppressing the
+    // head-naming report here is the outer of two guards — it avoids dead
+    // traffic; the head's own self-report reject is the trust boundary.
     if (headMac48 == MacToUInt64(lostMac)) return;
-    if (disconnectReportChannel == nullptr) return;
     uint8_t headMac[6];
     unpackMac(headMac48, headMac);
+    sendDisconnectReport(headMac, lostMac);
+}
+
+void RemoteDeviceCoordinator::sendDisconnectReport(const uint8_t* headMac,
+                                                   const uint8_t* lostMac) {
+    if (disconnectReportChannel == nullptr) return;
     DisconnectReportPayload report{};
     memcpy(report.disconnectedMac, lostMac, 6);
-    disconnectReportChannel->sendReliable(headMac, report);
+    pendingReportSeqId = disconnectReportChannel->sendReliable(headMac, report);
+    memcpy(pendingReportMac.data(), lostMac, 6);
 }
 
 void RemoteDeviceCoordinator::removeChainMemberSubtree(const uint8_t* mac) {
@@ -1246,22 +1271,25 @@ void RemoteDeviceCoordinator::onConnectionAnnounce(const uint8_t* fromMac,
     if (membershipChangeCallback) membershipChangeCallback();
 }
 
-void RemoteDeviceCoordinator::onDisconnectReport(const DisconnectReportPayload& report) {
+void RemoteDeviceCoordinator::onDisconnectReport(const uint8_t* fromMac,
+                                                 const DisconnectReportPayload& report) {
     // Trust boundary: no report may name this device. A member that lost the
     // link to its own head sends nothing, so a self-referential report is
     // bogus — and honoring it would erase the whole roster via the subtree walk.
     if (memcmp(report.disconnectedMac, selfMac.data(), 6) == 0) return;
     if (!isRosterAuthority()) {
         // Head propagation is hop-by-hop, so a just-demoted head can still be
-        // addressed under the old regime. Unlike the announce path there is no
-        // re-send on head change, so forward the edit to the head now held
-        // rather than dropping it.
+        // addressed under the old regime; forward the edit to the head now
+        // held rather than dropping it.
         const uint64_t headMac48 = chainHeadState.load() & HEAD_MAC_MASK;
-        if (headMac48 != 0 && disconnectReportChannel != nullptr) {
-            uint8_t headMac[6];
-            unpackMac(headMac48, headMac);
-            disconnectReportChannel->sendReliable(headMac, report);
-        }
+        // Never forward a report back to the device it arrived from: during a
+        // head transient two mutually-stale non-authorities can each hold the
+        // other as head and bounce the report between them, and with
+        // KEEP_DISTINCT every hop would pile up a fresh pending retry entry.
+        if (headMac48 == 0 || headMac48 == MacToUInt64(fromMac)) return;
+        uint8_t headMac[6];
+        unpackMac(headMac48, headMac);
+        sendDisconnectReport(headMac, report.disconnectedMac);
         return;
     }
     removeChainMemberSubtree(report.disconnectedMac);

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -1213,8 +1213,11 @@ void RemoteDeviceCoordinator::sendDisconnectReport(const uint8_t* headMac,
 }
 
 void RemoteDeviceCoordinator::removeChainMemberSubtree(const uint8_t* mac) {
-    // Everything downstream of the departed MAC is unreachable too: walk the
-    // upstream links to a fixpoint. `gone` doubles as the BFS frontier.
+    // Everything downstream of the departed MAC is unreachable too. Forks are
+    // impossible by construction (transfers carry true upstreams, announces
+    // evict stale claimants), so this walk is a list traversal that finds at
+    // most one child per step by scanning — no reverse index kept. Tolerating
+    // multiple children anyway is cheap defense. `gone` doubles as the frontier.
     std::vector<std::array<uint8_t, 6>> gone;
     gone.emplace_back();
     memcpy(gone.back().data(), mac, 6);
@@ -1241,6 +1244,7 @@ void RemoteDeviceCoordinator::transferRosterTo(const uint8_t* newHeadMac) {
         // array regardless.
         if (transfer.memberCount >= MAX_CHAIN_MEMBERS) break;
         memcpy(transfer.memberMacs[transfer.memberCount], entry.first.data(), 6);
+        memcpy(transfer.upstreamMacs[transfer.memberCount], entry.second.data(), 6);
         transfer.memberCount++;
     }
     headTransferChannel->sendReliable(newHeadMac, transfer);
@@ -1266,8 +1270,35 @@ void RemoteDeviceCoordinator::onConnectionAnnounce(const uint8_t* fromMac,
         return;
     }
     if (!isNew && chainRoster[member] == upstream) return;  // resend duplicate
+    evictStaleUpstreamClaimant(member, upstream);
     chainRoster[member] = upstream;
     if (membershipChangeCallback) membershipChangeCallback();
+}
+
+void RemoteDeviceCoordinator::evictStaleUpstreamClaimant(
+    const std::array<uint8_t, 6>& member, const std::array<uint8_t, 6>& upstream) {
+    // Hardware invariant: one OUTPUT jack means one downstream, so at most one
+    // member can hang off any upstream. A fresh announce claiming an upstream
+    // some OTHER member already recorded proves the old claimant unplugged
+    // (its departure report may still be in flight); drop it and its subtree.
+    // Only announces evict — a head-transfer snapshot is older than any
+    // announce and must not displace one.
+    for (const auto& entry : chainRoster) {
+        // entry.first == member guards self-eviction (wiping our own subtree);
+        // the caller's duplicate check makes it unreachable today, kept so the
+        // helper stays correct independent of caller ordering.
+        if (entry.second != upstream || entry.first == member) continue;
+        removeChainMemberSubtree(entry.first.data());
+        return;
+    }
+}
+
+bool RemoteDeviceCoordinator::upstreamHeldByOther(
+    const std::array<uint8_t, 6>& upstream, const std::array<uint8_t, 6>& member) const {
+    for (const auto& entry : chainRoster) {
+        if (entry.second == upstream && entry.first != member) return true;
+    }
+    return false;
 }
 
 void RemoteDeviceCoordinator::onDisconnectReport(const uint8_t* fromMac,
@@ -1297,16 +1328,9 @@ void RemoteDeviceCoordinator::onDisconnectReport(const uint8_t* fromMac,
     removeChainMemberSubtree(report.disconnectedMac);
 }
 
-void RemoteDeviceCoordinator::onHeadTransfer(const uint8_t* fromMac,
+void RemoteDeviceCoordinator::onHeadTransfer(const uint8_t* /*fromMac*/,
                                              const HeadTransferPayload& transfer) {
     if (!isRosterAuthority()) return;
-    // The demoted head now sits between this head and its old subtree, so it is
-    // the transferred members' effective upstream here; transitive removal then
-    // drops that subtree if the demoted head itself departs. Insert-only: an
-    // entry already present came from the member's own post-merge announce,
-    // which names its true upstream and must not be flattened onto fromMac.
-    std::array<uint8_t, 6> upstream;
-    memcpy(upstream.data(), fromMac, 6);
     if (transfer.memberCount > MAX_CHAIN_MEMBERS) {
         // Every sender caps at MAX_CHAIN_MEMBERS, so an oversized count means a
         // corrupt frame; the clamp bounds the array walk either way.
@@ -1315,12 +1339,22 @@ void RemoteDeviceCoordinator::onHeadTransfer(const uint8_t* fromMac,
     }
     const uint8_t count =
         transfer.memberCount <= MAX_CHAIN_MEMBERS ? transfer.memberCount : MAX_CHAIN_MEMBERS;
+    // Each pair carries the member's true recorded upstream, so the transferred
+    // chain keeps its order and a mid-chain departure prunes exactly its tail.
+    // A transfer snapshot is older than any announce, so it never displaces one:
+    // it is skipped when the member already exists, or when its upstream slot is
+    // already claimed by another member (a fresher announce that reached us
+    // first). That skip, paired with the announce-side eviction, keeps the
+    // one-downstream invariant true so a stale post-replug snapshot cannot fork.
     bool changed = false;
     for (uint8_t i = 0; i < count; ++i) {
         std::array<uint8_t, 6> member;
+        std::array<uint8_t, 6> upstream;
         memcpy(member.data(), transfer.memberMacs[i], 6);
+        memcpy(upstream.data(), transfer.upstreamMacs[i], 6);
         if (memcmp(member.data(), selfMac.data(), 6) == 0) continue;  // never roster self
         if (chainRoster.count(member) != 0) continue;
+        if (upstreamHeldByOther(upstream, member)) continue;
         if (chainRoster.size() >= MAX_CHAIN_MEMBERS) break;
         chainRoster[member] = upstream;
         changed = true;

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -1054,8 +1054,9 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
         const uint64_t formingHead = chainHeadState.load() & HEAD_MAC_MASK;
         chainHeadState.store(0);
         // A downstream-loss report is owed only while we remain a child under a
-        // head; becoming our own head voids it, so drop the pending re-send state
-        // before releaseHeadPeer silently cancels the in-flight report.
+        // head. Becoming our own head voids it: clear the pending re-send state so
+        // a later head adoption (applyUpstreamHead's successor-chase) cannot ship
+        // this stale report to an unrelated new head and prune a live member.
         pendingReportMac.fill(0);
         pendingReportSeqId = 0;
         releaseHeadPeer(formingHead);
@@ -1107,8 +1108,9 @@ void RemoteDeviceCoordinator::onLinkLost(SerialIdentifier port) {
         const uint64_t lostHead = chainHeadState.load() & HEAD_MAC_MASK;
         chainHeadState.store(0);
         // A downstream-loss report is owed only while we remain a child under a
-        // head; becoming our own head voids it, so drop the pending re-send state
-        // before releaseHeadPeer silently cancels the in-flight report.
+        // head. Becoming our own head voids it: clear the pending re-send state so
+        // a later head adoption (applyUpstreamHead's successor-chase) cannot ship
+        // this stale report to an unrelated new head and prune a live member.
         pendingReportMac.fill(0);
         pendingReportSeqId = 0;
         releaseHeadPeer(lostHead);
@@ -1222,9 +1224,9 @@ void RemoteDeviceCoordinator::sendDisconnectReport(const uint8_t* headMac,
     DisconnectReportPayload report{};
     memcpy(report.disconnectedMac, lostMac, 6);
     pendingReportSeqId = disconnectReportChannel->sendReliable(headMac, report);
-    // The successor-chase re-send passes pendingReportMac.data() back in as
-    // lostMac; skip the self-copy (overlapping memcpy is UB).
-    if (lostMac != pendingReportMac.data()) memcpy(pendingReportMac.data(), lostMac, 6);
+    // memmove, not memcpy: the successor-chase re-send passes pendingReportMac
+    // back in as lostMac, so source and destination alias on that path.
+    memmove(pendingReportMac.data(), lostMac, 6);
 }
 
 void RemoteDeviceCoordinator::removeChainMemberSubtree(const uint8_t* mac) {

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -1053,6 +1053,11 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
         // ring was forming, or we would sit in RING advertising a stale foreign head.
         const uint64_t formingHead = chainHeadState.load() & HEAD_MAC_MASK;
         chainHeadState.store(0);
+        // A downstream-loss report is owed only while we remain a child under a
+        // head; becoming our own head voids it, so drop the pending re-send state
+        // before releaseHeadPeer silently cancels the in-flight report.
+        pendingReportMac.fill(0);
+        pendingReportSeqId = 0;
         releaseHeadPeer(formingHead);
         if (ringClosedCallback) ringClosedCallback();
         return;
@@ -1101,6 +1106,11 @@ void RemoteDeviceCoordinator::onLinkLost(SerialIdentifier port) {
     if (port == SerialIdentifier::INPUT_JACK) {
         const uint64_t lostHead = chainHeadState.load() & HEAD_MAC_MASK;
         chainHeadState.store(0);
+        // A downstream-loss report is owed only while we remain a child under a
+        // head; becoming our own head voids it, so drop the pending re-send state
+        // before releaseHeadPeer silently cancels the in-flight report.
+        pendingReportMac.fill(0);
+        pendingReportSeqId = 0;
         releaseHeadPeer(lostHead);
     }
 }
@@ -1209,7 +1219,9 @@ void RemoteDeviceCoordinator::sendDisconnectReport(const uint8_t* headMac,
     DisconnectReportPayload report{};
     memcpy(report.disconnectedMac, lostMac, 6);
     pendingReportSeqId = disconnectReportChannel->sendReliable(headMac, report);
-    memcpy(pendingReportMac.data(), lostMac, 6);
+    // The successor-chase re-send passes pendingReportMac.data() back in as
+    // lostMac; skip the self-copy (overlapping memcpy is UB).
+    if (lostMac != pendingReportMac.data()) memcpy(pendingReportMac.data(), lostMac, 6);
 }
 
 void RemoteDeviceCoordinator::removeChainMemberSubtree(const uint8_t* mac) {

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -139,7 +139,7 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
     // HELLO deviceType is not consulted. RDC forwards the profile bytes opaquely.
     transport = new ReliableTransport(wirelessManager);
     pdnContextChannel = transport->channel<PdnConnectionContext>(
-        PktType::kPdnConnectionContext, [](uint8_t, const uint8_t*) {});
+        PktType::kPdnConnectionContext);
     if (pdnContextChannel != nullptr) {
         pdnContextChannel->onReceive(
             [this](const uint8_t* fromMac, const PdnConnectionContext& ctx) {
@@ -149,7 +149,7 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
             });
     }
     fdnContextChannel = transport->channel<FdnConnectionContext>(
-        PktType::kFdnConnectionContext, [](uint8_t, const uint8_t*) {});
+        PktType::kFdnConnectionContext);
     if (fdnContextChannel != nullptr) {
         fdnContextChannel->onReceive(
             [this](const uint8_t* fromMac, const FdnConnectionContext& ctx) {
@@ -164,16 +164,19 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
     // chain state changes and re-triggers the send — the accepted residual of the
     // no-ack design.
     connectionAnnounceChannel = transport->channel<ConnectionAnnouncePayload>(
-        PktType::kConnectionAnnounce, [](uint8_t, const uint8_t*) {});
+        PktType::kConnectionAnnounce);
     if (connectionAnnounceChannel != nullptr) {
         connectionAnnounceChannel->onReceive(
             [this](const uint8_t* fromMac, const ConnectionAnnouncePayload& announce) {
                 onConnectionAnnounce(fromMac, announce);
             });
         // SEND_SUCCESS on the announce IS its delivery signal (#144): only then
-        // may the HELLO confirmed bit rise — and only if the head it was sent to
-        // is still the head this device holds.
-        connectionAnnounceChannel->setOnDelivered([this](uint8_t, const uint8_t* toMac) {
+        // may the HELLO confirmed bit rise. A head change mid-flight makes an
+        // older announce's delivery stale — the re-announce to the current head
+        // is what gates confirmed — so both the seqId and the destination must
+        // still match the announce most recently sent.
+        connectionAnnounceChannel->setOnDelivered([this](uint8_t seqId, const uint8_t* toMac) {
+            if (seqId != pendingAnnounceSeqId) return;
             const uint64_t head = chainHeadState.load();
             const uint64_t headMac48 = head & HEAD_MAC_MASK;
             if (headMac48 == 0 || headMac48 != MacToUInt64(toMac)) return;
@@ -181,7 +184,7 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
         });
     }
     disconnectReportChannel = transport->channel<DisconnectReportPayload>(
-        PktType::kDisconnectReport, [](uint8_t, const uint8_t*) {});
+        PktType::kDisconnectReport);
     if (disconnectReportChannel != nullptr) {
         disconnectReportChannel->onReceive(
             [this](const uint8_t*, const DisconnectReportPayload& report) {
@@ -189,7 +192,7 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
             });
     }
     headTransferChannel = transport->channel<HeadTransferPayload>(
-        PktType::kHeadTransfer, [](uint8_t, const uint8_t*) {});
+        PktType::kHeadTransfer);
     if (headTransferChannel != nullptr) {
         headTransferChannel->onReceive(
             [this](const uint8_t* fromMac, const HeadTransferPayload& transfer) {
@@ -852,8 +855,7 @@ void RemoteDeviceCoordinator::completeJackContext(SerialIdentifier jack, DeviceT
     helloByPort[portIndex(jack)].peerChainRole = chainRole;
     if (contextReceivedCallback) contextReceivedCallback(jack, peerType, profile, len);
     onContextExchangeComplete(jack);
-    // The upstream exchange completing is the join moment: announce to the head
-    // (#158). The head itself carries no upstream head, so this no-ops there.
+    // The upstream exchange completing is the join moment: announce to the head (#158).
     if (jack == SerialIdentifier::INPUT_JACK) maybeAnnounceToHead();
 }
 
@@ -920,6 +922,9 @@ void RemoteDeviceCoordinator::releaseHelloPeer(SerialIdentifier jack, const uint
             if (memcmp(m.data(), mac, 6) == 0) return;
         }
     }
+    // The held head keeps its slot: it stays the roster unicast target even
+    // when it is no longer adjacent (adjacency is what just ended here).
+    if ((chainHeadState.load() & HEAD_MAC_MASK) == MacToUInt64(mac)) return;
     // Drop the context retries with the slot: a retransmit re-registers its target
     // inside the driver (EnsurePeerIsRegistered), which would re-add the slot just
     // removed and leak it. cancel() is silent — no abandon callback fires.
@@ -1035,7 +1040,9 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
         lastSelfHeadReturnMs = nowMs();
         // Our own MAC came back, so we ARE the head: drop any head adopted while the
         // ring was forming, or we would sit in RING advertising a stale foreign head.
+        const uint64_t formingHead = chainHeadState.load() & HEAD_MAC_MASK;
         chainHeadState.store(0);
+        releaseHeadPeer(formingHead);
         if (ringClosedCallback) ringClosedCallback();
         return;
     }
@@ -1044,8 +1051,13 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     // encodes as an absent head_mac); the ring case above already handled it.
     if (peerHeadIsSelf) return;
 
-    if ((chainHeadState.load() & HEAD_MAC_MASK) == MacToUInt64(peerEffectiveHead)) return;
+    const uint64_t previousHead = chainHeadState.load() & HEAD_MAC_MASK;
+    if (previousHead == MacToUInt64(peerEffectiveHead)) return;
 
+    // The head is a unicast target (announce/report/transfer) that is usually
+    // not an adjacent HELLO peer, so its radio slot is managed here: claim the
+    // successor's before any send below, drop the predecessor's after.
+    registerPeer(peerEffectiveHead);
     // Adopt the upstream head, dropping to confirmed=0 until re-confirmed under
     // it. The new head then propagates in our own HELLO.
     chainHeadState.store(packHead(peerEffectiveHead, false));
@@ -1054,6 +1066,7 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     // confirmed can rise again.
     transferRosterTo(peerEffectiveHead);
     maybeAnnounceToHead();
+    releaseHeadPeer(previousHead);
 }
 
 void RemoteDeviceCoordinator::onLinkLost(SerialIdentifier port) {
@@ -1068,8 +1081,34 @@ void RemoteDeviceCoordinator::onLinkLost(SerialIdentifier port) {
     // Only the upstream (INPUT) peer supplies the inherited head; its loss makes
     // this device its own head again.
     if (port == SerialIdentifier::INPUT_JACK) {
+        const uint64_t lostHead = chainHeadState.load() & HEAD_MAC_MASK;
         chainHeadState.store(0);
+        releaseHeadPeer(lostHead);
     }
+}
+
+void RemoteDeviceCoordinator::releaseHeadPeer(uint64_t headMac48) {
+    if (headMac48 == 0) return;
+    uint8_t mac[6];
+    unpackMac(headMac48, mac);
+    // Same keep-slot guards as releaseHelloPeer: an adjacent link or a daisy
+    // record still using this MAC keeps the radio slot alive.
+    for (SerialIdentifier port : HELLO_JACKS) {
+        const HelloLinkMachine* machine = helloByPort_[portIndex(port)].machine;
+        if (machine == nullptr || machine->currentStateId() == HELLO_LINK_IDLE) continue;
+        if (memcmp(machine->peer().data(), mac, 6) == 0) return;
+    }
+    for (const std::vector<std::array<uint8_t, 6>>& chain : daisyChainedByPort_) {
+        for (const std::array<uint8_t, 6>& m : chain) {
+            if (memcmp(m.data(), mac, 6) == 0) return;
+        }
+    }
+    // Roster retries to a departed head are dead traffic; drop them with the
+    // slot so a retransmit can't re-register it inside the driver.
+    if (connectionAnnounceChannel != nullptr) connectionAnnounceChannel->cancel(mac);
+    if (disconnectReportChannel != nullptr) disconnectReportChannel->cancel(mac);
+    if (headTransferChannel != nullptr) headTransferChannel->cancel(mac);
+    unregisterPeer(mac);
 }
 
 void RemoteDeviceCoordinator::maybeFireChainRoleChange() {
@@ -1080,6 +1119,16 @@ void RemoteDeviceCoordinator::maybeFireChainRoleChange() {
 }
 
 // ---- Head roster (#158) ----
+
+bool RemoteDeviceCoordinator::isRosterAuthority() const {
+    // Only the device currently heading a chain (or a latched ring, its own
+    // head) may edit a roster. Gating on role rather than "no head held"
+    // matters for STANDALONE: an ex-head keeps an all-zero head word after its
+    // chain dies, and late Resender retries from members would otherwise seed
+    // phantom entries that resurface the next time it heads a chain.
+    const ChainRole role = getChainRole();
+    return role == ChainRole::HEAD || role == ChainRole::RING;
+}
 
 std::vector<std::array<uint8_t, 6>> RemoteDeviceCoordinator::getChainMembers() const {
     // A RING device is its own head, so it serves its roster like a HEAD does.
@@ -1111,16 +1160,26 @@ void RemoteDeviceCoordinator::maybeAnnounceToHead() {
     unpackMac(headMac48, headMac);
     ConnectionAnnouncePayload announce{};
     memcpy(announce.upstreamMac, upstream->peer().data(), 6);
-    connectionAnnounceChannel->sendReliable(headMac, announce);
+    pendingAnnounceSeqId = connectionAnnounceChannel->sendReliable(headMac, announce);
 }
 
 void RemoteDeviceCoordinator::reportDownstreamLoss(const uint8_t* lostMac) {
     const uint64_t headMac48 = chainHeadState.load() & HEAD_MAC_MASK;
     if (headMac48 == 0) {
-        // This device is the head (incl. a latched ring): edit in place.
-        removeChainMemberSubtree(lostMac);
+        // This device is the head (incl. a latched ring) and its only OUTPUT
+        // link died, so the entire chain below is unreachable — not just
+        // lostMac's subtree. A full clear also flushes any entry whose recorded
+        // upstream path had gone gappy and a subtree walk would miss.
+        if (!chainRoster.empty()) {
+            chainRoster.clear();
+            if (membershipChangeCallback) membershipChangeCallback();
+        }
         return;
     }
+    // Losing the cable to our own head (a ring's closing link) strands nobody:
+    // every member is still chained beneath the head, and a report naming the
+    // head's own MAC would make it prune its entire roster.
+    if (headMac48 == MacToUInt64(lostMac)) return;
     if (disconnectReportChannel == nullptr) return;
     uint8_t headMac[6];
     unpackMac(headMac48, headMac);
@@ -1154,7 +1213,9 @@ void RemoteDeviceCoordinator::transferRosterTo(const uint8_t* newHeadMac) {
     if (chainRoster.empty() || headTransferChannel == nullptr) return;
     HeadTransferPayload transfer{};
     for (const auto& entry : chainRoster) {
-        if (transfer.memberCount >= kMaxChainMembers) break;  // roster is capped; belt only
+        // Cannot trip while both insert paths cap at kMaxChainMembers; kept as
+        // the payload array's hard bound.
+        if (transfer.memberCount >= kMaxChainMembers) break;
         memcpy(transfer.memberMacs[transfer.memberCount], entry.first.data(), 6);
         transfer.memberCount++;
     }
@@ -1165,9 +1226,12 @@ void RemoteDeviceCoordinator::transferRosterTo(const uint8_t* newHeadMac) {
 
 void RemoteDeviceCoordinator::onConnectionAnnounce(const uint8_t* fromMac,
                                                    const ConnectionAnnouncePayload& announce) {
-    // Only the head keeps a roster. A stale announce reaching a demoted head is
-    // dropped; the member re-announces once the new head propagates via HELLO.
-    if ((chainHeadState.load() & HEAD_MAC_MASK) != 0) return;
+    // Only the roster authority accepts announces; a stale one reaching a
+    // demoted head is dropped, and the member re-announces once the new head
+    // propagates via HELLO. An announce racing this head's own OUTPUT
+    // Connected commit is dropped too — the same accepted residual class as a
+    // lost radio frame, healed by the member's next head change or replug.
+    if (!isRosterAuthority()) return;
     std::array<uint8_t, 6> member;
     std::array<uint8_t, 6> upstream;
     memcpy(member.data(), fromMac, 6);
@@ -1183,16 +1247,34 @@ void RemoteDeviceCoordinator::onConnectionAnnounce(const uint8_t* fromMac,
 }
 
 void RemoteDeviceCoordinator::onDisconnectReport(const DisconnectReportPayload& report) {
-    if ((chainHeadState.load() & HEAD_MAC_MASK) != 0) return;
+    // Trust boundary: no report may name this device. A member that lost the
+    // link to its own head sends nothing, so a self-referential report is
+    // bogus — and honoring it would erase the whole roster via the subtree walk.
+    if (memcmp(report.disconnectedMac, selfMac_.data(), 6) == 0) return;
+    if (!isRosterAuthority()) {
+        // Head propagation is hop-by-hop, so a just-demoted head can still be
+        // addressed under the old regime. Unlike the announce path there is no
+        // re-send on head change, so forward the edit to the head now held
+        // rather than dropping it.
+        const uint64_t headMac48 = chainHeadState.load() & HEAD_MAC_MASK;
+        if (headMac48 != 0 && disconnectReportChannel != nullptr) {
+            uint8_t headMac[6];
+            unpackMac(headMac48, headMac);
+            disconnectReportChannel->sendReliable(headMac, report);
+        }
+        return;
+    }
     removeChainMemberSubtree(report.disconnectedMac);
 }
 
 void RemoteDeviceCoordinator::onHeadTransfer(const uint8_t* fromMac,
                                              const HeadTransferPayload& transfer) {
-    if ((chainHeadState.load() & HEAD_MAC_MASK) != 0) return;
+    if (!isRosterAuthority()) return;
     // The demoted head now sits between this head and its old subtree, so it is
-    // every transferred member's effective upstream here; transitive removal then
-    // drops that subtree if the demoted head itself departs.
+    // the transferred members' effective upstream here; transitive removal then
+    // drops that subtree if the demoted head itself departs. Insert-only: an
+    // entry already present came from the member's own post-merge announce,
+    // which names its true upstream and must not be flattened onto fromMac.
     std::array<uint8_t, 6> upstream;
     memcpy(upstream.data(), fromMac, 6);
     const uint8_t count =
@@ -1202,9 +1284,8 @@ void RemoteDeviceCoordinator::onHeadTransfer(const uint8_t* fromMac,
         std::array<uint8_t, 6> member;
         memcpy(member.data(), transfer.memberMacs[i], 6);
         if (memcmp(member.data(), selfMac_.data(), 6) == 0) continue;  // never roster self
-        const bool isNew = chainRoster.count(member) == 0;
-        if (isNew && chainRoster.size() >= kMaxChainMembers) break;
-        if (!isNew && chainRoster[member] == upstream) continue;
+        if (chainRoster.count(member) != 0) continue;
+        if (chainRoster.size() >= kMaxChainMembers) break;
         chainRoster[member] = upstream;
         changed = true;
     }

--- a/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
+++ b/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
@@ -32,6 +32,13 @@ constexpr uint8_t PEER_BROADCAST_ADDR[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 constexpr size_t MAX_PKT_DATA_SIZE =
     std::numeric_limits<decltype(DataPktHdr::pktLen)>::max() - sizeof(DataPktHdr);
 
+// The head-roster handoff is the largest reliable payload and grows with
+// MAX_CHAIN_MEMBERS (#218 raises it). A cap bump that overflows this budget
+// must break the build here, not silently fail sendData at runtime.
+static_assert(sizeof(HeadTransferPayload) <= MAX_PKT_DATA_SIZE,
+              "HeadTransferPayload exceeds the reliable-payload budget; "
+              "lower MAX_CHAIN_MEMBERS or split the transfer across frames");
+
 //Singleton class that handles communication over ESP-NOW protocol.
 class EspNowManager : public PeerCommsDriverInterface
 {

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -2135,6 +2135,44 @@ inline void rdcAnnounceEvictsStaleUpstreamClaimant(RDCHelloTests* suite) {
     EXPECT_EQ(0, memcmp(members[0].data(), memberD, 6));
 }
 
+// At a full roster, a new member announcing an upstream a stale claimant still
+// holds must be admitted: eviction runs before the capacity check, so freeing
+// the stale slot lets the fresh claim land instead of being dropped as full.
+inline void rdcFullRosterEvictsStaleThenAdmits(RDCHelloTests* suite) {
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    // Fill to capacity with a flat roster: member i hangs off its own distinct
+    // upstream, so no member is another's subtree.
+    uint8_t staleUpstream[6] = {0x80, 0x02, 0x03, 0x04, 0x05, 0x06};
+    uint8_t staleMember[6] = {0x30, 0x02, 0x03, 0x04, 0x05, 0x06};
+    for (uint8_t i = 0; i < MAX_CHAIN_MEMBERS; ++i) {
+        uint8_t member[6] = {static_cast<uint8_t>(0x30 + i), 0x02, 0x03, 0x04, 0x05, 0x06};
+        uint8_t upstream[6] = {static_cast<uint8_t>(0x80 + i), 0x02, 0x03, 0x04, 0x05, 0x06};
+        std::vector<uint8_t> a = announceBytes(upstream, 1);
+        suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, member, a.data(), a.size());
+    }
+    ASSERT_EQ(suite->rdc.getChainMembers().size(), static_cast<size_t>(MAX_CHAIN_MEMBERS));
+
+    // A new member claims the stale member's upstream at a full roster.
+    uint8_t newMember[6] = {0xFE, 0x02, 0x03, 0x04, 0x05, 0x06};
+    std::vector<uint8_t> a = announceBytes(staleUpstream, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, newMember, a.data(), a.size());
+
+    std::vector<std::array<uint8_t, 6>> members = suite->rdc.getChainMembers();
+    EXPECT_EQ(members.size(), static_cast<size_t>(MAX_CHAIN_MEMBERS));
+    bool hasNew = false;
+    bool hasStale = false;
+    for (const auto& m : members) {
+        if (memcmp(m.data(), newMember, 6) == 0) hasNew = true;
+        if (memcmp(m.data(), staleMember, 6) == 0) hasStale = true;
+    }
+    EXPECT_TRUE(hasNew);
+    EXPECT_FALSE(hasStale);
+}
+
 // A resend of the SAME member's announce (fresh seqId, same content) is not a
 // competing claim and must evict nobody.
 inline void rdcDuplicateReannounceDoesNotEvict(RDCHelloTests* suite) {
@@ -2164,7 +2202,7 @@ inline void rdcDuplicateReannounceDoesNotEvict(RDCHelloTests* suite) {
 // A stale head-transfer snapshot must not re-fork an upstream a fresher announce
 // already claimed: Y announces Y->b1, then a demoted head's older transfer lists
 // X->b1 (X absent). The transfer is skipped, so b1 keeps its one downstream and
-// the roster stays a list. Without the upstreamHeldByOther skip, X inserts and
+// the roster stays a list. Without the isUpstreamHeldByOther skip, X inserts and
 // b1 forks.
 inline void rdcStaleTransferDoesNotReforkClaimedUpstream(RDCHelloTests* suite) {
     const uint8_t b1[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -1606,6 +1606,273 @@ inline void rdcDemotedHeadTransfersRoster(RDCHelloTests* suite) {
     EXPECT_TRUE(suite->rdc.getChainMembers().empty());
 }
 
+// A ring's closing cable dying is the OUTPUT link to the device's own head;
+// reporting that "loss" would name the head itself, and the head's subtree walk
+// would then erase every member still physically chained beneath it.
+inline void rdcOutputLossOfOwnHeadSendsNoReport(RDCHelloTests* suite) {
+    const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture report;
+    captureSends(suite, PktType::kDisconnectReport, report);
+
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(upstream, head));
+    // The OUTPUT peer IS the head: this device closes the loop back to it.
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                chainHelloFrame(head, nullptr));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
+
+    // Only the closing cable dies; the upstream HELLO stays fresh.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, head));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+
+    EXPECT_EQ(report.count, 0);
+}
+
+// Belt at the trust boundary: an inbound report naming this device would wipe
+// the whole roster via the subtree walk, so it is dropped outright.
+inline void rdcHeadIgnoresSelfDisconnectReport(RDCHelloTests* suite) {
+    const uint8_t c1[6] = {0xC1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t c2[6] = {0xC2, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    int membershipChanges = 0;
+    suite->rdc.setOnMembershipChange([&]() { membershipChanges++; });
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    std::vector<uint8_t> a1 = announceBytes(suite->localMac, 1);
+    std::vector<uint8_t> a2 = announceBytes(c1, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, c1, a1.data(), a1.size());
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, c2, a2.data(), a2.size());
+    ASSERT_EQ(suite->rdc.getChainMembers().size(), 2u);
+    ASSERT_EQ(membershipChanges, 2);
+
+    std::vector<uint8_t> selfReport = disconnectReportBytes(suite->localMac, 1);
+    suite->transport()->deliverIncoming(PktType::kDisconnectReport, c1,
+                                        selfReport.data(), selfReport.size());
+    EXPECT_EQ(suite->rdc.getChainMembers().size(), 2u);
+    EXPECT_EQ(membershipChanges, 2);
+}
+
+// A member's own post-merge announce names its true upstream; a HeadTransfer
+// arriving later (reliable send, subject to backoff) must not flatten that
+// edge onto the demoted head, or the member gets pruned with the wrong subtree.
+inline void rdcHeadTransferDoesNotOverwriteAnnouncedUpstream(RDCHelloTests* suite) {
+    const uint8_t oldHead[6] = {0x77, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t member[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t b1[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    // The member's announce lands first, recording its true upstream (b1).
+    std::vector<uint8_t> a1 = announceBytes(b1, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, member, a1.data(), a1.size());
+    ASSERT_EQ(suite->rdc.getChainMembers().size(), 1u);
+
+    // The demoted head's transfer arrives late, listing the same member.
+    std::array<uint8_t, 6> m{};
+    memcpy(m.data(), member, 6);
+    std::vector<uint8_t> handoff = headTransferBytes({m}, 5);
+    suite->transport()->deliverIncoming(PktType::kHeadTransfer, oldHead,
+                                        handoff.data(), handoff.size());
+
+    // The demoted head departing must not take the member with it: the member's
+    // recorded upstream is still b1.
+    std::vector<uint8_t> report = disconnectReportBytes(oldHead, 1);
+    suite->transport()->deliverIncoming(PktType::kDisconnectReport, b1,
+                                        report.data(), report.size());
+    std::vector<std::array<uint8_t, 6>> members = suite->rdc.getChainMembers();
+    ASSERT_EQ(members.size(), 1u);
+    EXPECT_EQ(0, memcmp(members[0].data(), member, 6));
+}
+
+// Head propagation is hop-by-hop, so a report can be addressed to a device
+// that was just demoted; it forwards the edit to the head it now holds
+// instead of dropping it (the announce path self-heals on head change, the
+// report path has no equivalent retry).
+inline void rdcDemotedDeviceForwardsDisconnectReport(RDCHelloTests* suite) {
+    const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+    const uint8_t lost[6] = {0xD1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t reporter[6] = {0xC1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture forwarded;
+    captureSends(suite, PktType::kDisconnectReport, forwarded);
+
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(upstream, head));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
+
+    std::vector<uint8_t> report = disconnectReportBytes(lost, 1);
+    suite->transport()->deliverIncoming(PktType::kDisconnectReport, reporter,
+                                        report.data(), report.size());
+    ASSERT_EQ(forwarded.count, 1);
+    EXPECT_EQ(0, memcmp(forwarded.lastDst.data(), head, 6));
+    DisconnectReportPayload sent{};
+    ASSERT_EQ(forwarded.lastPayload.size(), sizeof(sent));
+    memcpy(&sent, forwarded.lastPayload.data(), sizeof(sent));
+    EXPECT_EQ(0, memcmp(sent.disconnectedMac, lost, 6));
+}
+
+// An ex-head is STANDALONE, not a roster authority: late Resender retries from
+// its dead chain must not seed entries that resurface when it heads again.
+inline void rdcStandaloneIgnoresLateRosterTraffic(RDCHelloTests* suite) {
+    const uint8_t m1[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t m2[6] = {0xA2, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t oldHead[6] = {0x77, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    int membershipChanges = 0;
+    suite->rdc.setOnMembershipChange([&]() { membershipChanges++; });
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::STANDALONE);
+
+    std::vector<uint8_t> late = announceBytes(oldHead, 3);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, m1, late.data(), late.size());
+    std::array<uint8_t, 6> m{};
+    memcpy(m.data(), m2, 6);
+    std::vector<uint8_t> handoff = headTransferBytes({m}, 4);
+    suite->transport()->deliverIncoming(PktType::kHeadTransfer, oldHead,
+                                        handoff.data(), handoff.size());
+    EXPECT_EQ(membershipChanges, 0);
+
+    // Heading a fresh chain later must start from an empty roster.
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+    EXPECT_TRUE(suite->rdc.getChainMembers().empty());
+}
+
+// A head losing its one OUTPUT link loses the entire chain, including members
+// whose recorded upstream path went gappy — a subtree walk from the direct
+// child alone would leave those behind as phantoms for the next chain.
+inline void rdcHeadDirectChildLossClearsWholeRoster(RDCHelloTests* suite) {
+    const uint8_t b1[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t gapped[6] = {0xD7, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t unknownUpstream[6] = {0xEE, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_)).Times(testing::AnyNumber());
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    std::vector<uint8_t> a1 = announceBytes(suite->localMac, 1);
+    std::vector<uint8_t> a2 = announceBytes(unknownUpstream, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, b1, a1.data(), a1.size());
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, gapped, a2.data(), a2.size());
+    ASSERT_EQ(suite->rdc.getChainMembers().size(), 2u);
+
+    // The direct child's cable dies.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+
+    // Re-heading a chain must not resurface the gapped member.
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+    EXPECT_TRUE(suite->rdc.getChainMembers().empty());
+}
+
+// A late SEND_SUCCESS for a superseded announce (head flapped away and back,
+// so destination alone can't tell them apart) must not raise confirmed: only
+// the most recently sent announce's delivery counts.
+inline void rdcStaleAnnounceDeliveryDoesNotConfirm(RDCHelloTests* suite) {
+    const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t h1[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+    const uint8_t h2[6] = {0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture announce;
+    captureSends(suite, PktType::kConnectionAnnounce, announce);
+
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, h1));
+    suite->rdc.sync(&suite->device);
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, upstream, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(announce.count, 1);
+    std::vector<uint8_t> staleAnnounce = announce.lastPayload;
+
+    // Head flaps to h2 and back to h1: two more announces supersede the first.
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, h2));
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, h1));
+    ASSERT_EQ(announce.count, 3);
+
+    // The first announce's SEND_SUCCESS straggles in: same destination, stale seqId.
+    suite->transport()->onSendResult(PktType::kConnectionAnnounce, h1,
+                                     staleAnnounce.data(), staleAnnounce.size(), true);
+    suite->outJack.clearOutput();
+    suite->rdc.emitHello();
+    EXPECT_EQ(parseEmittedHello(suite->outJack.getOutput()).confirmed, 0);
+
+    suite->transport()->onSendResult(PktType::kConnectionAnnounce, h1,
+                                     announce.lastPayload.data(),
+                                     announce.lastPayload.size(), true);
+    suite->outJack.clearOutput();
+    suite->rdc.emitHello();
+    EXPECT_EQ(parseEmittedHello(suite->outJack.getOutput()).confirmed, 1);
+}
+
+// The held head is a unicast target that is usually not an adjacent HELLO
+// peer, so head adoption must claim its radio slot and a head change or link
+// loss must release it — without touching a head that is also the jack peer.
+inline void rdcHeadAdoptionManagesRadioSlot(RDCHelloTests* suite) {
+    const uint8_t peerIsHead[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+    const uint8_t newHead[6] = {0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5};
+
+    std::vector<std::array<uint8_t, 6>> added;
+    std::vector<std::array<uint8_t, 6>> removed;
+    ON_CALL(*suite->device.mockPeerComms, addEspNowPeer(_))
+        .WillByDefault(testing::DoAll(
+            testing::Invoke([&added](const uint8_t* mac) {
+                added.emplace_back();
+                memcpy(added.back().data(), mac, 6);
+            }),
+            Return(0)));
+    ON_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_))
+        .WillByDefault(testing::DoAll(
+            testing::Invoke([&removed](const uint8_t* mac) {
+                removed.emplace_back();
+                memcpy(removed.back().data(), mac, 6);
+            }),
+            Return(0)));
+    auto contains = [](const std::vector<std::array<uint8_t, 6>>& macs, const uint8_t* mac) {
+        for (const std::array<uint8_t, 6>& m : macs)
+            if (memcmp(m.data(), mac, 6) == 0) return true;
+        return false;
+    };
+
+    // The INPUT peer is itself the head: adjacent, slot claimed by the link.
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(peerIsHead, nullptr));
+    EXPECT_TRUE(contains(added, peerIsHead));
+
+    // The upstream re-advertises a farther head: claim it, keep the jack peer.
+    suite->deliverHello(suite->inJack, chainHelloFrame(peerIsHead, newHead));
+    EXPECT_TRUE(contains(added, newHead));
+    EXPECT_FALSE(contains(removed, peerIsHead));
+
+    // The link dies: the jack peer's slot and the held head's slot both go.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->rdc.sync(&suite->device);
+    EXPECT_TRUE(contains(removed, peerIsHead));
+    EXPECT_TRUE(contains(removed, newHead));
+}
+
 // Receiving a transfer merges the members under the demoted head as their
 // effective upstream, so a later loss of the demoted head prunes that subtree.
 inline void rdcHeadTransferReceiveMergesAndPrunes(RDCHelloTests* suite) {

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -1699,8 +1699,7 @@ inline void rdcHeadTransferDoesNotOverwriteAnnouncedUpstream(RDCHelloTests* suit
 
 // Head propagation is hop-by-hop, so a report can be addressed to a device
 // that was just demoted; it forwards the edit to the head it now holds
-// instead of dropping it (the announce path self-heals on head change, the
-// report path has no equivalent retry).
+// instead of dropping it.
 inline void rdcDemotedDeviceForwardsDisconnectReport(RDCHelloTests* suite) {
     const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
     const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
@@ -1871,6 +1870,137 @@ inline void rdcHeadAdoptionManagesRadioSlot(RDCHelloTests* suite) {
     suite->rdc.sync(&suite->device);
     EXPECT_TRUE(contains(removed, peerIsHead));
     EXPECT_TRUE(contains(removed, newHead));
+}
+
+// The held head keeping its radio slot must not keep the dead jack's context
+// retries: with the INPUT peer itself the held head, link death keeps the slot
+// in releaseHelloPeer, then onLinkLost unregisters it — a surviving context
+// retry would re-register the slot inside the driver and leak it permanently.
+inline void rdcInputHeadLinkDeathCancelsPendingContextSend(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_)).Times(testing::AnyNumber());
+
+    // The INPUT peer advertises no head, so it IS the head this device adopts.
+    suite->deliverHello(suite->inJack, chainHelloFrame(peer, nullptr));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+    ASSERT_TRUE(suite->rdc.isContextSendPending(peer));
+
+    // The exchange never completes (no SEND_SUCCESS); the link dies.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::CONTEXT_EXCHANGE_TIMEOUT_MS + 1);
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+
+    EXPECT_FALSE(suite->rdc.isContextSendPending(peer));
+}
+
+// Reports are distinct events, not current state: two reports forwarded to the
+// same head back to back (routine when a demoted device relays two children's
+// reports in one tick) must EACH keep a retry slot, so both retransmit while
+// undelivered. A per-target supersede would erase the first report's slot.
+inline void rdcBackToBackReportsBothRetryToHead(RDCHelloTests* suite) {
+    const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+    const uint8_t lost1[6] = {0xD1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t lost2[6] = {0xD2, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t reporter1[6] = {0xC1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t reporter2[6] = {0xC2, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture forwarded;
+    captureSends(suite, PktType::kDisconnectReport, forwarded);
+
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(upstream, head));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
+
+    std::vector<uint8_t> r1 = disconnectReportBytes(lost1, 1);
+    std::vector<uint8_t> r2 = disconnectReportBytes(lost2, 1);
+    suite->transport()->deliverIncoming(PktType::kDisconnectReport, reporter1,
+                                        r1.data(), r1.size());
+    suite->transport()->deliverIncoming(PktType::kDisconnectReport, reporter2,
+                                        r2.data(), r2.size());
+    ASSERT_EQ(forwarded.count, 2);
+
+    // Neither delivery is confirmed; the next backoff tick must retransmit BOTH.
+    // Keep the upstream link alive across the advance: an INPUT silent-link
+    // would clear the head and cancel the very retries under test.
+    suite->fakeClock->advance(Resender::INITIAL_TIMEOUT_MS + 1);
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, head));
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(forwarded.count, 4);
+}
+
+// A head change cancels the in-flight report to the old head (releaseHeadPeer),
+// and nothing else re-sends it — unlike the announce path, which re-announces.
+// The pending report must follow the head: re-sent to the successor, and, once
+// delivered, never re-sent again on a later head change.
+inline void rdcPendingReportResentOnHeadChange(RDCHelloTests* suite) {
+    const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t h1[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+    const uint8_t h2[6] = {0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5};
+    const uint8_t h3[6] = {0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5};
+    const uint8_t downstream[6] = {0xD1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture report;
+    captureSends(suite, PktType::kDisconnectReport, report);
+
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(upstream, h1));
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                suite->helloFrame(0xD1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
+
+    // Downstream dies: report goes to h1, but its delivery is never confirmed.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, h1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(report.count, 1);
+    ASSERT_EQ(0, memcmp(report.lastDst.data(), h1, 6));
+
+    // Head changes to h2: the undelivered report must chase the successor.
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, h2));
+    ASSERT_EQ(report.count, 2);
+    EXPECT_EQ(0, memcmp(report.lastDst.data(), h2, 6));
+    DisconnectReportPayload resent{};
+    ASSERT_EQ(report.lastPayload.size(), sizeof(resent));
+    memcpy(&resent, report.lastPayload.data(), sizeof(resent));
+    EXPECT_EQ(0, memcmp(resent.disconnectedMac, downstream, 6));
+
+    // Delivery lands; a later head change must NOT re-send the settled report.
+    suite->transport()->onSendResult(PktType::kDisconnectReport, h2,
+                                     report.lastPayload.data(),
+                                     report.lastPayload.size(), true);
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, h3));
+    EXPECT_EQ(report.count, 2);
+}
+
+// During a head transient two mutually-stale non-authorities can each hold the
+// other as head; forwarding a report back to the device it arrived from would
+// bounce it between them, each hop accumulating a fresh pending retry entry.
+inline void rdcReportFromHeldHeadNotForwardedBack(RDCHelloTests* suite) {
+    const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+    const uint8_t lost[6] = {0xD1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture forwarded;
+    captureSends(suite, PktType::kDisconnectReport, forwarded);
+
+    // The INPUT peer advertises no head, so it IS the head this device holds.
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(head, nullptr));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
+
+    std::vector<uint8_t> report = disconnectReportBytes(lost, 1);
+    suite->transport()->deliverIncoming(PktType::kDisconnectReport, head,
+                                        report.data(), report.size());
+    EXPECT_EQ(forwarded.count, 0);
 }
 
 // Receiving a transfer merges the members under the demoted head as their

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -1354,7 +1354,7 @@ inline std::vector<uint8_t> headTransferBytes(const std::vector<std::array<uint8
     HeadTransferPayload payload{};
     payload.seqId = seqId;
     payload.memberCount = static_cast<uint8_t>(macs.size());
-    for (size_t i = 0; i < macs.size() && i < kMaxChainMembers; ++i) {
+    for (size_t i = 0; i < macs.size() && i < MAX_CHAIN_MEMBERS; ++i) {
         memcpy(payload.memberMacs[i], macs[i].data(), 6);
     }
     std::vector<uint8_t> bytes(sizeof(payload));

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -1307,3 +1307,333 @@ inline void rdcChainDualLatchSettlesByLowerMac() {
 
     SimpleTimer::setPlatformClock(nullptr);
 }
+
+// ============================================
+// Head roster management (#158)
+// ============================================
+
+// Records every send of one PktType: count, last destination, last payload.
+struct RosterSendCapture {
+    int count = 0;
+    std::array<uint8_t, 6> lastDst{};
+    std::vector<uint8_t> lastPayload;
+};
+
+inline void captureSends(RDCHelloTests* suite, PktType type, RosterSendCapture& capture) {
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, type, _, _))
+        .WillByDefault(testing::DoAll(
+            testing::Invoke(
+                [&capture](const uint8_t* dst, PktType, const uint8_t* data, size_t len) {
+                    capture.count++;
+                    memcpy(capture.lastDst.data(), dst, 6);
+                    capture.lastPayload.assign(data, data + len);
+                }),
+            Return(1)));
+}
+
+inline std::vector<uint8_t> announceBytes(const uint8_t* upstream, uint8_t seqId) {
+    ConnectionAnnouncePayload payload{};
+    payload.seqId = seqId;
+    memcpy(payload.upstreamMac, upstream, 6);
+    std::vector<uint8_t> bytes(sizeof(payload));
+    memcpy(bytes.data(), &payload, sizeof(payload));
+    return bytes;
+}
+
+inline std::vector<uint8_t> disconnectReportBytes(const uint8_t* mac, uint8_t seqId) {
+    DisconnectReportPayload payload{};
+    payload.seqId = seqId;
+    memcpy(payload.disconnectedMac, mac, 6);
+    std::vector<uint8_t> bytes(sizeof(payload));
+    memcpy(bytes.data(), &payload, sizeof(payload));
+    return bytes;
+}
+
+inline std::vector<uint8_t> headTransferBytes(const std::vector<std::array<uint8_t, 6>>& macs,
+                                              uint8_t seqId) {
+    HeadTransferPayload payload{};
+    payload.seqId = seqId;
+    payload.memberCount = static_cast<uint8_t>(macs.size());
+    for (size_t i = 0; i < macs.size() && i < kMaxChainMembers; ++i) {
+        memcpy(payload.memberMacs[i], macs[i].data(), 6);
+    }
+    std::vector<uint8_t> bytes(sizeof(payload));
+    memcpy(bytes.data(), &payload, sizeof(payload));
+    return bytes;
+}
+
+// Join flow (#144 steps 3-6): the announce goes to the head only once the
+// upstream exchange completes, names the upstream neighbour, and the HELLO
+// confirmed bit stays 0 until the announce's SEND_SUCCESS lands.
+inline void rdcJoinAnnouncesToHeadAndGatesConfirmed(RDCHelloTests* suite) {
+    const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture announce;
+    captureSends(suite, PktType::kConnectionAnnounce, announce);
+
+    // Upstream HELLO arrives: head adopted, but the exchange is incomplete, so
+    // no announce yet.
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, head));
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(announce.count, 0);
+
+    // Upstream context lands: the join moment.
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, upstream, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(announce.count, 1);
+    EXPECT_EQ(0, memcmp(announce.lastDst.data(), head, 6));
+    ConnectionAnnouncePayload sent{};
+    ASSERT_EQ(announce.lastPayload.size(), sizeof(sent));
+    memcpy(&sent, announce.lastPayload.data(), sizeof(sent));
+    EXPECT_EQ(0, memcmp(sent.upstreamMac, upstream, 6));
+
+    // confirmed stays down until the announce is delivered.
+    suite->outJack.clearOutput();
+    suite->rdc.emitHello();
+    EXPECT_EQ(parseEmittedHello(suite->outJack.getOutput()).confirmed, 0);
+
+    suite->transport()->onSendResult(PktType::kConnectionAnnounce, head,
+                                     announce.lastPayload.data(),
+                                     announce.lastPayload.size(), true);
+    suite->outJack.clearOutput();
+    suite->rdc.emitHello();
+    EXPECT_EQ(parseEmittedHello(suite->outJack.getOutput()).confirmed, 1);
+}
+
+// A head change drops confirmed to 0 and re-announces to the new head; confirmed
+// rises again only on the new announce's delivery.
+inline void rdcHeadChangeDropsConfirmedAndReannounces(RDCHelloTests* suite) {
+    const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+    const uint8_t newHead[6] = {0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture announce;
+    captureSends(suite, PktType::kConnectionAnnounce, announce);
+
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, head));
+    suite->rdc.sync(&suite->device);
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, upstream, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(announce.count, 1);
+    suite->transport()->onSendResult(PktType::kConnectionAnnounce, head,
+                                     announce.lastPayload.data(),
+                                     announce.lastPayload.size(), true);
+    suite->outJack.clearOutput();
+    suite->rdc.emitHello();
+    ASSERT_EQ(parseEmittedHello(suite->outJack.getOutput()).confirmed, 1);
+
+    // The upstream now advertises a different head.
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, newHead));
+    ASSERT_EQ(announce.count, 2);
+    EXPECT_EQ(0, memcmp(announce.lastDst.data(), newHead, 6));
+    suite->outJack.clearOutput();
+    suite->rdc.emitHello();
+    EXPECT_EQ(parseEmittedHello(suite->outJack.getOutput()).confirmed, 0);
+
+    suite->transport()->onSendResult(PktType::kConnectionAnnounce, newHead,
+                                     announce.lastPayload.data(),
+                                     announce.lastPayload.size(), true);
+    suite->outJack.clearOutput();
+    suite->rdc.emitHello();
+    EXPECT_EQ(parseEmittedHello(suite->outJack.getOutput()).confirmed, 1);
+}
+
+// Head side: announces build the roster (member -> upstream), duplicates are
+// absorbed, and a disconnect report prunes the departed member AND everything
+// whose upstream chain passes through it.
+inline void rdcHeadBuildsAndPrunesRoster(RDCHelloTests* suite) {
+    const uint8_t c1[6] = {0xC1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t c2[6] = {0xC2, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t c3[6] = {0xC3, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    int membershipChanges = 0;
+    suite->rdc.setOnMembershipChange([&]() { membershipChanges++; });
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    // HEAD <- c1 <- c2 <- c3
+    std::vector<uint8_t> a1 = announceBytes(suite->localMac, 1);
+    std::vector<uint8_t> a2 = announceBytes(c1, 1);
+    std::vector<uint8_t> a3 = announceBytes(c2, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, c1, a1.data(), a1.size());
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, c2, a2.data(), a2.size());
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, c3, a3.data(), a3.size());
+    EXPECT_EQ(membershipChanges, 3);
+    EXPECT_EQ(suite->rdc.getChainMembers().size(), 3u);
+
+    // A re-announce with identical content is not a membership change.
+    std::vector<uint8_t> dup = announceBytes(c1, 2);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, c2, dup.data(), dup.size());
+    EXPECT_EQ(membershipChanges, 3);
+
+    // c2 departs: c3 hangs off c2, so both go.
+    std::vector<uint8_t> report = disconnectReportBytes(c2, 1);
+    suite->transport()->deliverIncoming(PktType::kDisconnectReport, c1, report.data(), report.size());
+    EXPECT_EQ(membershipChanges, 4);
+    std::vector<std::array<uint8_t, 6>> members = suite->rdc.getChainMembers();
+    ASSERT_EQ(members.size(), 1u);
+    EXPECT_EQ(0, memcmp(members[0].data(), c1, 6));
+}
+
+// A child reports a downstream (OUTPUT) departure to its head — and, not being
+// a head, ignores stray roster traffic addressed to it.
+inline void rdcChildReportsDownstreamLossToHead(RDCHelloTests* suite) {
+    const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+    const uint8_t downstream[6] = {0xD1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture report;
+    captureSends(suite, PktType::kDisconnectReport, report);
+    int membershipChanges = 0;
+    suite->rdc.setOnMembershipChange([&]() { membershipChanges++; });
+
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(upstream, head));
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                suite->helloFrame(0xD1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
+
+    // Not the head: an announce reaching this device must not grow a roster.
+    std::vector<uint8_t> stray = announceBytes(head, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, downstream,
+                                        stray.data(), stray.size());
+    EXPECT_EQ(membershipChanges, 0);
+    EXPECT_TRUE(suite->rdc.getChainMembers().empty());
+
+    // Only the downstream cable dies; the upstream HELLO stays fresh.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, head));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+
+    ASSERT_EQ(report.count, 1);
+    EXPECT_EQ(0, memcmp(report.lastDst.data(), head, 6));
+    DisconnectReportPayload sent{};
+    ASSERT_EQ(report.lastPayload.size(), sizeof(sent));
+    memcpy(&sent, report.lastPayload.data(), sizeof(sent));
+    EXPECT_EQ(0, memcmp(sent.disconnectedMac, downstream, 6));
+}
+
+// A latched ring device is its own head: it never announces to itself, and a
+// downstream loss edits its roster in place instead of sending a report.
+inline void rdcRingLatchedNeverAnnouncesOrReportsToSelf(RDCHelloTests* suite) {
+    const uint8_t lowNeighbour[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    const uint8_t downstream[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture announce;
+    RosterSendCapture report;
+    captureSends(suite, PktType::kConnectionAnnounce, announce);
+    captureSends(suite, PktType::kDisconnectReport, report);
+    int membershipChanges = 0;
+    suite->rdc.setOnMembershipChange([&]() { membershipChanges++; });
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    suite->deliverHello(suite->inJack, chainHelloFrame(lowNeighbour, suite->localMac));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::RING);
+
+    // The upstream exchange completing (the usual announce moment) must send
+    // nothing: this device holds no head above itself.
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/9);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, lowNeighbour, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(announce.count, 0);
+
+    // The ring's members announce to it like to any head.
+    std::vector<uint8_t> join = announceBytes(suite->localMac, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, downstream,
+                                        join.data(), join.size());
+    ASSERT_EQ(membershipChanges, 1);
+    EXPECT_EQ(suite->rdc.getChainMembers().size(), 1u);
+
+    // Downstream cable dies: roster edited in place, no packet to self.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->deliverHello(suite->inJack, chainHelloFrame(lowNeighbour, suite->localMac));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    EXPECT_EQ(report.count, 0);
+    EXPECT_EQ(membershipChanges, 2);
+}
+
+// Demotion: a head that adopts a new head above it hands its roster over in a
+// single unicast and clears it locally.
+inline void rdcDemotedHeadTransfersRoster(RDCHelloTests* suite) {
+    const uint8_t memberA[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t memberB[6] = {0xB2, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t newHead[6] = {0x11, 0x11, 0x11, 0x11, 0x11, 0x11};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture transfer;
+    captureSends(suite, PktType::kHeadTransfer, transfer);
+    int membershipChanges = 0;
+    suite->rdc.setOnMembershipChange([&]() { membershipChanges++; });
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+    std::vector<uint8_t> a1 = announceBytes(suite->localMac, 1);
+    std::vector<uint8_t> a2 = announceBytes(memberA, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, memberA, a1.data(), a1.size());
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, memberB, a2.data(), a2.size());
+    ASSERT_EQ(suite->rdc.getChainMembers().size(), 2u);
+    ASSERT_EQ(membershipChanges, 2);
+
+    // A standalone head plugs in above: its HELLO makes it our effective head.
+    suite->deliverHello(suite->inJack, chainHelloFrame(newHead, nullptr));
+
+    ASSERT_EQ(transfer.count, 1);
+    EXPECT_EQ(0, memcmp(transfer.lastDst.data(), newHead, 6));
+    HeadTransferPayload sent{};
+    ASSERT_EQ(transfer.lastPayload.size(), sizeof(sent));
+    memcpy(&sent, transfer.lastPayload.data(), sizeof(sent));
+    ASSERT_EQ(sent.memberCount, 2);
+    // Map order is byte-lexicographic: memberA (0xA1...) precedes memberB (0xB2...).
+    EXPECT_EQ(0, memcmp(sent.memberMacs[0], memberA, 6));
+    EXPECT_EQ(0, memcmp(sent.memberMacs[1], memberB, 6));
+    EXPECT_EQ(membershipChanges, 3);
+    EXPECT_TRUE(suite->rdc.getChainMembers().empty());
+}
+
+// Receiving a transfer merges the members under the demoted head as their
+// effective upstream, so a later loss of the demoted head prunes that subtree.
+inline void rdcHeadTransferReceiveMergesAndPrunes(RDCHelloTests* suite) {
+    const uint8_t oldHead[6] = {0x77, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t memberA[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t memberB[6] = {0xB2, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    int membershipChanges = 0;
+    suite->rdc.setOnMembershipChange([&]() { membershipChanges++; });
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    std::array<uint8_t, 6> a{};
+    std::array<uint8_t, 6> b{};
+    memcpy(a.data(), memberA, 6);
+    memcpy(b.data(), memberB, 6);
+    std::vector<uint8_t> handoff = headTransferBytes({a, b}, 5);
+    suite->transport()->deliverIncoming(PktType::kHeadTransfer, oldHead,
+                                        handoff.data(), handoff.size());
+    EXPECT_EQ(membershipChanges, 1);
+    EXPECT_EQ(suite->rdc.getChainMembers().size(), 2u);
+
+    // The demoted head departs: its whole transferred subtree goes with it.
+    std::vector<uint8_t> report = disconnectReportBytes(oldHead, 1);
+    suite->transport()->deliverIncoming(PktType::kDisconnectReport, memberA,
+                                        report.data(), report.size());
+    EXPECT_EQ(membershipChanges, 2);
+    EXPECT_TRUE(suite->rdc.getChainMembers().empty());
+}

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -1992,6 +1992,50 @@ inline void rdcPendingReportResentOnHeadChange(RDCHelloTests* suite) {
     EXPECT_EQ(report.count, 2);
 }
 
+// A downstream-loss report is owed only while a child under a head. If the child
+// then loses its own INPUT link it becomes its own head, voiding the report;
+// adopting a fresh head later must NOT re-send the stale report to it (which
+// would prune a live member whose MAC got reused under the new head).
+inline void rdcPendingReportVoidedByBecomingHead(RDCHelloTests* suite) {
+    const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t h1[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+    const uint8_t upstream2[6] = {0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F};
+    const uint8_t h2[6] = {0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5};
+    const uint8_t downstream[6] = {0xD1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture report;
+    captureSends(suite, PktType::kDisconnectReport, report);
+
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(upstream, h1));
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK,
+                suite->helloFrame(0xD1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
+
+    // Downstream dies: report to h1, delivery never confirmed, so the report
+    // stays pending. Keep the INPUT link alive so only OUTPUT goes silent.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream, h1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(report.count, 1);
+    ASSERT_EQ(0, memcmp(report.lastDst.data(), h1, 6));
+
+    // INPUT link drops: this device becomes its own head, voiding the report.
+    // releaseHeadPeer cancels the h1 retries here, so the count settles; baseline
+    // it (a resender retransmit to h1 may have fired) to isolate the h2 re-send.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::STANDALONE);
+    const int baseline = report.count;
+
+    // Adopt a fresh head h2 via a new upstream: the voided report must not chase it.
+    suite->deliverHello(suite->inJack, chainHelloFrame(upstream2, h2));
+    EXPECT_EQ(report.count, baseline);
+    EXPECT_NE(0, memcmp(report.lastDst.data(), h2, 6));
+}
+
 // During a head transient two mutually-stale non-authorities can each hold the
 // other as head; forwarding a report back to the device it arrived from would
 // bounce it between them, each hop accumulating a fresh pending retry entry.

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -1607,8 +1607,8 @@ inline void rdcDemotedHeadTransfersRoster(RDCHelloTests* suite) {
 }
 
 // A ring's closing cable dying is the OUTPUT link to the device's own head;
-// reporting that "loss" would name the head itself, and the head's subtree walk
-// would then erase every member still physically chained beneath it.
+// reporting that "loss" would name the head itself. The head rejects such a
+// report at its trust boundary, so sending one would only be dead traffic.
 inline void rdcOutputLossOfOwnHeadSendsNoReport(RDCHelloTests* suite) {
     const uint8_t upstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
     const uint8_t head[6] = {0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -1349,13 +1349,16 @@ inline std::vector<uint8_t> disconnectReportBytes(const uint8_t* mac, uint8_t se
     return bytes;
 }
 
-inline std::vector<uint8_t> headTransferBytes(const std::vector<std::array<uint8_t, 6>>& macs,
-                                              uint8_t seqId) {
+// Each entry is a (member, upstream) pair mirroring the roster edge it carries.
+inline std::vector<uint8_t> headTransferBytes(
+    const std::vector<std::pair<std::array<uint8_t, 6>, std::array<uint8_t, 6>>>& entries,
+    uint8_t seqId) {
     HeadTransferPayload payload{};
     payload.seqId = seqId;
-    payload.memberCount = static_cast<uint8_t>(macs.size());
-    for (size_t i = 0; i < macs.size() && i < MAX_CHAIN_MEMBERS; ++i) {
-        memcpy(payload.memberMacs[i], macs[i].data(), 6);
+    payload.memberCount = static_cast<uint8_t>(entries.size());
+    for (size_t i = 0; i < entries.size() && i < MAX_CHAIN_MEMBERS; ++i) {
+        memcpy(payload.memberMacs[i], entries[i].first.data(), 6);
+        memcpy(payload.upstreamMacs[i], entries[i].second.data(), 6);
     }
     std::vector<uint8_t> bytes(sizeof(payload));
     memcpy(bytes.data(), &payload, sizeof(payload));
@@ -1602,6 +1605,9 @@ inline void rdcDemotedHeadTransfersRoster(RDCHelloTests* suite) {
     // Map order is byte-lexicographic: memberA (0xA1...) precedes memberB (0xB2...).
     EXPECT_EQ(0, memcmp(sent.memberMacs[0], memberA, 6));
     EXPECT_EQ(0, memcmp(sent.memberMacs[1], memberB, 6));
+    // Each member travels with its recorded upstream, preserving chain order.
+    EXPECT_EQ(0, memcmp(sent.upstreamMacs[0], suite->localMac, 6));
+    EXPECT_EQ(0, memcmp(sent.upstreamMacs[1], memberA, 6));
     EXPECT_EQ(membershipChanges, 3);
     EXPECT_TRUE(suite->rdc.getChainMembers().empty());
 }
@@ -1680,10 +1686,13 @@ inline void rdcHeadTransferDoesNotOverwriteAnnouncedUpstream(RDCHelloTests* suit
     suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, member, a1.data(), a1.size());
     ASSERT_EQ(suite->rdc.getChainMembers().size(), 1u);
 
-    // The demoted head's transfer arrives late, listing the same member.
+    // The demoted head's transfer arrives late, listing the same member under
+    // its stale pre-merge upstream (the demoted head itself).
     std::array<uint8_t, 6> m{};
+    std::array<uint8_t, 6> staleUpstream{};
     memcpy(m.data(), member, 6);
-    std::vector<uint8_t> handoff = headTransferBytes({m}, 5);
+    memcpy(staleUpstream.data(), oldHead, 6);
+    std::vector<uint8_t> handoff = headTransferBytes({{m, staleUpstream}}, 5);
     suite->transport()->deliverIncoming(PktType::kHeadTransfer, oldHead,
                                         handoff.data(), handoff.size());
 
@@ -1740,8 +1749,10 @@ inline void rdcStandaloneIgnoresLateRosterTraffic(RDCHelloTests* suite) {
     std::vector<uint8_t> late = announceBytes(oldHead, 3);
     suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, m1, late.data(), late.size());
     std::array<uint8_t, 6> m{};
+    std::array<uint8_t, 6> mUpstream{};
     memcpy(m.data(), m2, 6);
-    std::vector<uint8_t> handoff = headTransferBytes({m}, 4);
+    memcpy(mUpstream.data(), oldHead, 6);
+    std::vector<uint8_t> handoff = headTransferBytes({{m, mUpstream}}, 4);
     suite->transport()->deliverIncoming(PktType::kHeadTransfer, oldHead,
                                         handoff.data(), handoff.size());
     EXPECT_EQ(membershipChanges, 0);
@@ -2003,12 +2014,14 @@ inline void rdcReportFromHeldHeadNotForwardedBack(RDCHelloTests* suite) {
     EXPECT_EQ(forwarded.count, 0);
 }
 
-// Receiving a transfer merges the members under the demoted head as their
-// effective upstream, so a later loss of the demoted head prunes that subtree.
+// Receiving a transfer records each member under its TRUE upstream from the
+// payload, so a mid-chain transferred member departing prunes exactly its
+// downstream tail — not the whole transferred set, and not just itself.
 inline void rdcHeadTransferReceiveMergesAndPrunes(RDCHelloTests* suite) {
     const uint8_t oldHead[6] = {0x77, 0x02, 0x03, 0x04, 0x05, 0x06};
     const uint8_t memberA[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
     const uint8_t memberB[6] = {0xB2, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t memberC[6] = {0xC3, 0x02, 0x03, 0x04, 0x05, 0x06};
 
     EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
     int membershipChanges = 0;
@@ -2017,20 +2030,125 @@ inline void rdcHeadTransferReceiveMergesAndPrunes(RDCHelloTests* suite) {
     connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
     ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
 
+    // Transferred chain: oldHead <- A <- B <- C, each pair naming the true edge.
+    std::array<uint8_t, 6> old{};
     std::array<uint8_t, 6> a{};
     std::array<uint8_t, 6> b{};
+    std::array<uint8_t, 6> c{};
+    memcpy(old.data(), oldHead, 6);
     memcpy(a.data(), memberA, 6);
     memcpy(b.data(), memberB, 6);
-    std::vector<uint8_t> handoff = headTransferBytes({a, b}, 5);
+    memcpy(c.data(), memberC, 6);
+    std::vector<uint8_t> handoff = headTransferBytes({{a, old}, {b, a}, {c, b}}, 5);
     suite->transport()->deliverIncoming(PktType::kHeadTransfer, oldHead,
                                         handoff.data(), handoff.size());
     EXPECT_EQ(membershipChanges, 1);
-    EXPECT_EQ(suite->rdc.getChainMembers().size(), 2u);
+    EXPECT_EQ(suite->rdc.getChainMembers().size(), 3u);
 
-    // The demoted head departs: its whole transferred subtree goes with it.
-    std::vector<uint8_t> report = disconnectReportBytes(oldHead, 1);
+    // Mid-chain B departs: C hangs off B and goes too; A stays.
+    std::vector<uint8_t> report = disconnectReportBytes(memberB, 1);
     suite->transport()->deliverIncoming(PktType::kDisconnectReport, memberA,
                                         report.data(), report.size());
     EXPECT_EQ(membershipChanges, 2);
+    std::vector<std::array<uint8_t, 6>> members = suite->rdc.getChainMembers();
+    ASSERT_EQ(members.size(), 1u);
+    EXPECT_EQ(0, memcmp(members[0].data(), memberA, 6));
+
+    // The demoted head departs: the rest of its transferred subtree follows.
+    std::vector<uint8_t> headLoss = disconnectReportBytes(oldHead, 2);
+    suite->transport()->deliverIncoming(PktType::kDisconnectReport, memberA,
+                                        headLoss.data(), headLoss.size());
+    EXPECT_EQ(membershipChanges, 3);
     EXPECT_TRUE(suite->rdc.getChainMembers().empty());
+}
+
+// One OUTPUT jack means one downstream: a fresh announce claiming an upstream
+// another member already recorded evicts the stale claimant and its subtree.
+inline void rdcAnnounceEvictsStaleUpstreamClaimant(RDCHelloTests* suite) {
+    const uint8_t b1[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t memberC[6] = {0xC1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t memberD[6] = {0xD1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t memberE[6] = {0xE1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    // Roster: C hangs off b1, E hangs off C.
+    std::vector<uint8_t> a1 = announceBytes(b1, 1);
+    std::vector<uint8_t> a2 = announceBytes(memberC, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, memberC, a1.data(), a1.size());
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, memberE, a2.data(), a2.size());
+    ASSERT_EQ(suite->rdc.getChainMembers().size(), 2u);
+
+    // D now claims b1: C was unplugged (its report may still be in flight), so
+    // C and its subtree leave and D is the sole downstream of b1.
+    std::vector<uint8_t> a3 = announceBytes(b1, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, memberD, a3.data(), a3.size());
+    std::vector<std::array<uint8_t, 6>> members = suite->rdc.getChainMembers();
+    ASSERT_EQ(members.size(), 1u);
+    EXPECT_EQ(0, memcmp(members[0].data(), memberD, 6));
+}
+
+// A resend of the SAME member's announce (fresh seqId, same content) is not a
+// competing claim and must evict nobody.
+inline void rdcDuplicateReannounceDoesNotEvict(RDCHelloTests* suite) {
+    const uint8_t b1[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t memberC[6] = {0xC1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t memberE[6] = {0xE1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    int membershipChanges = 0;
+    suite->rdc.setOnMembershipChange([&]() { membershipChanges++; });
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    std::vector<uint8_t> a1 = announceBytes(b1, 1);
+    std::vector<uint8_t> a2 = announceBytes(memberC, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, memberC, a1.data(), a1.size());
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, memberE, a2.data(), a2.size());
+    ASSERT_EQ(membershipChanges, 2);
+
+    std::vector<uint8_t> dup = announceBytes(b1, 2);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, memberC, dup.data(), dup.size());
+    EXPECT_EQ(membershipChanges, 2);
+    EXPECT_EQ(suite->rdc.getChainMembers().size(), 2u);
+}
+
+// A stale head-transfer snapshot must not re-fork an upstream a fresher announce
+// already claimed: Y announces Y->b1, then a demoted head's older transfer lists
+// X->b1 (X absent). The transfer is skipped, so b1 keeps its one downstream and
+// the roster stays a list. Without the upstreamHeldByOther skip, X inserts and
+// b1 forks.
+inline void rdcStaleTransferDoesNotReforkClaimedUpstream(RDCHelloTests* suite) {
+    const uint8_t b1[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t memberY[6] = {0xE1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t memberX[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t oldHead[6] = {0x77, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    // Y is the current, fresher claimant of b1.
+    std::vector<uint8_t> ay = announceBytes(b1, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, memberY, ay.data(), ay.size());
+    ASSERT_EQ(suite->rdc.getChainMembers().size(), 1u);
+
+    // A stale transfer arrives listing X on the same upstream b1.
+    std::array<uint8_t, 6> x{};
+    std::array<uint8_t, 6> up{};
+    memcpy(x.data(), memberX, 6);
+    memcpy(up.data(), b1, 6);
+    std::vector<uint8_t> handoff = headTransferBytes({{x, up}}, 5);
+    suite->transport()->deliverIncoming(PktType::kHeadTransfer, oldHead,
+                                        handoff.data(), handoff.size());
+
+    // b1 still has exactly one downstream, and it is Y not X.
+    std::vector<std::array<uint8_t, 6>> members = suite->rdc.getChainMembers();
+    ASSERT_EQ(members.size(), 1u);
+    EXPECT_EQ(0, memcmp(members[0].data(), memberY, 6));
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1410,6 +1410,18 @@ TEST_F(RDCHelloTests, staleAnnounceDeliveryDoesNotConfirm) {
 TEST_F(RDCHelloTests, headAdoptionManagesRadioSlot) {
     rdcHeadAdoptionManagesRadioSlot(this);
 }
+TEST_F(RDCHelloTests, inputHeadLinkDeathCancelsPendingContextSend) {
+    rdcInputHeadLinkDeathCancelsPendingContextSend(this);
+}
+TEST_F(RDCHelloTests, backToBackReportsBothRetryToHead) {
+    rdcBackToBackReportsBothRetryToHead(this);
+}
+TEST_F(RDCHelloTests, pendingReportResentOnHeadChange) {
+    rdcPendingReportResentOnHeadChange(this);
+}
+TEST_F(RDCHelloTests, reportFromHeldHeadNotForwardedBack) {
+    rdcReportFromHeldHeadNotForwardedBack(this);
+}
 
 TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {
     rdcHelloByteModeSuppressesStringAssembly();

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1389,6 +1389,9 @@ TEST_F(RDCHelloTests, headTransferReceiveMergesAndPrunes) {
 TEST_F(RDCHelloTests, announceEvictsStaleUpstreamClaimant) {
     rdcAnnounceEvictsStaleUpstreamClaimant(this);
 }
+TEST_F(RDCHelloTests, fullRosterEvictsStaleThenAdmits) {
+    rdcFullRosterEvictsStaleThenAdmits(this);
+}
 TEST_F(RDCHelloTests, duplicateReannounceDoesNotEvict) {
     rdcDuplicateReannounceDoesNotEvict(this);
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1365,6 +1365,28 @@ TEST_F(RDCHelloTests, duplicateContextSameTickFiresCallbackOnce) {
     rdcDuplicateContextSameTickFiresCallbackOnce(this);
 }
 
+TEST_F(RDCHelloTests, joinAnnouncesToHeadAndGatesConfirmed) {
+    rdcJoinAnnouncesToHeadAndGatesConfirmed(this);
+}
+TEST_F(RDCHelloTests, headChangeDropsConfirmedAndReannounces) {
+    rdcHeadChangeDropsConfirmedAndReannounces(this);
+}
+TEST_F(RDCHelloTests, headBuildsAndPrunesRoster) {
+    rdcHeadBuildsAndPrunesRoster(this);
+}
+TEST_F(RDCHelloTests, childReportsDownstreamLossToHead) {
+    rdcChildReportsDownstreamLossToHead(this);
+}
+TEST_F(RDCHelloTests, ringLatchedNeverAnnouncesOrReportsToSelf) {
+    rdcRingLatchedNeverAnnouncesOrReportsToSelf(this);
+}
+TEST_F(RDCHelloTests, demotedHeadTransfersRoster) {
+    rdcDemotedHeadTransfersRoster(this);
+}
+TEST_F(RDCHelloTests, headTransferReceiveMergesAndPrunes) {
+    rdcHeadTransferReceiveMergesAndPrunes(this);
+}
+
 TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {
     rdcHelloByteModeSuppressesStringAssembly();
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1386,6 +1386,30 @@ TEST_F(RDCHelloTests, demotedHeadTransfersRoster) {
 TEST_F(RDCHelloTests, headTransferReceiveMergesAndPrunes) {
     rdcHeadTransferReceiveMergesAndPrunes(this);
 }
+TEST_F(RDCHelloTests, outputLossOfOwnHeadSendsNoReport) {
+    rdcOutputLossOfOwnHeadSendsNoReport(this);
+}
+TEST_F(RDCHelloTests, headIgnoresSelfDisconnectReport) {
+    rdcHeadIgnoresSelfDisconnectReport(this);
+}
+TEST_F(RDCHelloTests, headTransferDoesNotOverwriteAnnouncedUpstream) {
+    rdcHeadTransferDoesNotOverwriteAnnouncedUpstream(this);
+}
+TEST_F(RDCHelloTests, demotedDeviceForwardsDisconnectReport) {
+    rdcDemotedDeviceForwardsDisconnectReport(this);
+}
+TEST_F(RDCHelloTests, standaloneIgnoresLateRosterTraffic) {
+    rdcStandaloneIgnoresLateRosterTraffic(this);
+}
+TEST_F(RDCHelloTests, headDirectChildLossClearsWholeRoster) {
+    rdcHeadDirectChildLossClearsWholeRoster(this);
+}
+TEST_F(RDCHelloTests, staleAnnounceDeliveryDoesNotConfirm) {
+    rdcStaleAnnounceDeliveryDoesNotConfirm(this);
+}
+TEST_F(RDCHelloTests, headAdoptionManagesRadioSlot) {
+    rdcHeadAdoptionManagesRadioSlot(this);
+}
 
 TEST(RDCHelloStandalone, byteModeSuppressesStringAssembly) {
     rdcHelloByteModeSuppressesStringAssembly();

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1386,6 +1386,15 @@ TEST_F(RDCHelloTests, demotedHeadTransfersRoster) {
 TEST_F(RDCHelloTests, headTransferReceiveMergesAndPrunes) {
     rdcHeadTransferReceiveMergesAndPrunes(this);
 }
+TEST_F(RDCHelloTests, announceEvictsStaleUpstreamClaimant) {
+    rdcAnnounceEvictsStaleUpstreamClaimant(this);
+}
+TEST_F(RDCHelloTests, duplicateReannounceDoesNotEvict) {
+    rdcDuplicateReannounceDoesNotEvict(this);
+}
+TEST_F(RDCHelloTests, staleTransferDoesNotReforkClaimedUpstream) {
+    rdcStaleTransferDoesNotReforkClaimedUpstream(this);
+}
 TEST_F(RDCHelloTests, outputLossOfOwnHeadSendsNoReport) {
     rdcOutputLossOfOwnHeadSendsNoReport(this);
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1428,6 +1428,9 @@ TEST_F(RDCHelloTests, backToBackReportsBothRetryToHead) {
 TEST_F(RDCHelloTests, pendingReportResentOnHeadChange) {
     rdcPendingReportResentOnHeadChange(this);
 }
+TEST_F(RDCHelloTests, pendingReportVoidedByBecomingHead) {
+    rdcPendingReportVoidedByBecomingHead(this);
+}
 TEST_F(RDCHelloTests, reportFromHeldHeadNotForwardedBack) {
     rdcReportFromHeldHeadNotForwardedBack(this);
 }


### PR DESCRIPTION
# rdc: head roster — announce, disconnect report, head transfer (#158)

Closes #158. The head now keeps a member -> direct-upstream roster: members announce on joining (ConnectionAnnounce), departures propagate as DisconnectReport and prune the departed subtree, and a demoted head hands its roster to the successor in one HeadTransfer. The HELLO confirmed bit rises only when the announce's SEND_SUCCESS lands, gated on both seqId and destination still matching the latest send.

## Where to look
- **Ring break must not wipe the roster.** A member losing its OUTPUT link to its *own head* (the ring's closing cable) sends nothing — a report naming the head would prune every member, since all upstream edges root there. Belt on the receive side: a report naming the receiving device is dropped at the trust boundary. This is the case that defeats the feature if it regresses; `rdcOutputLossOfOwnHeadSendsNoReport` covers it.
- **`isRosterAuthority()` (role HEAD or RING) gates all three handlers**, not "no head held" — an ex-head is STANDALONE with a zero head word, and late Resender retries would otherwise seed phantom members that resurface on its next chain. The accepted trade: an announce racing the head's own OUTPUT Connected commit (~1 tick) is dropped — same residual class as a lost radio frame, heals on the member's next head change or replug.
- **Transfer merge is insert-only.** A member's own post-merge announce carries its true upstream and can beat the demoted head's transfer; the transfer must not flatten that edge onto the demoted head or a later departure prunes the wrong subtree.
- **Reports forward across demotion.** Head propagation is hop-by-hop, so a just-demoted head can be addressed under the old regime; it forwards the report to the head it now holds (the announce path self-heals on head change; the report path has no retry).
- **Head radio-slot lifecycle.** The held head is a unicast target that's usually not an adjacent HELLO peer: adoption claims its ESP-NOW slot, swap/ring-latch/INPUT-loss release it, with the same keep-slot guards as jack peers (2-node ring one-cable drop keeps wireless alive).

## Deliberate style exceptions
The three new PktType values keep the enum's existing k-style rather than going UPPER_CASE — renaming 3 of 23 values would leave the enum mixed; a whole-enum sweep should be its own change. One read of legacy `daisyChainedByPort_` mirrors the identical loop in `releaseHelloPeer` beside it.

## Validation
Native 353/353 (16 roster tests, each written failing-first), CLI 86/86, `esp32-s3_pdn_release` builds. Hardware-unvalidated; the bench sweep worth doing before an event is chain -> ring -> break-one-cable -> shootout, which exercises the ring-break suppression end to end.


## Review round 2 (post-open six-lens rerun)

Two commits landed after opening, from rerunning the review lenses against the tip:

- **67a2a43** — three delivery-reliability fixes in the report path, each with a falsified test: context-retry cancels now run before the held-head keep guard in `releaseHelloPeer` (a dying INPUT peer that IS the head could otherwise resurrect its just-released radio slot via a pending retry — permanent 16-slot-table leak in the plain 2-device chain); the DisconnectReport channel is KEEP_DISTINCT (reports are distinct events; back-to-back reports to one head were superseding each other's retry slots); and an undelivered report now chases a head change the way announces already did, instead of being cancelled with the old head's slot. Plus a fence refusing to forward a report back to its sender (head-transient ping-pong).
- **267f928** — `getChainMembers` gates on `!isRosterAuthority()` instead of a hand-written inverse; LOG_W on the two trust-boundary drops; comment accuracy fixes.

Known residual, consistent with the no-ack design: pending-report tracking is single-slot, so of multiple in-flight reports only the newest re-sends on a head change; an older one whose first transmit also failed stays in the documented residual class (needs two first-transmit failures plus a head change inside the ~1.5s retry window).
