### PR TITLE
test: clock-race clamp coverage for link watchdog and parser (#173)

### DIFF
--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -44,8 +44,10 @@ struct HelloLinkContext {
     unsigned long lastHelloMs = 0;
     std::array<uint8_t, 6> peerMac{};  // source MAC last heard; consumed by #157
 
-    // Silent-link gap with the unsigned-underflow clamp: the UART task can stamp
-    // lastHelloMs just after now is read, so now - lastHelloMs would wrap to ~UINT_MAX.
+    // Silent-link gap with a defensive underflow clamp: HELLO processing is
+    // main-loop-only today, but any backwards step between stamp and read (a
+    // clock swap in tests, a future task split) would wrap now - lastHelloMs
+    // to ~ULONG_MAX and kill a live link.
     unsigned long sinceHello() const {
         const unsigned long now = nowMs();
         return now >= lastHelloMs ? now - lastHelloMs : 0;

--- a/lib/core/include/device/serial-frame-parser.hpp
+++ b/lib/core/include/device/serial-frame-parser.hpp
@@ -48,9 +48,10 @@ using HelloFrameHandler = std::function<void(const HelloPayload&)>;
 // Binary framing because the jacks are physically unreliable (TRS contacts,
 // partial insertion): a corrupted delimited string still parses as *some*
 // string, while a frame failing CRC is dropped and the preamble resyncs.
-// feed() runs on the UART event task; requestReset() is callable from the main
-// loop and is honored at the start of the next feed(), so the parser's
-// std::vector state is only ever mutated by the feeding thread.
+// feed() runs on the main loop today (the driver's exec() polls RX and fires
+// the byte callback inline). requestReset() is an atomic flag honored at the
+// start of the next feed(), so parser state stays single-owner even if
+// feeding ever moves onto a UART event task.
 class SerialFrameParser {
 public:
     /// Consumes one burst of raw serial bytes; fires the frame handler for

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -151,9 +151,8 @@ inline void rdcHelloRejectsSelfAndZeroSource(RDCHelloTests* suite) {
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
 }
 
-// The UART task can stamp lastHelloMs just after the main loop reads now, so
-// the watchdog can observe now < lastHelloMs; the gap must clamp to 0, not
-// underflow to ~ULONG_MAX and kill a live link (#173).
+// A watchdog read observing now < lastHelloMs (backwards clock step) must
+// clamp the gap to 0, not underflow to ~ULONG_MAX and kill a live link (#173).
 inline void rdcHelloWatchdogClampsClockRaceToZero(RDCHelloTests* suite) {
     suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
     suite->rdc.sync(&suite->device);

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -151,6 +151,28 @@ inline void rdcHelloRejectsSelfAndZeroSource(RDCHelloTests* suite) {
               RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
 }
 
+// The UART task can stamp lastHelloMs just after the main loop reads now, so
+// the watchdog can observe now < lastHelloMs; the gap must clamp to 0, not
+// underflow to ~ULONG_MAX and kill a live link (#173).
+inline void rdcHelloWatchdogClampsClockRaceToZero(RDCHelloTests* suite) {
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+
+    // now (999) behind the stamp (1000): the racing-stamp shape.
+    suite->fakeClock->setTime(999);
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+
+    // The clamp must not have defanged the watchdog: a real silent gap still kills.
+    suite->fakeClock->setTime(1000 + RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+}
+
 // (a) A HELLO from a new MAC drives that jack Idle -> Connecting.
 inline void rdcHelloNewMacDrivesConnecting(RDCHelloTests* suite) {
     EXPECT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),

--- a/test/test_core/serial-frame-parser-tests.hpp
+++ b/test/test_core/serial-frame-parser-tests.hpp
@@ -213,6 +213,23 @@ TEST_F(SerialFrameParserTests, midFrameTimeoutResets) {
     EXPECT_EQ(frameCount, 1);
 }
 
+TEST_F(SerialFrameParserTests, backwardClockKeepsPartialFrameAlive) {
+    // A feed observing now < lastByteMs (backwards clock step) must clamp the
+    // timeout gap to 0: unsigned subtraction would read as a huge stall and
+    // throw away a partial frame that is actually mid-flight.
+    int frameCount = 0;
+    parser.setHelloFrameHandler([&](const HelloPayload&) { ++frameCount; });
+
+    std::vector<uint8_t> frame = buildFrame(OP_HELLO, helloPayload());
+    parser.feed(frame.data(), 6);
+    EXPECT_EQ(frameCount, 0);
+
+    // Clock steps backwards relative to the partial's stamp.
+    fakeClock->setTime(999);
+    parser.feed(frame.data() + 6, frame.size() - 6);
+    EXPECT_EQ(frameCount, 1);
+}
+
 TEST_F(SerialFrameParserTests, requestResetClearsPartialFrameAtNextFeed) {
     // The cross-thread reset used when a jack is declared dead: mid-frame state
     // from the dying connection must not corrupt the next device to plug in.

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1311,6 +1311,9 @@ TEST_F(RDCHelloTests, contextCompleteConnects) {
 TEST_F(RDCHelloTests, silentLinkDisconnects) {
     rdcHelloSilentLinkDisconnects(this);
 }
+TEST_F(RDCHelloTests, watchdogClampsClockRaceToZero) {
+    rdcHelloWatchdogClampsClockRaceToZero(this);
+}
 
 TEST_F(RDCHelloTests, emitProducesFramesOnBothJacks) {
     rdcHelloEmitProducesFramesOnBothJacks(this);


### PR DESCRIPTION
# test: clock-race clamp coverage for link watchdog and parser (#173)

Closes #173. The issue asked for tests on the five #161 edge-case guards; scope-checking against the merged code shrank it to what was actually untested, and the result is two regression tests, both written failing-first against a broken clamp.

## What's here
- **`rdcHelloWatchdogClampsClockRaceToZero`** — the link watchdog's backwards-clock clamp (`HelloLinkContext::sinceHello`). Asserts the live link survives `now < lastHelloMs`, then that a real 101ms gap still kills it, so the clamp can't have defanged the watchdog.
- **`SerialFrameParserTests.backwardClockKeepsPartialFrameAlive`** — the parser's twin clamp in `checkTimeout()`, previously untested: a backwards step mid-frame must not read as a huge stall and discard an in-flight partial.
- A comment correction that fell out of review: the parser/link headers claimed `feed()` runs on a UART event task. Verified against the driver: the byte callback fires inline in `exec()` on the main loop. The comments now say so (and note the atomic reset is future-proofing, not present-tense thread safety).

## Why guard 5 has no new test
The issue's parser-reset-on-dead-jack test is unwritable non-vacuously: the parser self-heals before the RDC's Idle-mount reset can ever matter (50ms mid-frame timeout < 100ms silent-link window, plus unconditional post-CRC reset). I proved this the direct way — wrote the test, disabled the reset call, watched the test stay green — then deleted it. The mechanism itself is already covered at the parser layer (`requestResetClearsPartialFrameAtNextFeed`, `midFrameTimeoutResets`, `badCrcDropsFrame`); the RDC-level call remains as belt.

Guards 1 and 2 were already tested (`rdcHelloRejectsSelfAndZeroSource`, `rdc2NodeRingSingleJackDropKeepsPeerSlot`); guard 4 is structurally moot in the merged design (detection IS the HELLO that stamps liveness). Mapping in #161's closing comment.

## Validation
Native 340/340. Test-only plus comments — no behavior change.
