### PR TITLE
test: one-way HELLO cable times out instead of ghost child

### DIFF
--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -1391,14 +1391,11 @@ inline void rdcHelloOneWayCableTimesOutInsteadOfGhostChild() {
     EXPECT_EQ(0, memcmp(emitted.source, macA, 6));  // a frame really was parsed
     EXPECT_EQ(MacToUInt64(emitted.headMac), 0u);
 
-    // B heard nothing the whole time, so it never left its own chain.
-    EXPECT_EQ(B.rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
-              RemoteDeviceCoordinator::HelloLinkState::IDLE);
-    EXPECT_EQ(B.rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
-              RemoteDeviceCoordinator::HelloLinkState::IDLE);
-    EXPECT_EQ(B.rdc.getPortStatus(SerialIdentifier::OUTPUT_JACK), PortStatus::DISCONNECTED);
+    // One assertion for B, not five: nothing is ever injected into its jacks and a
+    // link leaves Idle only on a received HELLO, so its link states and counters are
+    // still the constructed defaults and would hold however A behaved. B earns its
+    // place by being the production emitter feeding A's production parser.
     EXPECT_EQ(B.rdc.getChainRole(), ChainRole::STANDALONE);
-    EXPECT_EQ(B.ringClosedCount, 0);
 
     SimpleTimer::setPlatformClock(nullptr);
 }

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -1329,6 +1329,80 @@ inline void rdcChainDualLatchSettlesByLowerMac() {
     SimpleTimer::setPlatformClock(nullptr);
 }
 
+// A faulty TRRS cable with one dead conductor: B's HELLO reaches A's INPUT jack
+// while A's HELLO reaches nobody, so B never opens a link and never sends its
+// context. A must not be left a ghost child of a peer that has never heard of
+// it. The edge that has to fire is the context-exchange timeout, NOT the liveness
+// watchdog: B's HELLO keeps arriving at cadence, so the silent-link gap never
+// grows past its window and only the incomplete exchange can end the link.
+inline void rdcHelloOneWayCableTimesOutInsteadOfGhostChild() {
+    FakePlatformClock clock;
+    SimpleTimer::setPlatformClock(&clock);
+    clock.setTime(1000);
+
+    const uint8_t macA[6] = {0xAA, 0x00, 0x00, 0x00, 0x00, 0x02};
+    const uint8_t macB[6] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x03};
+    ChainRingNode A(macA);
+    ChainRingNode B(macB);
+
+    // The one live conductor, B.out -> A.in: A hears an upstream peer and opens a
+    // link, but stays STANDALONE — CHILD demands a CONNECTED input.
+    B.rdc.emitHello();
+    pumpCable(B.out, A.in);
+    A.rdc.sync(&A.device);
+    B.rdc.sync(&B.device);
+    ASSERT_EQ(A.rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+    ASSERT_EQ(A.rdc.getPortStatus(SerialIdentifier::INPUT_JACK), PortStatus::CONNECTING);
+    ASSERT_EQ(A.rdc.getChainRole(), ChainRole::STANDALONE);
+
+    // Hold the link at HELLO cadence right up to the context timeout.
+    unsigned long connectingMs = 0;
+    while (connectingMs < RemoteDeviceCoordinator::CONTEXT_EXCHANGE_TIMEOUT_MS) {
+        clock.advance(RemoteDeviceCoordinator::HELLO_CADENCE_MS);
+        connectingMs += RemoteDeviceCoordinator::HELLO_CADENCE_MS;
+        A.rdc.emitHello();
+        B.rdc.emitHello();
+        pumpCable(B.out, A.in);
+        A.in.clearOutput();  // the cut conductor: A's frames reach no one
+        A.rdc.sync(&A.device);
+        B.rdc.sync(&B.device);
+        ASSERT_EQ(A.rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+                  RemoteDeviceCoordinator::HelloLinkState::CONNECTING)
+            << "connecting for " << connectingMs << "ms";
+    }
+
+    // One cadence step past the timeout ends it, with the HELLO still fresh.
+    clock.advance(RemoteDeviceCoordinator::HELLO_CADENCE_MS);
+    B.rdc.emitHello();
+    pumpCable(B.out, A.in);
+    A.rdc.sync(&A.device);
+
+    EXPECT_EQ(A.rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    EXPECT_EQ(A.rdc.getPortStatus(SerialIdentifier::INPUT_JACK), PortStatus::DISCONNECTED);
+    EXPECT_EQ(A.rdc.getChainRole(), ChainRole::STANDALONE);
+    EXPECT_EQ(A.rdc.getHeadMac(), nullptr);
+    // The head adopted from that HELLO is off the wire too: A must stop telling
+    // its downstream it sits under B.
+    A.out.clearOutput();
+    A.rdc.emitHello();
+    HelloPayload emitted = parseEmittedHello(A.out.getOutput());
+    EXPECT_EQ(0, memcmp(emitted.source, macA, 6));  // a frame really was parsed
+    EXPECT_EQ(MacToUInt64(emitted.headMac), 0u);
+
+    // B heard nothing the whole time, so it never left its own chain.
+    EXPECT_EQ(B.rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    EXPECT_EQ(B.rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::IDLE);
+    EXPECT_EQ(B.rdc.getPortStatus(SerialIdentifier::OUTPUT_JACK), PortStatus::DISCONNECTED);
+    EXPECT_EQ(B.rdc.getChainRole(), ChainRole::STANDALONE);
+    EXPECT_EQ(B.ringClosedCount, 0);
+
+    SimpleTimer::setPlatformClock(nullptr);
+}
+
 // ============================================
 // Head roster management (#158)
 // ============================================

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1568,6 +1568,9 @@ TEST(RDCHelloStandalone, chainTwoNodeRingCloses) {
 TEST(RDCHelloStandalone, chainDualLatchSettlesByLowerMac) {
     rdcChainDualLatchSettlesByLowerMac();
 }
+TEST(RDCHelloStandalone, oneWayCableTimesOutInsteadOfGhostChild) {
+    rdcHelloOneWayCableTimesOutInsteadOfGhostChild();
+}
 TEST_F(RDCHelloTests, chainRingYieldsToHigherHeadAfterEvidenceTimeout) {
     rdcChainRingYieldsToHigherHeadAfterEvidenceTimeout(this);
 }


### PR DESCRIPTION
Closes #172.

A TRRS cable with one dead conductor leaves A hearing B's HELLO while B hears nothing from A. Neither device may get stuck, and A in particular must not sit there as a ghost child of a peer that has never heard of it.

## The edge that has to fire

The context-exchange timeout, not the liveness watchdog. B's HELLO keeps arriving at cadence, so A's silent-link gap never grows past its window; the only thing that can end the link is the exchange that can never complete.

That distinction is what the test is for. Every pre-existing test touching the context timeout jumps the clock past both windows at once, so `sinceHello() > silentLinkMs` fires alongside and either edge satisfies them. This is the only test that holds HELLO fresh at 20ms cadence and isolates the 500ms timeout.

Falsified by deleting the `connecting > contextTimeoutMs` disjunct from `HelloConnectingState::transitionToIdle`: exactly one test of 365 fails, this one, reporting the link stuck CONNECTING, the port stuck CONNECTING, and A still advertising B as head. The converse run — keeping only that disjunct — leaves this test passing while two silent-link tests fail.

## Where to look

Ghost-child is asserted as more than a link state: after the timeout A must report DISCONNECTED on the port, STANDALONE for chain role, a null head MAC, and must have stopped advertising B as head in its emitted frame. That last one is parsed back off the wire and the source is checked, so the assertion cannot pass vacuously.

While A's INPUT link is merely CONNECTING it still advertises the adopted head downstream — `emitHello` reads `chainHeadState` directly while `getHeadMac` masks it by role. The timeout clears it, and the emitted-frame assertion is what pins that. The underlying ungated adoption is being fixed in #159.

B carries one assertion rather than five. Nothing is ever injected into its jacks and a link leaves Idle only on a received HELLO, so its link states and counters are still the constructed defaults and would hold however A behaved. It earns its place by being the production emitter feeding A's production parser.

No production code changed. No hardware validation was performed.
