### PR TITLE
rdc: role-change context re-broadcast; half-open match gate

### DIFF
--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -32,8 +32,8 @@ enum class PktType : uint8_t {
 // wire format (both ends run the same firmware). RDC never reads these fields —
 // it forwards the profile to the game layer opaquely.
 struct PlayerProfile {
-    uint16_t userId;
-    uint8_t gameRole;
+    uint16_t userId;   // 0xFFFF while unregistered
+    uint8_t gameRole;  // 1 = hunter, 0 = target/bounty, as in RoleAnnouncePayload
     uint8_t allegiance;
     char faction[8];
     char name[16];

--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -40,8 +40,9 @@ struct PlayerProfile {
 } __attribute__((packed));
 
 // PDN-to-neighbour connection context. seqId is stamped by the ReliableChannel.
-// chainRole is recorded by the receiver for the device chain SM (#156). The peer's
-// device kind arrives out-of-band in HELLO and picks which context struct to decode.
+// chainRole is the sender's own ChainRole as of the send (0 = standalone), recorded
+// by the receiver. The peer's device kind arrives out-of-band in HELLO and picks
+// which context struct to decode.
 struct PdnConnectionContext {
     uint8_t seqId;
     uint8_t chainRole;

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -184,11 +184,23 @@ public:
         contextReceivedCallback = std::move(callback);
     }
 
-    /// Supplies this device's outgoing player profile, forwarded verbatim in the
-    /// context this device sends to a new peer on any jack. Opaque to RDC.
-    void setSelfPlayerProfile(const PlayerProfile& profile) {
-        selfPlayerProfile = profile;
+    /// Yields this device's outgoing player profile, forwarded verbatim in the
+    /// context this device sends. Opaque to RDC.
+    using SelfProfileProvider = std::function<PlayerProfile()>;
+
+    /// Registers the outgoing-profile source. A provider rather than a stored
+    /// copy because the id, name, faction and role each settle at a different
+    /// point in registration: reading at send time keeps a context honest
+    /// without every one of those setters having to re-push here.
+    void setSelfProfileProvider(SelfProfileProvider provider) {
+        selfProfileProvider = std::move(provider);
     }
+
+    /// Queues a fresh context to the peer on every Connected jack. The exchange
+    /// is otherwise once-per-connect, so a profile field a peer acts on (the
+    /// hunter/bounty role) changing on an already-open link has to push itself
+    /// or the peer keeps acting on the stale value until the next replug.
+    void resendContext();
 
     /// The chainRole recorded from the peer's context on `jack`; 0 until one
     /// arrives. Recorded for the device chain SM (#156), not acted on here.
@@ -381,7 +393,7 @@ private:
     bool helloConnectivityEnabled = false;
     bool externalConnectivityTask = false;
     ContextReceivedCallback contextReceivedCallback;
-    PlayerProfile selfPlayerProfile{};
+    SelfProfileProvider selfProfileProvider;
     std::array<uint8_t, 6> selfMac{};
     DeviceType selfDeviceType = DeviceType::UNKNOWN;
 

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -202,8 +202,9 @@ public:
     /// or the peer keeps acting on the stale value until the next replug.
     void resendContext();
 
-    /// The chainRole recorded from the peer's context on `jack`; 0 until one
-    /// arrives. Recorded for the device chain SM (#156), not acted on here.
+    /// The peer's own ChainRole as of the context it sent on `jack`, recorded but
+    /// not acted on here. 0 before any context arrives, which is also STANDALONE:
+    /// a peer whose only link is the one still connecting reports exactly that.
     uint8_t getPeerChainRole(SerialIdentifier jack) const {
         return helloByPort[portIndex(jack)].peerChainRole;
     }

--- a/lib/core/include/game/player.hpp
+++ b/lib/core/include/game/player.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <iostream>
 #include <cstdint>
+#include "device/drivers/peer-comms-types.hpp"
 #include "symbol.hpp"
 
 enum class Allegiance {
@@ -15,11 +17,14 @@ enum class Allegiance {
 
 class Player {
 public:
+    /// Fires after the hunter/bounty role flips.
+    using RoleChangedCallback = std::function<void()>;
+
     Player() = default;
     ~Player() = default;
-    
+
     Player(const std::string& id, Allegiance allegiance, bool isHunter);
-    
+
     std::string toJson() const;
 
     void fromJson(const std::string &json);
@@ -29,6 +34,16 @@ public:
     void setIsHunter(bool isHunter);
 
     void toggleHunter();
+
+    /// Registers the role-flip observer (one slot). Fires only on an actual
+    /// flip, never on a set that reasserts the current role.
+    void setOnRoleChanged(RoleChangedCallback callback);
+
+    /// This player as the packed profile peers receive in the connection
+    /// context. userId is 0xFFFF while the player id is not wholly numeric
+    /// (registration has not completed); faction and name truncate to the
+    /// fixed wire widths.
+    PlayerProfile toProfile() const;
 
     Allegiance getAllegiance() const;
 
@@ -85,6 +100,12 @@ public:
     void addReactionTime(unsigned long reactionTime);
 
 private:
+    // Sole write path for `hunter`, so every flip notifies exactly once no
+    // matter which public setter produced it.
+    void applyRole(bool isHunter);
+
+    RoleChangedCallback roleChangedCallback;
+
     std::string id = "default";
     std::string name = "";
     std::string allegianceStr = "none";

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -820,8 +820,21 @@ void RemoteDeviceCoordinator::sendSelfContext(const uint8_t* mac) {
     if (pdnContextChannel == nullptr) return;
     PdnConnectionContext ctx{};
     ctx.chainRole = 0;
-    ctx.player = selfPlayerProfile;
+    if (selfProfileProvider) ctx.player = selfProfileProvider();
     pdnContextChannel->sendReliable(mac, ctx);
+}
+
+void RemoteDeviceCoordinator::resendContext() {
+    for (SerialIdentifier port : HELLO_JACKS) {
+        const HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
+        if (machine == nullptr || machine->currentStateId() != HELLO_LINK_CONNECTED) continue;
+        const uint8_t* mac = machine->peer().data();
+        // A 2-node ring faces the same peer on both jacks, and one copy completes
+        // both: the pending entry the first jack leaves collapses the second,
+        // exactly as on the initiate path.
+        if (isContextSendPending(mac)) continue;
+        sendSelfContext(mac);
+    }
 }
 
 bool RemoteDeviceCoordinator::isContextSendPending(const uint8_t* mac) const {

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -825,14 +825,25 @@ void RemoteDeviceCoordinator::sendSelfContext(const uint8_t* mac) {
 }
 
 void RemoteDeviceCoordinator::resendContext() {
+    // No pending-send guard, unlike the initiate path: there the queued payload is
+    // the one we would re-queue, here it is the STALE one this call exists to
+    // replace. The context channels supersede per target, so the fresh send drops
+    // the unacked entry and its old bytes.
+    std::array<std::array<uint8_t, 6>, kNumPorts> alreadySent{};
+    size_t sentCount = 0;
     for (SerialIdentifier port : HELLO_JACKS) {
         const HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
         if (machine == nullptr || machine->currentStateId() != HELLO_LINK_CONNECTED) continue;
         const uint8_t* mac = machine->peer().data();
-        // A 2-node ring faces the same peer on both jacks, and one copy completes
-        // both: the pending entry the first jack leaves collapses the second,
-        // exactly as on the initiate path.
-        if (isContextSendPending(mac)) continue;
+        // A 2-node ring faces the same peer on more than one jack and one copy
+        // covers them all. Every MAC covered so far is checked, not just the last
+        // one: the jacks sharing a peer need not be adjacent in HELLO_JACKS.
+        bool covered = false;
+        for (size_t i = 0; i < sentCount; ++i) {
+            if (memcmp(alreadySent[i].data(), mac, 6) == 0) covered = true;
+        }
+        if (covered) continue;
+        memcpy(alreadySent[sentCount++].data(), mac, 6);
         sendSelfContext(mac);
     }
 }

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -808,18 +808,19 @@ void RemoteDeviceCoordinator::initiateContextExchange(SerialIdentifier jack) {
 
 void RemoteDeviceCoordinator::sendSelfContext(const uint8_t* mac) {
     // Each device describes itself, so the payload is chosen by THIS device's kind,
-    // not the peer's. chainRole 0 = unresolved: the device chain SM (#156) fills it
-    // once it learns this device's position.
+    // not the peer's, and the role is read at send time: a resend on a role change
+    // has to carry the position this device holds now, not the one it held at plug-in.
+    const uint8_t role = static_cast<uint8_t>(getChainRole());
     if (selfDeviceType == DeviceType::FDN) {
         if (fdnContextChannel == nullptr) return;
         FdnConnectionContext ctx{};
-        ctx.chainRole = 0;
+        ctx.chainRole = role;
         fdnContextChannel->sendReliable(mac, ctx);
         return;
     }
     if (pdnContextChannel == nullptr) return;
     PdnConnectionContext ctx{};
-    ctx.chainRole = 0;
+    ctx.chainRole = role;
     if (selfProfileProvider) ctx.player = selfProfileProvider();
     pdnContextChannel->sendReliable(mac, ctx);
 }

--- a/lib/core/src/game/player.cpp
+++ b/lib/core/src/game/player.cpp
@@ -1,7 +1,9 @@
 #include "game/player.hpp"
 #include <memory>
+#include <cstdio>
 #include <cstring>
 #include <cstdlib>
+#include <utility>
 #include <ArduinoJson.h>
 #include "wireless/mac-functions.hpp"
 
@@ -45,7 +47,7 @@ void Player::fromJson(const std::string &json) {
       if (doc["faction"].is<const char*>()) {
         faction = doc["faction"].as<std::string>();
       }
-      hunter = doc["hunter"];
+      applyRole(doc["hunter"].as<bool>());
     } else {
       // Serial.println("Failed to parse JSON");
     }
@@ -53,12 +55,38 @@ void Player::fromJson(const std::string &json) {
 
 void Player::toggleHunter()
 {
-  hunter = !hunter;
+    applyRole(!hunter);
 }
 
-void Player::setIsHunter(bool isHunter) 
-{
-  hunter = isHunter;
+void Player::setIsHunter(bool isHunter) {
+    applyRole(isHunter);
+}
+
+void Player::applyRole(bool isHunter) {
+    if (hunter == isHunter) return;
+    hunter = isHunter;
+    if (roleChangedCallback) roleChangedCallback();
+}
+
+void Player::setOnRoleChanged(RoleChangedCallback callback) {
+    roleChangedCallback = std::move(callback);
+}
+
+PlayerProfile Player::toProfile() const {
+    PlayerProfile profile{};
+    char* end = nullptr;
+    const unsigned long parsed = std::strtoul(id.c_str(), &end, 10);
+    // A non-numeric id ("default", or a name) means registration has not
+    // completed; 0xFFFF is the unregistered player-id sentinel peers expect.
+    profile.userId = (!id.empty() && end != nullptr && *end == '\0')
+                         ? static_cast<uint16_t>(parsed)
+                         : 0xFFFF;
+    profile.gameRole = hunter ? 1 : 0;
+    profile.allegiance = static_cast<uint8_t>(allegiance);
+    // snprintf both truncates to the fixed wire width and NUL-terminates.
+    std::snprintf(profile.faction, sizeof(profile.faction), "%s", faction.c_str());
+    std::snprintf(profile.name, sizeof(profile.name), "%s", name.c_str());
+    return profile;
 }
 
 void Player::clearUserID()

--- a/src/pdn/game/chain-duel-manager.cpp
+++ b/src/pdn/game/chain-duel-manager.cpp
@@ -3,18 +3,17 @@
 
 #define TAG "CDM"
 
-ChainDuelManager::ChainDuelManager(Player* player, WirelessManager* wirelessManager, RemoteDeviceCoordinator* rdc) {
-    this->player_ = player;
-    this->wirelessManager_ = wirelessManager;
-    this->rdc_ = rdc;
-}
+ChainDuelManager::ChainDuelManager(Player* player, WirelessManager* wirelessManager, RemoteDeviceCoordinator* rdc)
+    : player(player)
+    , wirelessManager(wirelessManager)
+    , rdc(rdc) {}
 
 SerialIdentifier ChainDuelManager::opponentJack() const {
-    return player_->isHunter() ? SerialIdentifier::OUTPUT_JACK : SerialIdentifier::INPUT_JACK;
+    return player->isHunter() ? SerialIdentifier::OUTPUT_JACK : SerialIdentifier::INPUT_JACK;
 }
 
 SerialIdentifier ChainDuelManager::supporterJack() const {
-    return player_->isHunter() ? SerialIdentifier::INPUT_JACK : SerialIdentifier::OUTPUT_JACK;
+    return player->isHunter() ? SerialIdentifier::INPUT_JACK : SerialIdentifier::OUTPUT_JACK;
 }
 
 std::optional<bool> ChainDuelManager::peerIsHunter(SerialIdentifier port) const {
@@ -22,8 +21,8 @@ std::optional<bool> ChainDuelManager::peerIsHunter(SerialIdentifier port) const 
 }
 
 bool ChainDuelManager::isLoop() const {
-    PortState oState = rdc_->getPortState(opponentJack());
-    PortState sState = rdc_->getPortState(supporterJack());
+    PortState oState = rdc->getPortState(opponentJack());
+    PortState sState = rdc->getPortState(supporterJack());
     for (const auto& oPeer : oState.peerMacAddresses) {
         for (const auto& sPeer : sState.peerMacAddresses) {
             if (memcmp(oPeer.data(), sPeer.data(), 6) == 0) return true;
@@ -35,7 +34,7 @@ bool ChainDuelManager::isLoop() const {
 bool ChainDuelManager::isSupporter() const {
     auto opponentRole = peerIsHunter(opponentJack());
     if (!opponentRole.has_value()) return false;
-    if (*opponentRole != player_->isHunter()) return false;
+    if (*opponentRole != player->isHunter()) return false;
     return !isLoop();
 }
 
@@ -47,20 +46,28 @@ bool ChainDuelManager::isChampion() const {
 }
 
 bool ChainDuelManager::canInitiateMatch() const {
-    if (!player_->isHunter()) return false;
-    auto opponentRole = peerIsHunter(opponentJack());
+    if (!player->isHunter()) return false;
+    // A closed ring is the shootout's topology; no 1v1 pairing forms inside one.
+    if (isLoop()) return false;
+    // Half-open gate. Connected means the context exchange completed in both
+    // directions, so the peer is listening; a jack that only reached Connecting
+    // has a peer MAC off one HELLO and may have no return path at all, and a
+    // match pushed across it strands the initiator waiting for an ack.
+    if (rdc->getPortStatus(opponentJack()) != PortStatus::CONNECTED) return false;
+    if (rdc->getPeerDeviceType(opponentJack()) != DeviceType::PDN) return false;
+    std::optional<bool> opponentRole = peerIsHunter(opponentJack());
     if (!opponentRole.has_value()) return false;
-    return *opponentRole != player_->isHunter();
+    return *opponentRole != player->isHunter();
 }
 
 std::vector<std::array<uint8_t, 6>> ChainDuelManager::getSupporterChainPeers() const {
     if (isLoop()) return {};
-    PortState state = rdc_->getPortState(supporterJack());
+    PortState state = rdc->getPortState(supporterJack());
     return state.peerMacAddresses;
 }
 
 bool ChainDuelManager::isKnownGameEventSender(const uint8_t* fromMac) const {
-    PortState oState = rdc_->getPortState(opponentJack());
+    PortState oState = rdc->getPortState(opponentJack());
     for (const auto& peer : oState.peerMacAddresses) {
         if (memcmp(peer.data(), fromMac, 6) == 0) return true;
     }
@@ -113,7 +120,7 @@ void ChainDuelManager::sendGameEventToSupporters(ChainGameEventType eventType) {
             retryStats_.sends++;
         }
 
-        wirelessManager_->sendEspNowData(
+        wirelessManager->sendEspNowData(
             peerMac.data(),
             PktType::kChainGameEvent,
             reinterpret_cast<const uint8_t*>(&payload),
@@ -125,7 +132,7 @@ void ChainDuelManager::sendGameEventAck(const uint8_t* toMac, uint8_t seqId) {
     if (toMac == nullptr || seqId == 0) return;
     ChainGameEventAckPayload ack{};
     ack.seqId = seqId;
-    wirelessManager_->sendEspNowData(
+    wirelessManager->sendEspNowData(
         toMac, PktType::kChainGameEventAck,
         reinterpret_cast<const uint8_t*>(&ack), sizeof(ack));
 }
@@ -145,7 +152,7 @@ void ChainDuelManager::onChainGameEventAckReceived(const uint8_t* fromMac, uint8
 void ChainDuelManager::sendConfirm() {
     if (!championMac_.has_value()) return;
 
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
     if (selfMac == nullptr) return;
 
     ChainConfirmPayload payload{};
@@ -153,7 +160,7 @@ void ChainDuelManager::sendConfirm() {
     payload.seqId = nextConfirmSeqId_++;
     if (nextConfirmSeqId_ == 0) nextConfirmSeqId_ = 1;
 
-    wirelessManager_->sendEspNowData(
+    wirelessManager->sendEspNowData(
         championMac_->data(),
         PktType::kChainConfirm,
         reinterpret_cast<const uint8_t*>(&payload),
@@ -184,7 +191,7 @@ void ChainDuelManager::onConfirmReceived(
 }
 
 void ChainDuelManager::onChainStateChanged() {
-    PortState sState = rdc_->getPortState(supporterJack());
+    PortState sState = rdc->getPortState(supporterJack());
     size_t count = sState.peerMacAddresses.size();
     if (lastSupporterChainCount_ > 0 && count == 0) {
         clearSupporterConfirms();
@@ -193,14 +200,14 @@ void ChainDuelManager::onChainStateChanged() {
 
     // Drop cached peer roles for any port that no longer has a direct peer.
     for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK}) {
-        if (rdc_->getPeerMac(port) == nullptr) {
+        if (rdc->getPeerMac(port) == nullptr) {
             peerRoleByPort_[port == SerialIdentifier::INPUT_JACK ? 0 : 1].reset();
         }
     }
 
     // Re-evaluate championMac_. If I'm now champion, self-assign.
     if (isChampion()) {
-        const uint8_t* selfMac = wirelessManager_->getMacAddress();
+        const uint8_t* selfMac = wirelessManager->getMacAddress();
         if (selfMac != nullptr) {
             std::array<uint8_t, 6> selfArr;
             memcpy(selfArr.data(), selfMac, 6);
@@ -208,14 +215,14 @@ void ChainDuelManager::onChainStateChanged() {
                 championMac_ = selfArr;
                 broadcastRoleAndChampion();
                 // Track that we just announced to our current supporter-jack peer.
-                const uint8_t* supporterPeer = rdc_->getPeerMac(supporterJack());
+                const uint8_t* supporterPeer = rdc->getPeerMac(supporterJack());
                 if (supporterPeer != nullptr) {
                     std::array<uint8_t, 6> cur;
                     memcpy(cur.data(), supporterPeer, 6);
                     lastAnnouncedSupporterJackMac_ = cur;
                 }
                 // Announce role to opponent-jack peer if new.
-                const uint8_t* opponentPeer = rdc_->getPeerMac(opponentJack());
+                const uint8_t* opponentPeer = rdc->getPeerMac(opponentJack());
                 if (opponentPeer != nullptr) {
                     std::array<uint8_t, 6> cur;
                     memcpy(cur.data(), opponentPeer, 6);
@@ -233,7 +240,7 @@ void ChainDuelManager::onChainStateChanged() {
     // invalidate it — the real champion's announce will repopulate via
     // onRoleAnnounceReceived.
     if (isSupporter() && championMac_.has_value()) {
-        const uint8_t* selfMac = wirelessManager_->getMacAddress();
+        const uint8_t* selfMac = wirelessManager->getMacAddress();
         if (selfMac != nullptr && memcmp(championMac_->data(), selfMac, 6) == 0) {
             championMac_.reset();
         }
@@ -243,7 +250,7 @@ void ChainDuelManager::onChainStateChanged() {
     // broadcast the current championMac to it. Guard against re-firing on every
     // chain-state event (which would cause packet storms and destabilize the
     // serial heartbeat timing).
-    const uint8_t* supporterPeer = rdc_->getPeerMac(supporterJack());
+    const uint8_t* supporterPeer = rdc->getPeerMac(supporterJack());
     if (championMac_.has_value() && supporterPeer != nullptr) {
         std::array<uint8_t, 6> cur;
         memcpy(cur.data(), supporterPeer, 6);
@@ -256,7 +263,7 @@ void ChainDuelManager::onChainStateChanged() {
     }
 
     // Announce our role to the opponent-jack peer if it has changed.
-    const uint8_t* opponentPeer = rdc_->getPeerMac(opponentJack());
+    const uint8_t* opponentPeer = rdc->getPeerMac(opponentJack());
     if (opponentPeer != nullptr) {
         std::array<uint8_t, 6> cur;
         memcpy(cur.data(), opponentPeer, 6);
@@ -302,7 +309,7 @@ void ChainDuelManager::onRoleAnnounceReceived(
     bool fromOpponentJack = false;
     bool fromKnownDirectPeer = false;
     for (SerialIdentifier port : {SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK}) {
-        const uint8_t* directMac = rdc_->getPeerMac(port);
+        const uint8_t* directMac = rdc->getPeerMac(port);
         if (directMac != nullptr && memcmp(directMac, fromMac, 6) == 0) {
             setPeerRole(port, role == 1);
             fromKnownDirectPeer = true;
@@ -319,7 +326,7 @@ void ChainDuelManager::onRoleAnnounceReceived(
 
     RoleAnnounceAckPayload ack{};
     ack.seqId = seqId;
-    wirelessManager_->sendEspNowData(
+    wirelessManager->sendEspNowData(
         fromMac, PktType::kRoleAnnounceAck,
         reinterpret_cast<const uint8_t*>(&ack), sizeof(ack));
 
@@ -327,14 +334,14 @@ void ChainDuelManager::onRoleAnnounceReceived(
     // championMac_. Opposite-role senders are dueling opponents, not chain
     // parents — their championMac is irrelevant.
     if (!fromOpponentJack) return;
-    if (role != (player_->isHunter() ? 1u : 0u)) return;
+    if (role != (player->isHunter() ? 1u : 0u)) return;
 
     // 3. Register champion as ESP-NOW peer (only if it's not our own MAC).
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
     bool championIsSelf = (selfMac != nullptr &&
                            memcmp(selfMac, championMac, 6) == 0);
     if (!championIsSelf) {
-        rdc_->registerPeer(championMac);
+        rdc->registerPeer(championMac);
     }
 
     // 4. Update championMac_ and cascade if changed. On change, release the
@@ -351,7 +358,7 @@ void ChainDuelManager::onRoleAnnounceReceived(
         if (!oldIsSelf) {
             bool oldStillInChain = false;
             for (SerialIdentifier p : {SerialIdentifier::INPUT_JACK, SerialIdentifier::OUTPUT_JACK}) {
-                PortState ps = rdc_->getPortState(p);
+                PortState ps = rdc->getPortState(p);
                 for (const auto& m : ps.peerMacAddresses) {
                     if (memcmp(m.data(), oldMac.data(), 6) == 0) {
                         oldStillInChain = true;
@@ -361,7 +368,7 @@ void ChainDuelManager::onRoleAnnounceReceived(
                 if (oldStillInChain) break;
             }
             if (!oldStillInChain) {
-                rdc_->unregisterPeer(oldMac.data());
+                rdc->unregisterPeer(oldMac.data());
             }
         }
     }
@@ -374,14 +381,14 @@ void ChainDuelManager::onRoleAnnounceReceived(
 void ChainDuelManager::broadcastRoleAndChampion() {
     if (!championMac_.has_value()) return;
 
-    const uint8_t* supporterPeer = rdc_->getPeerMac(supporterJack());
+    const uint8_t* supporterPeer = rdc->getPeerMac(supporterJack());
     if (supporterPeer == nullptr) return;
 
     uint8_t seqId = nextRoleAnnounceSeqId_++;
     if (nextRoleAnnounceSeqId_ == 0) nextRoleAnnounceSeqId_ = 1;
 
     RoleAnnouncePayload payload{};
-    payload.role = player_->isHunter() ? 1 : 0;
+    payload.role = player->isHunter() ? 1 : 0;
     memcpy(payload.championMac, championMac_->data(), 6);
     payload.seqId = seqId;
 
@@ -394,7 +401,7 @@ void ChainDuelManager::broadcastRoleAndChampion() {
     pending_.timer.setTimer(kAckTimeoutMs);
     retryStats_.sends++;
 
-    wirelessManager_->sendEspNowData(
+    wirelessManager->sendEspNowData(
         supporterPeer, PktType::kRoleAnnounce,
         reinterpret_cast<const uint8_t*>(&payload), sizeof(payload));
 }
@@ -408,21 +415,21 @@ void ChainDuelManager::broadcastRoleAndChampion() {
 // would double the airtime cost of every chain change; the relaxed model is
 // acceptable given the healing path.
 void ChainDuelManager::sendRoleToOpponentJack() {
-    const uint8_t* opponentPeer = rdc_->getPeerMac(opponentJack());
+    const uint8_t* opponentPeer = rdc->getPeerMac(opponentJack());
     if (opponentPeer == nullptr) return;
 
     uint8_t seqId = nextRoleAnnounceSeqId_++;
     if (nextRoleAnnounceSeqId_ == 0) nextRoleAnnounceSeqId_ = 1;
 
     RoleAnnouncePayload payload{};
-    payload.role = player_->isHunter() ? 1 : 0;
+    payload.role = player->isHunter() ? 1 : 0;
     // championMac is a placeholder — receiver ignores unless same-role peer.
     if (championMac_.has_value()) {
         memcpy(payload.championMac, championMac_->data(), 6);
     }
     payload.seqId = seqId;
 
-    wirelessManager_->sendEspNowData(
+    wirelessManager->sendEspNowData(
         opponentPeer, PktType::kRoleAnnounce,
         reinterpret_cast<const uint8_t*>(&payload), sizeof(payload));
 }
@@ -454,7 +461,7 @@ void ChainDuelManager::sync() {
             payload.role = pending_.role;
             memcpy(payload.championMac, pending_.championMac.data(), 6);
             payload.seqId = pending_.seqId;
-            wirelessManager_->sendEspNowData(
+            wirelessManager->sendEspNowData(
                 pending_.targetMac.data(), PktType::kRoleAnnounce,
                 reinterpret_cast<const uint8_t*>(&payload), sizeof(payload));
             // Exponential backoff between retransmits: 200, 400, 800ms
@@ -487,7 +494,7 @@ void ChainDuelManager::sync() {
         ChainGameEventPayload payload{};
         payload.event_type = pending.eventType;
         payload.seqId = pending.seqId;
-        wirelessManager_->sendEspNowData(
+        wirelessManager->sendEspNowData(
             pending.targetMac.data(), PktType::kChainGameEvent,
             reinterpret_cast<const uint8_t*>(&payload), sizeof(payload));
         pending.timer.setTimer(kAckTimeoutMs << pending.retries);

--- a/src/pdn/game/chain-duel-manager.cpp
+++ b/src/pdn/game/chain-duel-manager.cpp
@@ -49,10 +49,11 @@ bool ChainDuelManager::canInitiateMatch() const {
     if (!player->isHunter()) return false;
     // A closed ring is the shootout's topology; no 1v1 pairing forms inside one.
     if (isLoop()) return false;
-    // Half-open gate. Connected means the context exchange completed in both
-    // directions, so the peer is listening; a jack that only reached Connecting
-    // has a peer MAC off one HELLO and may have no return path at all, and a
-    // match pushed across it strands the initiator waiting for an ack.
+    // Half-open gate. Connected means the peer answered over the radio — the
+    // handshake's EXCHANGE_ID round trip, or the peer's context landing on a HELLO
+    // link — so a path back exists. A jack that only reached Connecting has a peer
+    // MAC off one inbound serial frame and nothing proving the peer can answer, and
+    // a match pushed across it strands the initiator waiting for an ack.
     if (rdc->getPortStatus(opponentJack()) != PortStatus::CONNECTED) return false;
     if (rdc->getPeerDeviceType(opponentJack()) != DeviceType::PDN) return false;
     std::optional<bool> opponentRole = peerIsHunter(opponentJack());

--- a/src/pdn/game/chain-duel-manager.hpp
+++ b/src/pdn/game/chain-duel-manager.hpp
@@ -90,9 +90,9 @@ public:
 
 private:
     RetryStats retryStats_;
-    Player* player_;
-    WirelessManager* wirelessManager_;
-    RemoteDeviceCoordinator* rdc_;
+    Player* player;
+    WirelessManager* wirelessManager;
+    RemoteDeviceCoordinator* rdc;
 
     SerialIdentifier opponentJack() const;
     SerialIdentifier supporterJack() const;

--- a/src/pdn/game/quickdraw-states/idle-state.cpp
+++ b/src/pdn/game/quickdraw-states/idle-state.cpp
@@ -77,9 +77,7 @@ void Idle::onStateLoop(PDN* pdn) {
     ShootoutManager* shMgr = matchManager->getShootoutManager();
     bool shootoutActive = shMgr && shMgr->active();
     if (!shootoutActive && isConnected()) {
-        if (chainDuelManager->canInitiateMatch()
-            && getPeerDeviceType(SerialIdentifier::OUTPUT_JACK) == DeviceType::PDN
-            && player->isHunter()) {
+        if (chainDuelManager->canInitiateMatch()) {
             if (!matchInitialized) {
                 const uint8_t* peerMac = remoteDeviceCoordinator->getPeerMac(SerialIdentifier::OUTPUT_JACK);
                 if (peerMac != nullptr) {

--- a/src/pdn/game/quickdraw.cpp
+++ b/src/pdn/game/quickdraw.cpp
@@ -105,6 +105,17 @@ Quickdraw::Quickdraw(Player* player, Device* PDN, QuickdrawWirelessManager* quic
             shootoutManager_->onLocalRDCDisconnect(lostMac);
         }
     });
+
+    // The Player is the authority on this device's identity; RDC only carries it.
+    remoteDeviceCoordinator->setSelfProfileProvider([this]() -> PlayerProfile {
+        return this->player->toProfile();
+    });
+
+    // Registration flips hunter/bounty long after the jacks came up, and the
+    // context exchange only runs on connect, so the flip has to push itself.
+    this->player->setOnRoleChanged([this]() {
+        remoteDeviceCoordinator->resendContext();
+    });
 }
 
 void Quickdraw::onChainStateChanged() {
@@ -270,6 +281,10 @@ void Quickdraw::onShootoutCommandAckPacket(const uint8_t* fromMac, const uint8_t
 }
 
 Quickdraw::~Quickdraw() {
+    // Both callbacks capture `this` and are held by objects that outlive this
+    // state machine, so they must be dropped before the capture dangles.
+    if (player) player->setOnRoleChanged(nullptr);
+    if (remoteDeviceCoordinator) remoteDeviceCoordinator->setSelfProfileProvider(nullptr);
     player = nullptr;
     // The coordinator and the wireless manager are device-owned and outlive this
     // app, so every slot holding `this` has to be emptied here. kSymbolMatchCommand

--- a/test/test_core/chain-duel-manager-tests.hpp
+++ b/test/test_core/chain-duel-manager-tests.hpp
@@ -134,6 +134,31 @@ inline void cdmRoleDerivationWithChampionTopology(ChainDuelManagerTests* suite) 
     EXPECT_FALSE(cdm2.getSupporterChainPeers().empty());
 }
 
+// Half-open gate (#162): a jack that only reached CONNECTING knows its peer MAC
+// from one serial frame but has no proven return path, and a match pushed across
+// it strands the initiator waiting for an ack that never comes. Only a CONNECTED
+// opponent jack opens the gate.
+inline void cdmCanInitiateMatchRequiresConnectedOpponentJack(ChainDuelManagerTests* suite) {
+    suite->player.setIsHunter(true);
+    ChainDuelManager cdm(&suite->player, suite->device.wirelessManager, &suite->rdc);
+
+    // One serial frame: the OUTPUT jack knows the peer MAC and its PDN kind, but
+    // the connection is still half-open.
+    suite->device.outputJackSerial.stringCallback(SEND_MAC_ADDRESS + "AA:BB:CC:DD:EE:FF#1t1");
+    suite->rdc.sync(&suite->device);
+    cdm.setPeerRole(SerialIdentifier::OUTPUT_JACK, false);  // bounty opponent
+
+    ASSERT_EQ(suite->rdc.getPortStatus(SerialIdentifier::OUTPUT_JACK), PortStatus::CONNECTING);
+    ASSERT_EQ(suite->rdc.getPeerDeviceType(SerialIdentifier::OUTPUT_JACK), DeviceType::PDN);
+    EXPECT_FALSE(cdm.canInitiateMatch());
+
+    suite->deliverPacketViaRDC(HSCommand::EXCHANGE_ID, SerialIdentifier::INPUT_JACK);
+    suite->rdc.sync(&suite->device);
+
+    ASSERT_EQ(suite->rdc.getPortStatus(SerialIdentifier::OUTPUT_JACK), PortStatus::CONNECTED);
+    EXPECT_TRUE(cdm.canInitiateMatch());
+}
+
 // Bounties never initiate matches regardless of topology
 inline void cdmCanInitiateMatchFalseForBounty(ChainDuelManagerTests* suite) {
     suite->player.setIsHunter(false);

--- a/test/test_core/player-tests.hpp
+++ b/test/test_core/player-tests.hpp
@@ -165,3 +165,60 @@ inline void playerReactionTimeAverageCalculatesCorrectly(Player* player) {
     EXPECT_EQ(player->getLastReactionTime(), 400);
     EXPECT_EQ(player->getAverageReactionTime(), 300); // (200+300+400)/3
 }
+
+// ============================================
+// Role Change + Outgoing Profile Tests
+// ============================================
+
+// The role-flip observer is what drives the connection-context re-broadcast, so
+// it must fire on every real flip and stay silent on a set that reasserts the
+// current role — an idle re-registration would otherwise put a redundant frame
+// on the air for every peer.
+inline void playerRoleChangeFiresOnlyOnFlip(Player* player) {
+    int flips = 0;
+    player->setIsHunter(true);
+    player->setOnRoleChanged([&flips]() { flips++; });
+
+    player->setIsHunter(true);
+    EXPECT_EQ(flips, 0);
+
+    player->setIsHunter(false);
+    EXPECT_EQ(flips, 1);
+    EXPECT_FALSE(player->isHunter());
+
+    player->toggleHunter();
+    EXPECT_EQ(flips, 2);
+    EXPECT_TRUE(player->isHunter());
+
+    // A fetched profile is the other role write path and must notify too.
+    Player source("1234", Allegiance::HELIX, false);
+    player->fromJson(source.toJson());
+    EXPECT_EQ(flips, 3);
+    EXPECT_FALSE(player->isHunter());
+}
+
+// toProfile is what a peer decodes out of the connection context, so gameRole
+// must track the live role and an unregistered id must read as the sentinel
+// rather than as player 0.
+inline void playerProfileCarriesRoleAndIdentity(Player* player) {
+    PlayerProfile unregistered = player->toProfile();
+    EXPECT_EQ(unregistered.userId, 0xFFFF);
+
+    char testId[] = "4242";
+    player->setUserID(testId);
+    player->setName("A-very-long-player-name");
+    player->setFaction("LongFactionName");
+    player->setAllegiance(Allegiance::HELIX);
+    player->setIsHunter(true);
+
+    PlayerProfile hunter = player->toProfile();
+    EXPECT_EQ(hunter.userId, 4242);
+    EXPECT_EQ(hunter.gameRole, 1);
+    EXPECT_EQ(hunter.allegiance, static_cast<uint8_t>(Allegiance::HELIX));
+    // Truncated to the fixed wire widths and still NUL-terminated.
+    EXPECT_EQ(std::string(hunter.name), "A-very-long-pla");
+    EXPECT_EQ(std::string(hunter.faction), "LongFac");
+
+    player->setIsHunter(false);
+    EXPECT_EQ(player->toProfile().gameRole, 0);
+}

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -2455,6 +2455,18 @@ inline PlayerProfile profileFromContextBytes(const std::vector<uint8_t>& bytes) 
     return ctx.player;
 }
 
+// Captures every outbound PdnConnectionContext frame's exact bytes, and lets the
+// caller vary the profile the RDC reads at send time.
+inline void captureContextSends(RDCHelloTests* suite, std::vector<std::vector<uint8_t>>* sends) {
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, PktType::kPdnConnectionContext, _, _))
+        .WillByDefault(testing::DoAll(
+            testing::Invoke([sends](const uint8_t*, PktType, const uint8_t* data, size_t len) {
+                sends->push_back(std::vector<uint8_t>(data, data + len));
+            }),
+            Return(1)));
+}
+
 // #162: a hunter/bounty flip on an already-Connected link must put a fresh
 // context on the air, and that context must carry the CURRENT profile — the
 // exchange otherwise runs once per connect, so the peer would keep acting on the
@@ -2542,4 +2554,69 @@ inline void rdcResendContextSkipsUnconnectedJacks(RDCHelloTests* suite) {
 
     suite->rdc.resendContext();
     EXPECT_EQ(contextSends, 1);
+}
+
+// A Connected jack whose connect-time send is still unacked is the case that
+// matters most: that armed entry holds the OLD role's bytes, so skipping the peer
+// would freeze it on the stale role forever. SEND_FAIL is ignored and the peer's
+// context completes the jack without clearing the entry, so this state persists.
+inline void rdcResendContextSupersedesUnackedSend(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    uint8_t liveRole = 0;
+    suite->rdc.setSelfProfileProvider([&liveRole]() -> PlayerProfile {
+        PlayerProfile profile{};
+        profile.userId = 4242;
+        profile.gameRole = liveRole;
+        return profile;
+    });
+
+    std::vector<std::vector<uint8_t>> contextSends;
+    captureContextSends(suite, &contextSends);
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(contextSends.size(), 1u);
+    // Deliberately no onSendResult: the connect-time send stays armed.
+
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    ASSERT_TRUE(suite->rdc.isContextSendPending(peer));
+    ASSERT_EQ(contextSends.size(), 1u);
+
+    liveRole = 1;
+    suite->rdc.resendContext();
+
+    ASSERT_EQ(contextSends.size(), 2u);
+    EXPECT_EQ(profileFromContextBytes(contextSends[1]).gameRole, 1);
+}
+
+// A 2-node ring points both jacks at one peer, and one frame reaches it however
+// many jacks face it: the re-broadcast sends once per PEER, not once per jack.
+inline void rdcResendContextSendsOncePerPeer(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xB1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    std::vector<std::vector<uint8_t>> contextSends;
+    captureContextSends(suite, &contextSends);
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xB1));
+    suite->deliverHello(suite->inJack, suite->helloFrame(0xB1));
+    suite->rdc.sync(&suite->device);
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    const size_t beforeResend = contextSends.size();
+
+    suite->rdc.resendContext();
+
+    EXPECT_EQ(contextSends.size(), beforeResend + 1);
 }

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -2447,3 +2447,101 @@ inline void rdcUnprovenUpstreamIsNeverAdopted(RDCHelloTests* suite) {
     const uint8_t zero[6] = {0, 0, 0, 0, 0, 0};
     EXPECT_EQ(0, memcmp(parseEmittedHello(suite->outJack.getOutput()).headMac, zero, 6));
 }
+
+// Reads the PlayerProfile back out of a captured PdnConnectionContext frame.
+inline PlayerProfile profileFromContextBytes(const std::vector<uint8_t>& bytes) {
+    PdnConnectionContext ctx{};
+    memcpy(&ctx, bytes.data(), sizeof(ctx) < bytes.size() ? sizeof(ctx) : bytes.size());
+    return ctx.player;
+}
+
+// #162: a hunter/bounty flip on an already-Connected link must put a fresh
+// context on the air, and that context must carry the CURRENT profile — the
+// exchange otherwise runs once per connect, so the peer would keep acting on the
+// role it learned at plug-in until the cable is pulled. Also covers the profile
+// source itself: an unwired provider is what made the whole exchange ship 28
+// zero bytes.
+inline void rdcResendContextPushesCurrentProfile(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    uint8_t liveRole = 0;
+    suite->rdc.setSelfProfileProvider([&liveRole]() -> PlayerProfile {
+        PlayerProfile profile{};
+        profile.userId = 4242;
+        profile.gameRole = liveRole;
+        return profile;
+    });
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    std::vector<std::vector<uint8_t>> contextSends;
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, PktType::kPdnConnectionContext, _, _))
+        .WillByDefault(testing::DoAll(
+            testing::Invoke([&contextSends](const uint8_t*, PktType, const uint8_t* data,
+                                            size_t len) {
+                contextSends.push_back(std::vector<uint8_t>(data, data + len));
+            }),
+            Return(1)));
+
+    // Full connect on the OUT jack; the connect-time context carries the profile
+    // the provider held at that moment.
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(contextSends.size(), 1u);
+    EXPECT_EQ(profileFromContextBytes(contextSends[0]).userId, 4242);
+    EXPECT_EQ(profileFromContextBytes(contextSends[0]).gameRole, 0);
+    suite->transport()->onSendResult(PktType::kPdnConnectionContext, peer,
+                                     contextSends[0].data(), contextSends[0].size(), true);
+
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    ASSERT_EQ(contextSends.size(), 1u);
+
+    // The role flips; the re-broadcast carries the new one.
+    liveRole = 1;
+    suite->rdc.resendContext();
+
+    ASSERT_EQ(contextSends.size(), 2u);
+    EXPECT_EQ(profileFromContextBytes(contextSends[1]).gameRole, 1);
+    EXPECT_EQ(profileFromContextBytes(contextSends[1]).userId, 4242);
+    EXPECT_TRUE(suite->rdc.isContextSendPending(peer));
+}
+
+// A jack that only reached CONNECTING has no proven return path, so a
+// re-broadcast must skip it rather than racing the connect-time send it would
+// otherwise duplicate. Nothing is Connected here, so nothing goes out.
+inline void rdcResendContextSkipsUnconnectedJacks(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    int contextSends = 0;
+    std::vector<uint8_t> sentPayload;
+    ON_CALL(*suite->device.mockPeerComms, sendData(_, PktType::kPdnConnectionContext, _, _))
+        .WillByDefault(testing::DoAll(
+            testing::Invoke([&](const uint8_t*, PktType, const uint8_t* data, size_t len) {
+                contextSends++;
+                sentPayload.assign(data, data + len);
+            }),
+            Return(1)));
+
+    // Every jack Idle: a re-broadcast has nowhere to go.
+    suite->rdc.resendContext();
+    EXPECT_EQ(contextSends, 0);
+
+    // OUT jack CONNECTING (one HELLO, no context back). Clear the connect-time
+    // send first so the pending-collapse guard is not what suppresses the resend.
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(contextSends, 1);
+    suite->transport()->onSendResult(
+        PktType::kPdnConnectionContext, peer, sentPayload.data(), sentPayload.size(), true);
+    ASSERT_FALSE(suite->rdc.isContextSendPending(peer));
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+
+    suite->rdc.resendContext();
+    EXPECT_EQ(contextSends, 1);
+}

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -2458,9 +2458,7 @@ inline PlayerProfile profileFromContextBytes(const std::vector<uint8_t>& bytes) 
 // #162: a hunter/bounty flip on an already-Connected link must put a fresh
 // context on the air, and that context must carry the CURRENT profile — the
 // exchange otherwise runs once per connect, so the peer would keep acting on the
-// role it learned at plug-in until the cable is pulled. Also covers the profile
-// source itself: an unwired provider is what made the whole exchange ship 28
-// zero bytes.
+// role it learned at plug-in until the cable is pulled.
 inline void rdcResendContextPushesCurrentProfile(RDCHelloTests* suite) {
     const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
 

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -2455,6 +2455,13 @@ inline PlayerProfile profileFromContextBytes(const std::vector<uint8_t>& bytes) 
     return ctx.player;
 }
 
+// Reads the sender's chainRole back out of a captured PdnConnectionContext frame.
+inline uint8_t chainRoleFromContextBytes(const std::vector<uint8_t>& bytes) {
+    PdnConnectionContext ctx{};
+    memcpy(&ctx, bytes.data(), sizeof(ctx) < bytes.size() ? sizeof(ctx) : bytes.size());
+    return ctx.chainRole;
+}
+
 // Captures every outbound PdnConnectionContext frame's exact bytes, and lets the
 // caller vary the profile the RDC reads at send time.
 inline void captureContextSends(RDCHelloTests* suite, std::vector<std::vector<uint8_t>>* sends) {
@@ -2593,6 +2600,36 @@ inline void rdcResendContextSupersedesUnackedSend(RDCHelloTests* suite) {
 
     ASSERT_EQ(contextSends.size(), 2u);
     EXPECT_EQ(profileFromContextBytes(contextSends[1]).gameRole, 1);
+}
+
+// The context tells a neighbour where this device sits in the chain, so the field
+// has to come from the live topology: the connect-time frame goes out with no link
+// up yet (STANDALONE), and once the OUT jack is Connected this device is the HEAD.
+inline void rdcContextCarriesOwnChainRole(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    std::vector<std::vector<uint8_t>> contextSends;
+    captureContextSends(suite, &contextSends);
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(contextSends.size(), 1u);
+    EXPECT_EQ(chainRoleFromContextBytes(contextSends[0]),
+              static_cast<uint8_t>(ChainRole::STANDALONE));
+    suite->transport()->onSendResult(PktType::kPdnConnectionContext, peer,
+                                     contextSends[0].data(), contextSends[0].size(), true);
+
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/0, /*userId=*/7, /*seqId=*/3);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    suite->rdc.resendContext();
+
+    ASSERT_EQ(contextSends.size(), 2u);
+    EXPECT_EQ(chainRoleFromContextBytes(contextSends[1]),
+              static_cast<uint8_t>(ChainRole::HEAD));
 }
 
 // A 2-node ring points both jacks at one peer, and one frame reaches it however

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -496,6 +496,14 @@ TEST_F(PlayerTestSuite, jsonRoundTripWithBountyRole) {
     playerJsonRoundTripWithBountyRole(player);
 }
 
+TEST_F(PlayerTestSuite, roleChangeFiresOnlyOnFlip) {
+    playerRoleChangeFiresOnlyOnFlip(player);
+}
+
+TEST_F(PlayerTestSuite, profileCarriesRoleAndIdentity) {
+    playerProfileCarriesRoleAndIdentity(player);
+}
+
 TEST_F(PlayerTestSuite, statsIncrementCorrectly) {
     playerStatsIncrementCorrectly(player);
 }
@@ -1418,6 +1426,12 @@ TEST_F(RDCHelloTests, replugAfterFailedExchangeRecovers) {
 TEST_F(RDCHelloTests, connectedRetryResendThrottled) {
     rdcConnectedRetryResendThrottled(this);
 }
+TEST_F(RDCHelloTests, resendContextPushesCurrentProfile) {
+    rdcResendContextPushesCurrentProfile(this);
+}
+TEST_F(RDCHelloTests, resendContextSkipsUnconnectedJacks) {
+    rdcResendContextSkipsUnconnectedJacks(this);
+}
 TEST_F(RDCHelloTests, linkDeathClearsPeerChainRole) {
     rdcLinkDeathClearsPeerChainRole(this);
 }
@@ -1578,6 +1592,10 @@ TEST_F(RDCHelloTests, unprovenUpstreamIsNeverAdopted) {
 
 TEST_F(ChainDuelManagerTests, roleDerivationWithChampionTopology) {
     cdmRoleDerivationWithChampionTopology(this);
+}
+
+TEST_F(ChainDuelManagerTests, canInitiateMatchRequiresConnectedOpponentJack) {
+    cdmCanInitiateMatchRequiresConnectedOpponentJack(this);
 }
 
 TEST_F(ChainDuelManagerTests, canInitiateMatchFalseForBounty) {

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1438,6 +1438,9 @@ TEST_F(RDCHelloTests, resendContextSupersedesUnackedSend) {
 TEST_F(RDCHelloTests, resendContextSendsOncePerPeer) {
     rdcResendContextSendsOncePerPeer(this);
 }
+TEST_F(RDCHelloTests, contextCarriesOwnChainRole) {
+    rdcContextCarriesOwnChainRole(this);
+}
 TEST_F(RDCHelloTests, linkDeathClearsPeerChainRole) {
     rdcLinkDeathClearsPeerChainRole(this);
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1432,6 +1432,12 @@ TEST_F(RDCHelloTests, resendContextPushesCurrentProfile) {
 TEST_F(RDCHelloTests, resendContextSkipsUnconnectedJacks) {
     rdcResendContextSkipsUnconnectedJacks(this);
 }
+TEST_F(RDCHelloTests, resendContextSupersedesUnackedSend) {
+    rdcResendContextSupersedesUnackedSend(this);
+}
+TEST_F(RDCHelloTests, resendContextSendsOncePerPeer) {
+    rdcResendContextSendsOncePerPeer(this);
+}
 TEST_F(RDCHelloTests, linkDeathClearsPeerChainRole) {
     rdcLinkDeathClearsPeerChainRole(this);
 }


### PR DESCRIPTION
Closes #162.

Two behaviours from the edge-case checklist, plus the gap that made the first one pointless.

## Role-change re-broadcast

`Player::setOnRoleChanged` registers one observer; all three role write paths (`setIsHunter`, `toggleHunter`, `fromJson`) funnel through a private `applyRole` that fires only on an actual flip. `Quickdraw` registers it to call `rdc->resendContext()`, which walks the HELLO jacks and re-sends this device's context to every CONNECTED peer, reusing `sendSelfContext`.

`resendContext` deliberately does **not** skip a peer with a send already in flight. The context channels run `SUPERSEDE_PER_TARGET`, whose `send()` erases prior entries for that target and transmits immediately, while a pending entry holds a byte snapshot of the *old* payload. Skipping would have meant the peer kept acting on the stale role permanently, since the abandon callback is a no-op. `initiateContextExchange` keeps its identical guard, because there the payload really is the same and the saving is real. Dedup within a resend pass is by covered-MAC set, not by previous MAC — three jacks can point two of them at one peer with the third differing.

## The blocking gap

`setSelfPlayerProfile` had zero callers anywhere in the tree, so `sendSelfContext` was putting 28 zero bytes on the air. Re-broadcasting a zeroed profile achieves nothing, so this wires the real one.

**This changes the RDC surface and you should push back if you disagree.** I replaced the dead `setSelfPlayerProfile(const PlayerProfile&)` setter with `setSelfProfileProvider(std::function<PlayerProfile()>)`, pulled at send time. A stored copy is only correct if every field's settle point remembers to push again, and userId, name, faction and role each settle at a different moment in registration — a device that never flips role would still ship zeros. A provider cannot go stale. The push form is one line to restore if you want it.

## Half-open connection gate

`canInitiateMatch` now also requires not-in-ring (reusing the existing `isLoop()` rather than inventing a second ring notion), the opponent jack at `CONNECTED`, and the peer being a PDN. The two now-redundant terms at the `idle-state` call site are gone.

**I kept the opposite-role term that `rdc-chain.allium` says is deliberately absent.** On this base `isSupporter()` still derives from `peerIsHunter(opponentJack())`, so dropping it makes a hunter-behind-hunter device both a supporter and a match initiator — it would emit a spurious match id before every transition to SupporterReady, and I would have had to invert two green tests to assert that. The spec's removal is coupled to moving supporter derivation onto `chain_role`, which is #145's work, not this issue. The `MATCH_ROLE_MISMATCH` bounce does exist in `match-manager.cpp`, so the term can come out safely once that lands.

## chainRole on the wire

`sendSelfContext` hardcoded `ctx.chainRole = 0` in both branches, with a comment saying #156 would fill it. #156 closed without doing so, and nothing else does, so `getPeerChainRole` could only ever return 0 — including the value PR #216 hands the game layer inside `ConnectionContext`. It now carries `getChainRole()`, mapped identity since the enum values are the wire values.

Two consequences worth knowing before anyone trusts that field. Wire 0 is ambiguous between "no context yet" and "the sender is STANDALONE". And `getChainRole()` counts only CONNECTED links, so on the connect-time frame the sending jack is still CONNECTING and the honest answer is usually STANDALONE anyway. The value is a snapshot at send time and goes stale as the chain forms, because the only re-send trigger is a player role flip, not a chain-role change. Wiring `resendContext` to chain-role changes would close that, but it needs a callback slot and belongs with #159's callback work rather than here.

## Reachability

`resendContext` is dormant on hardware: nothing under `src/` calls `enableHelloConnectivity()`, so it goes live at the HELLO cutover. The half-open gate **is** live today, because `getPortStatus` falls back to the handshake mapping.

Every new test was falsified by reverting its own mechanism and confirmed to fail alone. No existing test was changed, weakened or removed. Expect a rebase: #216 and #159 both touch these two files. No hardware validation was performed.
