### PR TITLE
scale: broadcast ring fan-out, roster cap 64, parser resync

### DIFF
--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -122,9 +122,9 @@ struct ShootoutAckPayload
 // Point-to-point ReliableChannel payloads; the chain head is the sole consumer.
 // seqId is stamped by the channel on send.
 
-// Head-roster capacity, sized to the event envelope rather than to a frame:
-// a single ESP-NOW v2 HeadTransfer frame holds well over a hundred (member,
-// upstream) pairs, so the old 18 (one v1 250-byte frame) no longer binds.
+// Head-roster capacity, sized to the event envelope rather than to a frame: a
+// single ESP-NOW v2 HeadTransfer frame holds well over a hundred (member,
+// upstream) pairs, so framing is not what bounds this.
 //
 // Overflow contract: past this cap the head drops the announce, and the member
 // cannot learn that. SEND_SUCCESS on the announce is the only delivery signal

--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -64,8 +64,10 @@ struct FdnConnectionContext {
 
 struct DataPktHdr
 {
-    //Total packet length including header
-    uint8_t pktLen;
+    // Total packet length including header. Wide enough for a full ESP-NOW v2
+    // frame: the fleet is single-firmware on IDF 5.5, so every link negotiates
+    // v2 and a payload can exceed 255 bytes.
+    uint16_t pktLen;
     PktType packetType;
 } __attribute__((packed));
 
@@ -120,7 +122,17 @@ struct ShootoutAckPayload
 // Point-to-point ReliableChannel payloads; the chain head is the sole consumer.
 // seqId is stamped by the channel on send.
 
-constexpr uint8_t MAX_CHAIN_MEMBERS = 18;
+// Head-roster capacity, sized to the event envelope rather than to a frame:
+// a single ESP-NOW v2 HeadTransfer frame holds well over a hundred (member,
+// upstream) pairs, so the old 18 (one v1 250-byte frame) no longer binds.
+//
+// Overflow contract: past this cap the head drops the announce, and the member
+// cannot learn that. SEND_SUCCESS on the announce is the only delivery signal
+// the no-ack design has, and the radio acks a frame the head then discards, so
+// the member's HELLO confirmed bit rises while it is absent from the roster.
+// The cap is set past any real chain so the divergence is unreachable in
+// practice; closing it would need an admission reply the design excludes.
+constexpr uint8_t MAX_CHAIN_MEMBERS = 64;
 
 // Sent by a newly joined member directly to the head it read from its upstream
 // neighbour's HELLO. upstreamMac names the sender's direct upstream (INPUT) peer.
@@ -140,10 +152,10 @@ struct DisconnectReportPayload {
 // ever travels, and it is a single unicast. Entries are (member, upstream)
 // pairs — memberMacs[i]'s recorded direct upstream is upstreamMacs[i] — so the
 // receiver keeps the chain's true order instead of flattening every
-// transferred member onto the demoted head. At MAX_CHAIN_MEMBERS=18 this is
-// 218 bytes. The ceiling is the driver's reliable-payload budget
-// (MAX_PKT_DATA_SIZE, the uint8_t length header, ~253 bytes), asserted where
-// the driver includes this header; raising MAX_CHAIN_MEMBERS past ~20 trips it.
+// transferred member onto the demoted head. At MAX_CHAIN_MEMBERS=64 this is
+// 770 bytes. The ceiling is the driver's reliable-payload budget
+// (MAX_PKT_DATA_SIZE, one ESP-NOW v2 frame), asserted where the driver includes
+// this header.
 struct HeadTransferPayload {
     uint8_t seqId;
     uint8_t memberCount;

--- a/lib/core/include/device/serial-frame-parser.hpp
+++ b/lib/core/include/device/serial-frame-parser.hpp
@@ -98,6 +98,8 @@ private:
 
     void resetParser();
     void checkTimeout();
+    void consumeByte(uint8_t b);
+    void resyncFromConsumedBytes();
     static size_t opcodePayloadLen(uint8_t opcode);
     static unsigned long nowMs();
 };

--- a/lib/core/include/protocol-constants.hpp
+++ b/lib/core/include/protocol-constants.hpp
@@ -3,7 +3,11 @@
 #include <string>
 
 // Serial communication speed shared by all serial drivers and the handshake protocol.
-constexpr uint16_t BAUDRATE = 19200;
+// uint32_t, not uint16_t: common rates above 65535 (115200 among them) wrap in 16
+// bits and would silently configure the UART for a different speed.
+constexpr uint32_t BAUDRATE = 19200;
+static_assert(static_cast<decltype(BAUDRATE)>(115200) == 115200,
+              "BAUDRATE type cannot express 115200; in 16 bits it wraps to 49664");
 
 // Heartbeat token sent on the serial line to keep connections alive.
 inline const std::string SERIAL_HEARTBEAT = "hb";

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -170,6 +170,9 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
         // older announce's delivery stale — the re-announce to the current head
         // is what gates confirmed — so the seqId must match the latest announce
         // sent AND the destination must still be the head currently held.
+        // confirmed therefore means "the head's radio took it", not "the head
+        // admitted me": a roster at MAX_CHAIN_MEMBERS drops the announce after
+        // the ack.
         connectionAnnounceChannel->setOnDelivered([this](uint8_t seqId, const uint8_t* toMac) {
             if (seqId != pendingAnnounceSeqId) return;
             const uint64_t head = chainHeadState.load();
@@ -1369,7 +1372,13 @@ void RemoteDeviceCoordinator::onConnectionAnnounce(const uint8_t* fromMac,
     // though eviction frees the slot. Re-read size after the eviction.
     evictStaleUpstreamClaimant(member, upstream);
     if (isNew && chainRoster.size() >= MAX_CHAIN_MEMBERS) {
-        LOG_W("RDC", "chain roster full (%u); dropping announce", MAX_CHAIN_MEMBERS);
+        // The member cannot be told: its announce already drew SEND_SUCCESS, so
+        // its HELLO confirmed bit reads 1 while it is absent from this roster
+        // (see MAX_CHAIN_MEMBERS). Loud because the cap sits past any real chain
+        // — reaching it means the roster is being fed by something else.
+        LOG_E("RDC", "chain roster full (%u); dropping announce from %s, which "
+                     "will still read as confirmed",
+              MAX_CHAIN_MEMBERS, MacToString(fromMac));
         return;
     }
     chainRoster[member] = upstream;
@@ -1456,6 +1465,9 @@ void RemoteDeviceCoordinator::onHeadTransfer(const uint8_t* /*fromMac*/,
         if (memcmp(member.data(), selfMac.data(), 6) == 0) continue;  // never roster self
         if (chainRoster.count(member) != 0) continue;
         if (isUpstreamHeldByOther(upstream, member)) continue;
+        // Unlike the announce path this drop is self-healing: the head change that
+        // triggered the transfer clears each member's confirmed bit and makes it
+        // re-announce, so a member cut here comes back under its own announce.
         if (chainRoster.size() >= MAX_CHAIN_MEMBERS) break;
         chainRoster[member] = upstream;
         changed = true;

--- a/lib/core/src/device/serial-frame-parser.cpp
+++ b/lib/core/src/device/serial-frame-parser.cpp
@@ -86,66 +86,91 @@ void SerialFrameParser::feed(const uint8_t* data, size_t len) {
     const unsigned long now = nowMs();
     lastByteMs = now;
     for (size_t i = 0; i < len; ++i) {
-        const uint8_t b = data[i];
-        switch (parser.state) {
-            case ParseState::SCAN_FOR_SYNC:
-                if (b == FRAME_PREAMBLE_0) {
-                    parser.state = ParseState::GOT_AA;
-                }
+        consumeByte(data[i]);
+    }
+}
+
+void SerialFrameParser::resyncFromConsumedBytes() {
+    // A CRC failure means the frame boundary is wrong, not merely that a byte
+    // flipped: a truncated frame keeps consuming into the next one, so throwing
+    // the consumed bytes away costs two frames per dropped byte instead of one.
+    // The driver drains the whole RX FIFO in a single loop, so there need be no
+    // inter-frame gap for the mid-frame timeout to catch that. Replaying the
+    // bytes after the (already disproven) preamble and opcode lets an embedded
+    // 0xAA 0x55 restart framing at the real frame start; a trailing lone 0xAA
+    // ends in GOT_AA and pairs with whatever byte arrives next.
+    std::vector<uint8_t> replay = parser.payloadBuf;
+    replay.insert(replay.end(), parser.crcBytes, parser.crcBytes + parser.crcBytesRead);
+    resetParser();
+    // Re-entry depth is one: dropping the preamble and opcode leaves the replay
+    // shorter than a whole frame, so it cannot reach another CRC comparison.
+    for (uint8_t b : replay) {
+        consumeByte(b);
+    }
+}
+
+void SerialFrameParser::consumeByte(uint8_t b) {
+    switch (parser.state) {
+        case ParseState::SCAN_FOR_SYNC:
+            if (b == FRAME_PREAMBLE_0) {
+                parser.state = ParseState::GOT_AA;
+            }
+            break;
+        case ParseState::GOT_AA:
+            if (b == FRAME_PREAMBLE_1) {
+                parser.state = ParseState::READING_OPCODE;
+            } else if (b == FRAME_PREAMBLE_0) {
+                // Stay in GOT_AA: a stray 0xAA followed by the real preamble (0xAA 0x55) should
+                // still detect the frame start. Going back to SCAN_FOR_SYNC would drop the second
+                // 0xAA, requiring a 3-byte preamble before re-syncing.
+            } else {
+                resetParser();
+            }
+            break;
+        case ParseState::READING_OPCODE:
+            if (b != OP_HELLO) {  // HELLO is the sole serial opcode
+                resetParser();
                 break;
-            case ParseState::GOT_AA:
-                if (b == FRAME_PREAMBLE_1) {
-                    parser.state = ParseState::READING_OPCODE;
-                } else if (b == FRAME_PREAMBLE_0) {
-                    // Stay in GOT_AA: a stray 0xAA followed by the real preamble (0xAA 0x55) should
-                    // still detect the frame start. Going back to SCAN_FOR_SYNC would drop the second
-                    // 0xAA, requiring a 3-byte preamble before re-syncing.
-                } else {
-                    resetParser();
-                }
-                break;
-            case ParseState::READING_OPCODE:
-                if (b != OP_HELLO) {  // HELLO is the sole serial opcode
-                    resetParser();
+            }
+            parser.opcode = b;
+            parser.expectedPayloadLen = opcodePayloadLen(b);
+            parser.payloadBuf.clear();
+            if (parser.expectedPayloadLen == 0) {
+                parser.state = ParseState::READING_CRC;
+                parser.crcBytesRead = 0;
+            } else {
+                parser.state = ParseState::READING_PAYLOAD;
+            }
+            break;
+        case ParseState::READING_PAYLOAD:
+            parser.payloadBuf.push_back(b);
+            if (parser.payloadBuf.size() >= parser.expectedPayloadLen) {
+                parser.state = ParseState::READING_CRC;
+                parser.crcBytesRead = 0;
+            }
+            break;
+        case ParseState::READING_CRC:
+            parser.crcBytes[parser.crcBytesRead++] = b;
+            if (parser.crcBytesRead == 2) {
+                const uint16_t got = (static_cast<uint16_t>(parser.crcBytes[0]) << 8) | static_cast<uint16_t>(parser.crcBytes[1]);
+                // CRC covers opcode + payload; fold the two spans into a
+                // running CRC to avoid a per-frame copy on the UART event task.
+                uint16_t expected = crc16(&parser.opcode, 1);
+                expected = crc16Update(expected, parser.payloadBuf.data(),
+                                       parser.payloadBuf.size());
+                if (got != expected) {
+                    resyncFromConsumedBytes();
                     break;
                 }
-                parser.opcode = b;
-                parser.expectedPayloadLen = opcodePayloadLen(b);
-                parser.payloadBuf.clear();
-                if (parser.expectedPayloadLen == 0) {
-                    parser.state = ParseState::READING_CRC;
-                    parser.crcBytesRead = 0;
-                } else {
-                    parser.state = ParseState::READING_PAYLOAD;
+                if (helloFrameHandler && parser.payloadBuf.size() == sizeof(HelloPayload)) {
+                    // The packed struct mirrors the wire byte-for-byte, so
+                    // the validated payload copies straight in.
+                    HelloPayload hello;
+                    std::memcpy(&hello, parser.payloadBuf.data(), sizeof(hello));
+                    helloFrameHandler(hello);
                 }
-                break;
-            case ParseState::READING_PAYLOAD:
-                parser.payloadBuf.push_back(b);
-                if (parser.payloadBuf.size() >= parser.expectedPayloadLen) {
-                    parser.state = ParseState::READING_CRC;
-                    parser.crcBytesRead = 0;
-                }
-                break;
-            case ParseState::READING_CRC:
-                parser.crcBytes[parser.crcBytesRead++] = b;
-                if (parser.crcBytesRead == 2) {
-                    const uint16_t got = (static_cast<uint16_t>(parser.crcBytes[0]) << 8) | static_cast<uint16_t>(parser.crcBytes[1]);
-                    // CRC covers opcode + payload; fold the two spans into a
-                    // running CRC to avoid a per-frame copy on the UART event task.
-                    uint16_t expected = crc16(&parser.opcode, 1);
-                    expected = crc16Update(expected, parser.payloadBuf.data(),
-                                           parser.payloadBuf.size());
-                    if (got == expected && helloFrameHandler &&
-                        parser.payloadBuf.size() == sizeof(HelloPayload)) {
-                        // The packed struct mirrors the wire byte-for-byte, so
-                        // the validated payload copies straight in.
-                        HelloPayload hello;
-                        std::memcpy(&hello, parser.payloadBuf.data(), sizeof(hello));
-                        helloFrameHandler(hello);
-                    }
-                    resetParser();
-                }
-                break;
-        }
+                resetParser();
+            }
+            break;
     }
 }

--- a/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
+++ b/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
@@ -24,17 +24,19 @@ constexpr uint8_t PEER_BROADCAST_ADDR[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 // Max application payload per frame. ESP-NOW v2.0 (IDF 5.x, all-S3 targets)
 // carries up to 1470 bytes in a single frame, so every packet type fits in
 // one send — no multi-frame clustering.
-// The payload ceiling is whatever DataPktHdr::pktLen can hold (it stores the
-// total packet length), minus the header. ESP-NOW v2 frames are far larger,
-// but the length field is the real ceiling: a payload above this would overflow
-// pktLen and deliver a corrupt short buffer. Derived from the field's type so
-// it follows automatically if pktLen ever widens.
-constexpr size_t MAX_PKT_DATA_SIZE =
-    std::numeric_limits<decltype(DataPktHdr::pktLen)>::max() - sizeof(DataPktHdr);
+// The payload ceiling is one ESP-NOW v2 frame minus the header: the radio, not
+// the length field, is what binds now.
+constexpr size_t MAX_PKT_DATA_SIZE = ESP_NOW_MAX_DATA_LEN_V2 - sizeof(DataPktHdr);
+
+// pktLen carries the total packet length on the wire, so it has to be able to
+// express a full frame or a large payload would arrive as a corrupt short buffer.
+static_assert(ESP_NOW_MAX_DATA_LEN_V2 <=
+                  std::numeric_limits<decltype(DataPktHdr::pktLen)>::max(),
+              "DataPktHdr::pktLen cannot express a full ESP-NOW v2 frame");
 
 // The head-roster handoff is the largest reliable payload and grows with
-// MAX_CHAIN_MEMBERS (#218 raises it). A cap bump that overflows this budget
-// must break the build here, not silently fail sendData at runtime.
+// MAX_CHAIN_MEMBERS. A cap bump that overflows this budget must break the build
+// here, not silently fail sendData at runtime.
 static_assert(sizeof(HeadTransferPayload) <= MAX_PKT_DATA_SIZE,
               "HeadTransferPayload exceeds the reliable-payload budget; "
               "lower MAX_CHAIN_MEMBERS or split the transfer across frames");

--- a/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
+++ b/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
@@ -389,6 +389,19 @@ private:
 
         const auto* pktHdr = reinterpret_cast<const DataPktHdr*>(data);
 
+        // pktLen comes off the wire and is what bounds the copy handed to the packet
+        // handlers, so it has to agree with what the radio actually delivered.
+        // sendData is the sole writer and sets the two equal. Below the header size it
+        // would also underflow handleSinglePacket's subtraction to about SIZE_MAX.
+        if (pktHdr->pktLen < sizeof(DataPktHdr) ||
+            static_cast<size_t>(pktHdr->pktLen) != static_cast<size_t>(data_len)) {
+            LOG_E("ENC", "Declared pktLen %u disagrees with received %i from %X:%X:%X:%X:%X:%X\n",
+                  pktHdr->pktLen, data_len,
+                  esp_now_info->src_addr[0], esp_now_info->src_addr[1], esp_now_info->src_addr[2],
+                  esp_now_info->src_addr[3], esp_now_info->src_addr[4], esp_now_info->src_addr[5]);
+            return;
+        }
+
 #if DEBUG_PRINT_ESP_NOW
         ESP_LOGD("ENC", "Packet Type: %i\n", pktHdr->packetType);
 #endif

--- a/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
+++ b/lib/esp32-drivers/include/device/drivers/esp32-s3/esp-now-driver.hpp
@@ -24,8 +24,6 @@ constexpr uint8_t PEER_BROADCAST_ADDR[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 // Max application payload per frame. ESP-NOW v2.0 (IDF 5.x, all-S3 targets)
 // carries up to 1470 bytes in a single frame, so every packet type fits in
 // one send — no multi-frame clustering.
-// The payload ceiling is one ESP-NOW v2 frame minus the header: the radio, not
-// the length field, is what binds now.
 constexpr size_t MAX_PKT_DATA_SIZE = ESP_NOW_MAX_DATA_LEN_V2 - sizeof(DataPktHdr);
 
 // pktLen carries the total packet length on the wire, so it has to be able to

--- a/src/pdn/game/quickdraw.cpp
+++ b/src/pdn/game/quickdraw.cpp
@@ -254,7 +254,7 @@ void Quickdraw::onShootoutCommandPacket(const uint8_t* fromMac, const uint8_t* d
             if (payloadLen >= 6) shootoutManager->onPeerLostReceived(payload);
             break;
         case ShootoutCmd::ABORT:
-            shootoutManager->onAbortReceived();
+            shootoutManager->onAbortReceived(fromMac);
             break;
     }
 }

--- a/src/pdn/game/quickdraw.cpp
+++ b/src/pdn/game/quickdraw.cpp
@@ -17,9 +17,11 @@ Quickdraw::Quickdraw(Player* player, Device* PDN, QuickdrawWirelessManager* quic
     this->remoteDeviceCoordinator = PDN->getRemoteDeviceCoordinator();
 
     this->chainDuelManager = new ChainDuelManager(player, wirelessManager, remoteDeviceCoordinator);
-    this->shootoutManager_ = new ShootoutManager(player, wirelessManager, remoteDeviceCoordinator, chainDuelManager);
-    this->shootoutManager_->setMatchManager(matchManager);
-    matchManager->setShootoutManager(shootoutManager_);
+    // Reads chainDuelManager, which this constructor assigns in the body: hoisting
+    // this into the member-initializer list would read it uninitialized.
+    this->shootoutManager = new ShootoutManager(player, wirelessManager, remoteDeviceCoordinator, chainDuelManager);  // NOLINT(cppcoreguidelines-prefer-member-initializer)
+    this->shootoutManager->setMatchManager(matchManager);
+    matchManager->setShootoutManager(shootoutManager);
 
     matchManager->initialize(player, storageManager, quickdrawWirelessManager);
     matchManager->setBoostProvider([this]() -> unsigned long {
@@ -101,8 +103,8 @@ Quickdraw::Quickdraw(Player* player, Device* PDN, QuickdrawWirelessManager* quic
     });
 
     remoteDeviceCoordinator->setPeerLostCallback([this](const uint8_t* lostMac) {
-        if (shootoutManager_ && shootoutManager_->active()) {
-            shootoutManager_->onLocalRDCDisconnect(lostMac);
+        if (shootoutManager && shootoutManager->active()) {
+            shootoutManager->onLocalRDCDisconnect(lostMac);
         }
     });
 
@@ -144,15 +146,15 @@ void Quickdraw::onStateLoop(Device* pdn) {
 
     if (chainDuelManager) {
         bool loopNow = chainDuelManager->isLoop();
-        if (loopNow != lastIsLoop_) {
-            LOG_W("CDM", "isLoop %d -> %d", (int)lastIsLoop_, (int)loopNow);
-            lastIsLoop_ = loopNow;
+        if (loopNow != lastIsLoop) {
+            LOG_W("CDM", "isLoop %d -> %d", (int)lastIsLoop, (int)loopNow);
+            lastIsLoop = loopNow;
         }
     }
 
-    if (!statsLogTimer_.isRunning()) {
-        statsLogTimer_.setTimer(kStatsLogIntervalMs);
-    } else if (statsLogTimer_.expired()) {
+    if (!statsLogTimer.isRunning()) {
+        statsLogTimer.setTimer(kStatsLogIntervalMs);
+    } else if (statsLogTimer.expired()) {
         if (remoteDeviceCoordinator != nullptr && chainDuelManager != nullptr) {
             auto r = remoteDeviceCoordinator->getRetryStats();
             auto c = chainDuelManager->getRetryStats();
@@ -167,7 +169,7 @@ void Quickdraw::onStateLoop(Device* pdn) {
                 (unsigned)c.sends, (unsigned)c.retries, (unsigned)c.abandons,
                 (unsigned)c.ackCount, cMean);
         }
-        statsLogTimer_.setTimer(kStatsLogIntervalMs);
+        statsLogTimer.setTimer(kStatsLogIntervalMs);
     }
 
     StateMachine::onStateLoop(pdn);
@@ -208,7 +210,7 @@ void Quickdraw::onChainConfirmPacket(const uint8_t* fromMac, const uint8_t* data
 }
 
 void Quickdraw::onShootoutCommandPacket(const uint8_t* fromMac, const uint8_t* data, size_t dataLen) {
-    if (!shootoutManager_ || dataLen < 2) return;
+    if (!shootoutManager || dataLen < 2) return;
     if (data[0] > static_cast<uint8_t>(ShootoutCmd::ABORT)) return;
     ShootoutCmd cmd = static_cast<ShootoutCmd>(data[0]);
     uint8_t seqId = data[1];
@@ -219,7 +221,7 @@ void Quickdraw::onShootoutCommandPacket(const uint8_t* fromMac, const uint8_t* d
             if (payloadLen < 6) break;
             const char* name = (payloadLen >= 6 + ShootoutManager::kNameLength)
                 ? reinterpret_cast<const char*>(payload + 6) : nullptr;
-            shootoutManager_->onConfirmReceived(payload, name);
+            shootoutManager->onConfirmReceived(payload, name);
             break;
         }
         case ShootoutCmd::BRACKET: {
@@ -234,46 +236,46 @@ void Quickdraw::onShootoutCommandPacket(const uint8_t* fromMac, const uint8_t* d
                 memcpy(mac.data(), payload + 1 + 6 * i, 6);
                 bracket.push_back(mac);
             }
-            shootoutManager_->onBracketReceived(bracket, seqId);
+            shootoutManager->onBracketReceived(bracket, seqId);
             break;
         }
         case ShootoutCmd::MATCH_START:
             if (payloadLen >= 13)
-                shootoutManager_->onMatchStartReceived(payload, payload + 6, payload[12], seqId);
+                shootoutManager->onMatchStartReceived(payload, payload + 6, payload[12], seqId);
             break;
         case ShootoutCmd::MATCH_RESULT:
             if (payloadLen >= 13)
-                shootoutManager_->onMatchResultReceived(payload, payload + 6, payload[12], seqId, fromMac);
+                shootoutManager->onMatchResultReceived(payload, payload + 6, payload[12], seqId, fromMac);
             break;
         case ShootoutCmd::TOURNAMENT_END:
-            if (payloadLen >= 6) shootoutManager_->onTournamentEndReceived(payload, seqId);
+            if (payloadLen >= 6) shootoutManager->onTournamentEndReceived(payload, seqId);
             break;
         case ShootoutCmd::PEER_LOST:
-            if (payloadLen >= 6) shootoutManager_->onPeerLostReceived(payload);
+            if (payloadLen >= 6) shootoutManager->onPeerLostReceived(payload);
             break;
         case ShootoutCmd::ABORT:
-            shootoutManager_->onAbortReceived();
+            shootoutManager->onAbortReceived();
             break;
     }
 }
 
 void Quickdraw::onShootoutCommandAckPacket(const uint8_t* fromMac, const uint8_t* data, size_t dataLen) {
-    if (!shootoutManager_ || dataLen < 2) return;
+    if (!shootoutManager || dataLen < 2) return;
     if (data[0] > static_cast<uint8_t>(ShootoutCmd::ABORT)) return;
     ShootoutCmd cmd = static_cast<ShootoutCmd>(data[0]);
     uint8_t seqId = data[1];
     switch (cmd) {
         case ShootoutCmd::BRACKET:
-            shootoutManager_->onBracketAckReceived(fromMac, seqId);
+            shootoutManager->onBracketAckReceived(fromMac, seqId);
             break;
         case ShootoutCmd::MATCH_START:
-            shootoutManager_->onMatchStartAckReceived(fromMac, seqId);
+            shootoutManager->onMatchStartAckReceived(fromMac, seqId);
             break;
         case ShootoutCmd::MATCH_RESULT:
-            shootoutManager_->onMatchResultAckReceived(fromMac, seqId);
+            shootoutManager->onMatchResultAckReceived(fromMac, seqId);
             break;
         case ShootoutCmd::TOURNAMENT_END:
-            shootoutManager_->onTournamentEndAckReceived(fromMac, seqId);
+            shootoutManager->onTournamentEndAckReceived(fromMac, seqId);
             break;
         default:
             break;
@@ -308,8 +310,8 @@ Quickdraw::~Quickdraw() {
     symbolWirelessManager = nullptr;
     delete chainDuelManager;
     chainDuelManager = nullptr;
-    delete shootoutManager_;
-    shootoutManager_ = nullptr;
+    delete shootoutManager;
+    shootoutManager = nullptr;
     storageManager = nullptr;
     peerComms = nullptr;
     matches.clear();
@@ -322,7 +324,7 @@ void Quickdraw::populateStateMap() {
     ctx.matchManager = matchManager;
     ctx.remoteDeviceCoordinator = remoteDeviceCoordinator;
     ctx.chainDuelManager = chainDuelManager;
-    ctx.shootoutManager = shootoutManager_;
+    ctx.shootoutManager = shootoutManager;
     ctx.quickdrawWirelessManager = quickdrawWirelessManager;
     ctx.symbolWirelessManager = symbolWirelessManager;
     ctx.wirelessManager = wirelessManager;
@@ -376,7 +378,7 @@ void Quickdraw::populateStateMap() {
     // (tournament) would be silently demoted to a 1v1 duel.
     {
         ChainDuelManager* cdm = chainDuelManager;
-        ShootoutManager* shMgr = shootoutManager_;
+        ShootoutManager* shMgr = shootoutManager;
         idle->addTransition(
             new StateTransition(
                 [cdm, shMgr]() {
@@ -398,7 +400,7 @@ void Quickdraw::populateStateMap() {
             supporterReady));
 
     {
-        ShootoutManager* shMgr = shootoutManager_;
+        ShootoutManager* shMgr = shootoutManager;
         auto phaseIsAborted = [shMgr]() {
             return shMgr && shMgr->getPhase() == ShootoutManager::Phase::ABORTED;
         };
@@ -424,7 +426,7 @@ void Quickdraw::populateStateMap() {
     duelCountdown->addTransition(
         new StateTransition(
             [this, duelCountdown]() {
-                return duelReturnsToIdle(*duelCountdown, shootoutManager_);
+                return duelReturnsToIdle(*duelCountdown, shootoutManager);
             },
             idle));
 
@@ -456,7 +458,7 @@ void Quickdraw::populateStateMap() {
     duelPushed->addTransition(
         new StateTransition(
             [this, duelPushed]() {
-                return duelReturnsToIdle(*duelPushed, shootoutManager_);
+                return duelReturnsToIdle(*duelPushed, shootoutManager);
             },
             idle));
 
@@ -468,7 +470,7 @@ void Quickdraw::populateStateMap() {
     duelReceivedResult->addTransition(
         new StateTransition(
             [this, duelReceivedResult]() {
-                return duelReturnsToIdle(*duelReceivedResult, shootoutManager_);
+                return duelReturnsToIdle(*duelReceivedResult, shootoutManager);
             },
             idle));
 

--- a/src/pdn/game/quickdraw.cpp
+++ b/src/pdn/game/quickdraw.cpp
@@ -227,7 +227,7 @@ void Quickdraw::onShootoutCommandPacket(const uint8_t* fromMac, const uint8_t* d
         case ShootoutCmd::BRACKET: {
             if (payloadLen < 1) break;
             uint8_t count = payload[0];
-            if (count > ShootoutManager::kMaxBracketSize) break;
+            if (count > ShootoutManager::MAX_BRACKET_SIZE) break;
             if (payloadLen < 1 + 6 * static_cast<size_t>(count)) break;
             std::vector<std::array<uint8_t, 6>> bracket;
             bracket.reserve(count);

--- a/src/pdn/game/quickdraw.hpp
+++ b/src/pdn/game/quickdraw.hpp
@@ -54,15 +54,15 @@ private:
     RemoteDebugManager* remoteDebugManager;
     SupporterReady* supporterReadyState = nullptr;
     ChainDuelManager* chainDuelManager = nullptr;
-    ShootoutManager* shootoutManager_ = nullptr;
+    ShootoutManager* shootoutManager = nullptr;
 
     // Every kStatsLogIntervalMs we emit one LOG_I line with the current retry
     // counters from both RDC and CDM. Intended for venue deployment: `cat`ing
     // the serial port gives a rolling view of retry-machine health. Parseable
     // by scripts/chain_status.sh (prefix: "STATS").
-    SimpleTimer statsLogTimer_;
+    SimpleTimer statsLogTimer;
     static constexpr unsigned long kStatsLogIntervalMs = 5000;
 
     // Diagnostic: track isLoop() transitions to expose ring re-formation timing.
-    bool lastIsLoop_ = false;
+    bool lastIsLoop = false;
 };

--- a/src/pdn/game/shootout-manager.cpp
+++ b/src/pdn/game/shootout-manager.cpp
@@ -26,59 +26,62 @@ ShootoutManager::ShootoutManager(Player* player,
                                  WirelessManager* wirelessManager,
                                  RemoteDeviceCoordinator* rdc,
                                  ChainDuelManager* cdm)
-    : player_(player), wirelessManager_(wirelessManager), rdc_(rdc), cdm_(cdm) {}
+    : player(player)
+    , wirelessManager(wirelessManager)
+    , rdc(rdc)
+    , cdm(cdm) {}
 
 bool ShootoutManager::active() const {
-    return phase_ != Phase::IDLE;
+    return phase != Phase::IDLE;
 }
 
 ShootoutManager::Phase ShootoutManager::getPhase() const {
-    return phase_;
+    return phase;
 }
 
 size_t ShootoutManager::getConfirmedCount() const {
-    return confirmedSet_.size();
+    return confirmedSet.size();
 }
 
 std::vector<std::array<uint8_t, 6>> ShootoutManager::getBracket() const {
-    return bracket_;
+    return bracket;
 }
 
 bool ShootoutManager::hasBye() const {
-    return bracket_.size() % 2 == 1;
+    return bracket.size() % 2 == 1;
 }
 
 uint8_t ShootoutManager::getLastBracketSeqId() const {
-    return lastBracketSeqId_;
+    return lastBracketSeqId;
 }
 
 size_t ShootoutManager::getBracketPendingAckCount() const {
-    return bracketPendingAcks_.size();
+    return bracketPendingAcks.size();
 }
 
 int ShootoutManager::getCurrentMatchIndex() const {
-    return currentMatchIndex_;
+    return currentMatchIndex;
 }
 
 bool ShootoutManager::isLocalDuelist() const {
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
     if (selfMac == nullptr) return false;
-    return memcmp(selfMac, currentDuelistA_.data(), 6) == 0 ||
-           memcmp(selfMac, currentDuelistB_.data(), 6) == 0;
+    return memcmp(selfMac, currentDuelistA.data(), 6) == 0 ||
+           memcmp(selfMac, currentDuelistB.data(), 6) == 0;
 }
 
 uint8_t ShootoutManager::nextSeqId() {
-    uint8_t id = nextShootoutSeqId_++;
-    if (nextShootoutSeqId_ == 0) nextShootoutSeqId_ = 1;
+    uint8_t id = nextShootoutSeqId++;
+    if (nextShootoutSeqId == 0) nextShootoutSeqId = 1;
     return id;
 }
 
 void ShootoutManager::sendToPeers(const std::vector<std::array<uint8_t, 6>>& peers,
                                   const uint8_t* packet, size_t len) {
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
     for (const auto& m : peers) {
         if (selfMac != nullptr && memcmp(m.data(), selfMac, 6) == 0) continue;
-        wirelessManager_->sendEspNowData(m.data(), PktType::kShootoutCommand, packet, len);
+        wirelessManager->sendEspNowData(m.data(), PktType::kShootoutCommand, packet, len);
     }
 }
 
@@ -86,7 +89,7 @@ void ShootoutManager::sendReliablyToPeers(std::vector<BracketPending>& pending,
                                           const std::vector<std::array<uint8_t, 6>>& peers,
                                           const uint8_t* packet, size_t len) {
     sendToPeers(peers, packet, len);
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
     pending.clear();
     for (const auto& m : peers) {
         if (selfMac != nullptr && memcmp(m.data(), selfMac, 6) == 0) continue;
@@ -109,85 +112,85 @@ void ShootoutManager::eraseFromPending(std::vector<BracketPending>& pending,
 }
 
 std::array<uint8_t, 6> ShootoutManager::getOpponentMac() const {
-    return opponentMac_;
+    return opponentMac;
 }
 
 uint8_t ShootoutManager::getLastMatchStartSeqId() const {
-    return lastMatchStartSeqId_;
+    return lastMatchStartSeqId;
 }
 
 size_t ShootoutManager::getTournamentEndPendingAckCount() const {
-    return tournamentEndPendingAcks_.size();
+    return tournamentEndPendingAcks.size();
 }
 
 std::array<uint8_t, 6> ShootoutManager::getTournamentWinner() const {
-    return tournamentWinner_;
+    return tournamentWinner;
 }
 
 void ShootoutManager::setLoopMembersForTest(const std::vector<std::array<uint8_t, 6>>& members) {
-    testLoopMembers_ = members;
-    testLoopMembersOverride_ = !members.empty();
+    testLoopMembers = members;
+    testLoopMembersOverride = !members.empty();
 }
 
 std::vector<std::array<uint8_t, 6>> ShootoutManager::getLoopMembers() const {
-    if (testLoopMembersOverride_) return testLoopMembers_;
+    if (testLoopMembersOverride) return testLoopMembers;
     return buildLoopMemberSet();
 }
 
 void ShootoutManager::resetToIdle() {
-    LOG_W(TAG, "resetToIdle from phase=%d", static_cast<int>(phase_));
-    phase_ = Phase::IDLE;
-    confirmedSet_.clear();
-    bracket_.clear();
-    currentRound_.clear();
-    bracketPendingAcks_.clear();
-    matchStartPendingAcks_.clear();
-    tournamentEndPendingAcks_.clear();
-    matchResultPendingAcks_.clear();
-    eliminated_.clear();
-    reportedLocalWin_ = false;
-    names_.clear();
-    lastObservedBracketSeqId_ = 0;
-    lastObservedMatchStartSeqId_ = 0;
-    lastObservedTournamentEndSeqId_ = 0;
-    currentMatchIndex_ = -1;
-    memset(tournamentWinner_.data(), 0, 6);
-    memset(opponentMac_.data(), 0, 6);
-    memset(currentDuelistA_.data(), 0, 6);
-    memset(currentDuelistB_.data(), 0, 6);
-    memset(coordinatorMac_.data(), 0, 6);
-    if (originalIsHunter_ && player_) {
-        player_->setIsHunter(*originalIsHunter_);
+    LOG_W(TAG, "resetToIdle from phase=%d", static_cast<int>(phase));
+    phase = Phase::IDLE;
+    confirmedSet.clear();
+    bracket.clear();
+    currentRound.clear();
+    bracketPendingAcks.clear();
+    matchStartPendingAcks.clear();
+    tournamentEndPendingAcks.clear();
+    matchResultPendingAcks.clear();
+    eliminated.clear();
+    reportedLocalWin = false;
+    names.clear();
+    lastObservedBracketSeqId = 0;
+    lastObservedMatchStartSeqId = 0;
+    lastObservedTournamentEndSeqId = 0;
+    currentMatchIndex = -1;
+    memset(tournamentWinner.data(), 0, 6);
+    memset(opponentMac.data(), 0, 6);
+    memset(currentDuelistA.data(), 0, 6);
+    memset(currentDuelistB.data(), 0, 6);
+    memset(coordinatorMac.data(), 0, 6);
+    if (originalIsHunter && player) {
+        player->setIsHunter(*originalIsHunter);
     }
-    originalIsHunter_.reset();
+    originalIsHunter.reset();
 }
 
 void ShootoutManager::startProposal() {
     LOG_W(TAG, "startProposal");
     resetToIdle();
-    if (player_) {
-        originalIsHunter_ = player_->isHunter();
+    if (player) {
+        originalIsHunter = player->isHunter();
     }
-    phase_ = Phase::PROPOSAL;
+    phase = Phase::PROPOSAL;
 }
 
 void ShootoutManager::confirmLocal() {
     // Gate on PROPOSAL: stale ShootoutProposal button callbacks can fire in
     // later phases and re-advance the bracket if not guarded.
-    if (phase_ != Phase::PROPOSAL) {
-        LOG_W(TAG, "confirmLocal ignored; phase=%d", static_cast<int>(phase_));
+    if (phase != Phase::PROPOSAL) {
+        LOG_W(TAG, "confirmLocal ignored; phase=%d", static_cast<int>(phase));
         return;
     }
-    LOG_W(TAG, "confirmLocal; confirmedCount before=%zu", confirmedSet_.size());
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    LOG_W(TAG, "confirmLocal; confirmedCount before=%zu", confirmedSet.size());
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
     if (selfMac == nullptr) return;
     std::array<uint8_t, 6> mac;
     memcpy(mac.data(), selfMac, 6);
     if (!hasConfirmed(mac.data())) {
-        confirmedSet_.push_back(mac);
+        confirmedSet.push_back(mac);
     }
-    if (player_ != nullptr) {
-        recordName(selfMac, player_->getName().c_str());
+    if (player != nullptr) {
+        recordName(selfMac, player->getName().c_str());
     }
     sendLocalConfirm();
     if (allMembersConfirmed()) {
@@ -197,7 +200,7 @@ void ShootoutManager::confirmLocal() {
 }
 
 void ShootoutManager::onConfirmReceived(const uint8_t* fromMac, const char* name) {
-    if (phase_ != Phase::PROPOSAL) return;
+    if (phase != Phase::PROPOSAL) return;
     // Fast path: already-confirmed peers bypass the loop-membership scan (this
     // is the common case during 1Hz rebroadcasts — the gate only needs to
     // block first-time stray CONFIRMs from outside the ring).
@@ -214,9 +217,9 @@ void ShootoutManager::onConfirmReceived(const uint8_t* fromMac, const char* name
     if (added) {
         std::array<uint8_t, 6> mac;
         memcpy(mac.data(), fromMac, 6);
-        confirmedSet_.push_back(mac);
+        confirmedSet.push_back(mac);
         LOG_W(TAG, "onConfirmReceived from=%s count=%zu",
-              MacToString(fromMac), confirmedSet_.size());
+              MacToString(fromMac), confirmedSet.size());
     }
     if (allMembersConfirmed()) {
         LOG_W(TAG, "allMembersConfirmed -> advanceToBracketReveal");
@@ -230,7 +233,7 @@ void ShootoutManager::recordName(const uint8_t* mac, const char* name) {
     strncpy(buf, name, kNameLength);
     buf[kNameLength] = '\0';
     if (buf[0] == '\0') return;
-    for (auto& entry : names_) {
+    for (auto& entry : names) {
         if (memcmp(entry.mac.data(), mac, 6) == 0) {
             entry.name = buf;
             return;
@@ -239,11 +242,11 @@ void ShootoutManager::recordName(const uint8_t* mac, const char* name) {
     NameEntry e;
     memcpy(e.mac.data(), mac, 6);
     e.name = buf;
-    names_.push_back(std::move(e));
+    names.push_back(std::move(e));
 }
 
 std::string ShootoutManager::getNameForMac(const uint8_t* mac) const {
-    for (const auto& entry : names_) {
+    for (const auto& entry : names) {
         if (memcmp(entry.mac.data(), mac, 6) == 0) return entry.name;
     }
     char fallback[4];
@@ -252,7 +255,7 @@ std::string ShootoutManager::getNameForMac(const uint8_t* mac) const {
 }
 
 bool ShootoutManager::hasConfirmed(const uint8_t* mac) const {
-    for (const auto& existing : confirmedSet_) {
+    for (const auto& existing : confirmedSet) {
         if (memcmp(existing.data(), mac, 6) == 0) return true;
     }
     return false;
@@ -268,58 +271,58 @@ bool ShootoutManager::allMembersConfirmed() const {
 }
 
 std::array<uint8_t, 6> ShootoutManager::getCoordinatorMac() const {
-    if (!bracket_.empty()) return coordinatorMac_;
-    return lowestMacIn(confirmedSet_);
+    if (!bracket.empty()) return coordinatorMac;
+    return lowestMacIn(confirmedSet);
 }
 
 bool ShootoutManager::isCoordinator() const {
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
     if (selfMac == nullptr) return false;
     auto coord = getCoordinatorMac();
     return memcmp(coord.data(), selfMac, 6) == 0;
 }
 
 void ShootoutManager::generateBracket() {
-    bracket_ = confirmedSet_;
-    coordinatorMac_ = lowestMacIn(bracket_);
+    bracket = confirmedSet;
+    coordinatorMac = lowestMacIn(bracket);
     // std::random_device is deterministic under newlib on ESP32, so seed
     // from platform clock XOR self-MAC to get real variation.
     unsigned long seed = 0;
     auto* clk = SimpleTimer::getPlatformClock();
     if (clk != nullptr) seed = clk->milliseconds();
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
     if (selfMac != nullptr) {
         for (int i = 0; i < 6; i++) {
             seed ^= static_cast<unsigned long>(selfMac[i]) << ((i % 4) * 8);
         }
     }
     std::mt19937 rng(seed);
-    std::shuffle(bracket_.begin(), bracket_.end(), rng);
-    currentRound_ = bracket_;
+    std::shuffle(bracket.begin(), bracket.end(), rng);
+    currentRound = bracket;
 }
 
 void ShootoutManager::primeMatchManagerForMatch() {
-    if (!matchManager_) return;
+    if (!matchManager) return;
     if (!isLocalDuelist()) return;
 
     // Role-for-this-match from MAC ordering: both sides compute the same
     // ordering so the hunter_draw_time and bounty_time slots in MatchManager
     // are written by exactly one duelist each.
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
     bool localIsHunterForMatch = selfMac != nullptr &&
-        memcmp(selfMac, opponentMac_.data(), 6) < 0;
-    if (player_) player_->setIsHunter(localIsHunterForMatch);
+                                 memcmp(selfMac, opponentMac.data(), 6) < 0;
+    if (player) player->setIsHunter(localIsHunterForMatch);
 
     char matchId[IdGenerator::UUID_BUFFER_SIZE];
-    deriveShootoutMatchId(currentMatchIndex_, matchId, sizeof(matchId));
+    deriveShootoutMatchId(currentMatchIndex, matchId, sizeof(matchId));
     LOG_W(TAG, "primeMatchManagerForMatch matchIndex=%d localHunter=%d",
-          currentMatchIndex_, localIsHunterForMatch);
-    matchManager_->initializeShootoutMatch(matchId, opponentMac_.data());
+          currentMatchIndex, localIsHunterForMatch);
+    matchManager->initializeShootoutMatch(matchId, opponentMac.data());
 }
 
 void ShootoutManager::advanceToBracketReveal() {
-    phase_ = Phase::BRACKET_REVEAL;
-    bracketRevealTimer_.setTimer(kBracketRevealMs);
+    phase = Phase::BRACKET_REVEAL;
+    bracketRevealTimer.setTimer(kBracketRevealMs);
     if (isCoordinator()) {
         generateBracket();
         sendBracketToPeers();
@@ -335,54 +338,54 @@ unsigned long ShootoutManager::ackTimeoutForRetry(uint8_t retries) {
 std::vector<uint8_t> ShootoutManager::buildBracketPacket() const {
     std::vector<uint8_t> packet;
     packet.push_back(static_cast<uint8_t>(ShootoutCmd::BRACKET));
-    packet.push_back(lastBracketSeqId_);
-    packet.push_back(static_cast<uint8_t>(bracket_.size()));
-    for (const auto& m : bracket_) {
+    packet.push_back(lastBracketSeqId);
+    packet.push_back(static_cast<uint8_t>(bracket.size()));
+    for (const auto& m : bracket) {
         packet.insert(packet.end(), m.begin(), m.end());
     }
     return packet;
 }
 
 void ShootoutManager::sendBracketToPeers() {
-    if (bracket_.empty()) return;
-    lastBracketSeqId_ = nextSeqId();
+    if (bracket.empty()) return;
+    lastBracketSeqId = nextSeqId();
     auto packet = buildBracketPacket();
-    sendReliablyToPeers(bracketPendingAcks_, bracket_, packet.data(), packet.size());
+    sendReliablyToPeers(bracketPendingAcks, bracket, packet.data(), packet.size());
 }
 
 void ShootoutManager::onBracketAckReceived(const uint8_t* fromMac, uint8_t seqId) {
-    if (seqId != lastBracketSeqId_) return;
-    eraseFromPending(bracketPendingAcks_, fromMac);
+    if (seqId != lastBracketSeqId) return;
+    eraseFromPending(bracketPendingAcks, fromMac);
 }
 
 bool ShootoutManager::retryBracketForPeer(BracketPending& p) {
     if (p.retries >= kMaxShootoutAckRetries) {
-        // Caller is iterating bracketPendingAcks_; don't abort here (that
+        // Caller is iterating bracketPendingAcks; don't abort here (that
         // clears the vector and invalidates the iterator). Signal and let
         // the caller abort after exiting the loop.
         return true;
     }
     auto packet = buildBracketPacket();
-    wirelessManager_->sendEspNowData(p.peer.data(), PktType::kShootoutCommand,
-                                     packet.data(), packet.size());
+    wirelessManager->sendEspNowData(p.peer.data(), PktType::kShootoutCommand,
+                                    packet.data(), packet.size());
     p.retries++;
     p.timer.setTimer(ackTimeoutForRetry(p.retries));
     return false;
 }
 
 void ShootoutManager::abortTournament() {
-    if (phase_ == Phase::ABORTED) return;
-    LOG_W(TAG, "abortTournament from phase=%d", static_cast<int>(phase_));
+    if (phase == Phase::ABORTED) return;
+    LOG_W(TAG, "abortTournament from phase=%d", static_cast<int>(phase));
 
-    // Broadcast before resetToIdle clears bracket_/confirmedSet_.
+    // Broadcast before resetToIdle clears bracket/confirmedSet.
     uint8_t packet[2];
     packet[0] = static_cast<uint8_t>(ShootoutCmd::ABORT);
     packet[1] = 0;
-    const auto& targets = bracket_.empty() ? confirmedSet_ : bracket_;
+    const std::vector<std::array<uint8_t, 6>>& targets = bracket.empty() ? confirmedSet : bracket;
     sendToPeers(targets, packet, sizeof(packet));
 
     resetToIdle();
-    phase_ = Phase::ABORTED;
+    phase = Phase::ABORTED;
 }
 
 void ShootoutManager::sendLocalConfirm() {
@@ -390,31 +393,31 @@ void ShootoutManager::sendLocalConfirm() {
     uint8_t payload[2 + 6 + kNameLength];
     payload[0] = static_cast<uint8_t>(ShootoutCmd::CONFIRM);
     payload[1] = 0;
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
     memcpy(&payload[2], selfMac, 6);
     memset(&payload[8], 0, kNameLength);
-    if (player_ != nullptr) {
-        const std::string& n = player_->getName();
+    if (player != nullptr) {
+        const std::string& n = player->getName();
         size_t copyLen = n.size() < kNameLength ? n.size() : kNameLength;
         memcpy(&payload[8], n.data(), copyLen);
     }
 
     sendToPeers(getLoopMembers(), payload, sizeof(payload));
-    confirmRebroadcastTimer_.setTimer(kConfirmRebroadcastMs);
+    confirmRebroadcastTimer.setTimer(kConfirmRebroadcastMs);
 }
 
 void ShootoutManager::sync() {
     // Check cheap conditions before allMembersConfirmed(), which rebuilds the
     // loop-member set each call.
-    if (phase_ == Phase::PROPOSAL && confirmRebroadcastTimer_.expired()) {
-        const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    if (phase == Phase::PROPOSAL && confirmRebroadcastTimer.expired()) {
+        const uint8_t* selfMac = wirelessManager->getMacAddress();
         if (selfMac != nullptr && hasConfirmed(selfMac) && !allMembersConfirmed()) {
             sendLocalConfirm();
         }
     }
 
     bool shouldAbort = false;
-    for (auto& p : bracketPendingAcks_) {
+    for (auto& p : bracketPendingAcks) {
         if (p.timer.expired()) {
             if (retryBracketForPeer(p)) {
                 shouldAbort = true;
@@ -426,51 +429,51 @@ void ShootoutManager::sync() {
 
     maybeStartNextMatch();
 
-    if (isCoordinator() && phase_ == Phase::MATCH_IN_PROGRESS &&
-        matchStartPendingAcks_.empty() &&
-        matchStartWatchdog_.expired()) {
-        sendMatchStartToPeers(currentMatchIndex_);
+    if (isCoordinator() && phase == Phase::MATCH_IN_PROGRESS &&
+        matchStartPendingAcks.empty() &&
+        matchStartWatchdog.expired()) {
+        sendMatchStartToPeers(currentMatchIndex);
     }
 
-    if (phase_ == Phase::ENDED && !tournamentEndPendingAcks_.empty()) {
+    if (phase == Phase::ENDED && !tournamentEndPendingAcks.empty()) {
         uint8_t packet[8];
         packet[0] = static_cast<uint8_t>(ShootoutCmd::TOURNAMENT_END);
-        packet[1] = lastTournamentEndSeqId_;
-        memcpy(&packet[2], tournamentWinner_.data(), 6);
-        for (auto it = tournamentEndPendingAcks_.begin();
-             it != tournamentEndPendingAcks_.end(); ) {
+        packet[1] = lastTournamentEndSeqId;
+        memcpy(&packet[2], tournamentWinner.data(), 6);
+        for (auto it = tournamentEndPendingAcks.begin();
+             it != tournamentEndPendingAcks.end();) {
             if (!it->timer.expired()) { ++it; continue; }
             if (it->retries >= kMaxShootoutAckRetries) {
                 LOG_W(TAG, "TOURNAMENT_END retries exhausted for %s",
                       MacToString(it->peer.data()));
-                it = tournamentEndPendingAcks_.erase(it);
+                it = tournamentEndPendingAcks.erase(it);
                 continue;
             }
-            wirelessManager_->sendEspNowData(it->peer.data(),
-                                             PktType::kShootoutCommand,
-                                             packet, sizeof(packet));
+            wirelessManager->sendEspNowData(it->peer.data(),
+                                            PktType::kShootoutCommand,
+                                            packet, sizeof(packet));
             it->retries++;
             it->timer.setTimer(ackTimeoutForRetry(it->retries));
             ++it;
         }
     }
 
-    if (!matchResultPendingAcks_.empty()) {
+    if (!matchResultPendingAcks.empty()) {
         auto packet = buildMatchResultPacket(
-            lastMatchResult_.winner.data(), lastMatchResult_.loser.data(),
-            lastMatchResult_.matchIndex);
-        for (auto it = matchResultPendingAcks_.begin();
-             it != matchResultPendingAcks_.end(); ) {
+            lastMatchResult.winner.data(), lastMatchResult.loser.data(),
+            lastMatchResult.matchIndex);
+        for (auto it = matchResultPendingAcks.begin();
+             it != matchResultPendingAcks.end();) {
             if (!it->timer.expired()) { ++it; continue; }
             if (it->retries >= kMaxShootoutAckRetries) {
                 LOG_W(TAG, "MATCH_RESULT retries exhausted for %s",
                       MacToString(it->peer.data()));
-                it = matchResultPendingAcks_.erase(it);
+                it = matchResultPendingAcks.erase(it);
                 continue;
             }
-            wirelessManager_->sendEspNowData(it->peer.data(),
-                                             PktType::kShootoutCommand,
-                                             packet.data(), packet.size());
+            wirelessManager->sendEspNowData(it->peer.data(),
+                                            PktType::kShootoutCommand,
+                                            packet.data(), packet.size());
             it->retries++;
             it->timer.setTimer(ackTimeoutForRetry(it->retries));
             ++it;
@@ -480,16 +483,16 @@ void ShootoutManager::sync() {
 
 std::pair<std::array<uint8_t,6>, std::array<uint8_t,6>>
 ShootoutManager::getCurrentMatchPair() const {
-    if (currentMatchIndex_ < 0) return {};
-    return {currentDuelistA_, currentDuelistB_};
+    if (currentMatchIndex < 0) return {};
+    return {currentDuelistA, currentDuelistB};
 }
 
 std::vector<uint8_t> ShootoutManager::buildMatchStartPacket(int matchIndex) const {
     std::vector<uint8_t> packet;
     packet.push_back(static_cast<uint8_t>(ShootoutCmd::MATCH_START));
-    packet.push_back(lastMatchStartSeqId_);
-    const auto& a = currentRound_[matchIndex * 2];
-    const auto& b = currentRound_[matchIndex * 2 + 1];
+    packet.push_back(lastMatchStartSeqId);
+    const std::array<uint8_t, 6>& a = currentRound[matchIndex * 2];
+    const std::array<uint8_t, 6>& b = currentRound[matchIndex * 2 + 1];
     packet.insert(packet.end(), a.begin(), a.end());
     packet.insert(packet.end(), b.begin(), b.end());
     packet.push_back(static_cast<uint8_t>(matchIndex));
@@ -497,40 +500,37 @@ std::vector<uint8_t> ShootoutManager::buildMatchStartPacket(int matchIndex) cons
 }
 
 void ShootoutManager::sendMatchStartToPeers(int matchIndex) {
-    lastMatchStartSeqId_ = nextSeqId();
+    lastMatchStartSeqId = nextSeqId();
 
     auto packet = buildMatchStartPacket(matchIndex);
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
-    const auto& a = currentRound_[matchIndex * 2];
-    const auto& b = currentRound_[matchIndex * 2 + 1];
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
+    const std::array<uint8_t, 6>& a = currentRound[matchIndex * 2];
+    const std::array<uint8_t, 6>& b = currentRound[matchIndex * 2 + 1];
     bool sameMatch = isSameMatch(matchIndex, a.data(), b.data());
-    currentDuelistA_ = a;
-    currentDuelistB_ = b;
-    currentMatchIndex_ = matchIndex;
-    if (!sameMatch) reportedLocalWin_ = false;
+    currentDuelistA = a;
+    currentDuelistB = b;
+    currentMatchIndex = matchIndex;
+    if (!sameMatch) reportedLocalWin = false;
     if (!sameMatch && isLocalDuelist() && selfMac != nullptr) {
         const uint8_t* opp = (memcmp(selfMac, a.data(), 6) == 0) ? b.data() : a.data();
-        memcpy(opponentMac_.data(), opp, 6);
+        memcpy(opponentMac.data(), opp, 6);
         primeMatchManagerForMatch();
     }
-    sendReliablyToPeers(matchStartPendingAcks_, bracket_, packet.data(), packet.size());
-    matchStartWatchdog_.setTimer(kMatchWatchdogMs);
+    sendReliablyToPeers(matchStartPendingAcks, bracket, packet.data(), packet.size());
+    matchStartWatchdog.setTimer(kMatchWatchdogMs);
 }
 
 void ShootoutManager::onMatchStartAckReceived(const uint8_t* fromMac, uint8_t seqId) {
-    if (seqId != lastMatchStartSeqId_) return;
-    eraseFromPending(matchStartPendingAcks_, fromMac);
+    if (seqId != lastMatchStartSeqId) return;
+    eraseFromPending(matchStartPendingAcks, fromMac);
 }
 
 bool ShootoutManager::isSameMatch(int matchIndex, const uint8_t* a, const uint8_t* b) const {
-    return matchIndex == currentMatchIndex_
-        && phase_ == Phase::MATCH_IN_PROGRESS
-        && memcmp(currentDuelistA_.data(), a, 6) == 0
-        && memcmp(currentDuelistB_.data(), b, 6) == 0;
+    return matchIndex == currentMatchIndex && phase == Phase::MATCH_IN_PROGRESS && memcmp(currentDuelistA.data(), a, 6) == 0 && memcmp(currentDuelistB.data(), b, 6) == 0;
 }
 
 bool ShootoutManager::isActiveDuelist(const uint8_t* mac) const {
-    if (currentMatchIndex_ < 0) return false;
+    if (currentMatchIndex < 0) return false;
     auto pair = getCurrentMatchPair();
     return memcmp(pair.first.data(), mac, 6) == 0 ||
            memcmp(pair.second.data(), mac, 6) == 0;
@@ -538,43 +538,46 @@ bool ShootoutManager::isActiveDuelist(const uint8_t* mac) const {
 
 void ShootoutManager::onLocalRDCDisconnect(const uint8_t* lostMac) {
     LOG_W(TAG, "onLocalRDCDisconnect %s phase=%d",
-          MacToString(lostMac), static_cast<int>(phase_));
-    if (phase_ == Phase::IDLE || phase_ == Phase::ABORTED || phase_ == Phase::ENDED) return;
-    if (rdc_ && rdc_->canReachPeer(lostMac)) return;
+          MacToString(lostMac), static_cast<int>(phase));
+    if (phase == Phase::IDLE || phase == Phase::ABORTED || phase == Phase::ENDED) return;
+    if (rdc && rdc->canReachPeer(lostMac)) return;
     uint8_t packet[8];
     packet[0] = static_cast<uint8_t>(ShootoutCmd::PEER_LOST);
     packet[1] = 0;
     memcpy(&packet[2], lostMac, 6);
-    const auto& targets = bracket_.empty() ? confirmedSet_ : bracket_;
+    const std::vector<std::array<uint8_t, 6>>& targets = bracket.empty() ? confirmedSet : bracket;
     sendToPeers(targets, packet, sizeof(packet));
     onPeerLostReceived(lostMac);
 }
 
 void ShootoutManager::onPeerLostReceived(const uint8_t* lostMac) {
     LOG_W(TAG, "onPeerLostReceived %s phase=%d",
-          MacToString(lostMac), static_cast<int>(phase_));
-    if (phase_ == Phase::IDLE || phase_ == Phase::ABORTED || phase_ == Phase::ENDED) return;
-    if (rdc_ && rdc_->canReachPeer(lostMac)) return;
+          MacToString(lostMac), static_cast<int>(phase));
+    if (phase == Phase::IDLE || phase == Phase::ABORTED || phase == Phase::ENDED) return;
+    if (rdc && rdc->canReachPeer(lostMac)) return;
     abortTournament();
 }
 
 void ShootoutManager::maybeStartNextMatch() {
     if (!isCoordinator()) return;
-    if (!bracketPendingAcks_.empty()) return;
-    if (phase_ != Phase::BRACKET_REVEAL && phase_ != Phase::BETWEEN_MATCHES) return;
-    if (phase_ == Phase::BRACKET_REVEAL && !bracketRevealTimer_.expired()) return;
-    // Re-entrancy guard: this function mutates currentMatchIndex_, bracket_,
-    // and phase_; concurrent entry from sync() and ESP-NOW recv callbacks
+    if (!bracketPendingAcks.empty()) return;
+    if (phase != Phase::BRACKET_REVEAL && phase != Phase::BETWEEN_MATCHES) return;
+    if (phase == Phase::BRACKET_REVEAL && !bracketRevealTimer.expired()) return;
+    // Re-entrancy guard: this function mutates currentMatchIndex, bracket,
+    // and phase; concurrent entry from sync() and ESP-NOW recv callbacks
     // (Core 0 vs main loop) would double-advance the bracket.
-    if (inMaybeStartNextMatch_) return;
-    inMaybeStartNextMatch_ = true;
-    struct Guard { bool& f; ~Guard() { f = false; } } guard{inMaybeStartNextMatch_};
+    if (inMaybeStartNextMatch) return;
+    inMaybeStartNextMatch = true;
+    struct Guard {
+        bool& f;
+        ~Guard() { f = false; }
+    } guard{inMaybeStartNextMatch};
 
-    currentMatchIndex_++;
-    int pairEnd = currentMatchIndex_ * 2 + 1;
-    if (pairEnd >= (int)currentRound_.size()) {
+    currentMatchIndex++;
+    int pairEnd = currentMatchIndex * 2 + 1;
+    if (pairEnd >= static_cast<int>(currentRound.size())) {
         std::vector<std::array<uint8_t, 6>> survivors;
-        for (const auto& m : currentRound_) {
+        for (const auto& m : currentRound) {
             if (!isEliminated(m.data())) survivors.push_back(m);
         }
         if (survivors.size() <= 1) {
@@ -585,12 +588,12 @@ void ShootoutManager::maybeStartNextMatch() {
             return;
         }
         LOG_W(TAG, "advancing round: %zu survivors -> %zu",
-              currentRound_.size(), survivors.size());
-        currentRound_ = survivors;
-        currentMatchIndex_ = 0;
+              currentRound.size(), survivors.size());
+        currentRound = survivors;
+        currentMatchIndex = 0;
     }
-    sendMatchStartToPeers(currentMatchIndex_);
-    phase_ = Phase::MATCH_IN_PROGRESS;
+    sendMatchStartToPeers(currentMatchIndex);
+    phase = Phase::MATCH_IN_PROGRESS;
 }
 
 std::array<uint8_t, 6> ShootoutManager::lowestMacIn(
@@ -603,58 +606,58 @@ std::array<uint8_t, 6> ShootoutManager::lowestMacIn(
 }
 
 void ShootoutManager::onBracketReceived(
-    const std::vector<std::array<uint8_t, 6>>& bracket, uint8_t seqId) {
+    const std::vector<std::array<uint8_t, 6>>& offeredBracket, uint8_t seqId) {
     if (isCoordinator()) return;
-    if (seqId != 0 && seqId == lastObservedBracketSeqId_) {
-        auto coord = lowestMacIn(bracket);
+    if (seqId != 0 && seqId == lastObservedBracketSeqId) {
+        std::array<uint8_t, 6> coord = lowestMacIn(offeredBracket);
         sendShootoutAck(ShootoutCmd::BRACKET, seqId, coord.data());
         return;
     }
-    lastObservedBracketSeqId_ = seqId;
-    bracket_ = bracket;
-    currentRound_ = bracket;
-    coordinatorMac_ = lowestMacIn(bracket_);
-    phase_ = Phase::BRACKET_REVEAL;
-    bracketRevealTimer_.setTimer(kBracketRevealMs);
-    sendShootoutAck(ShootoutCmd::BRACKET, seqId, coordinatorMac_.data());
+    lastObservedBracketSeqId = seqId;
+    bracket = offeredBracket;
+    currentRound = offeredBracket;
+    coordinatorMac = lowestMacIn(bracket);
+    phase = Phase::BRACKET_REVEAL;
+    bracketRevealTimer.setTimer(kBracketRevealMs);
+    sendShootoutAck(ShootoutCmd::BRACKET, seqId, coordinatorMac.data());
 }
 
 void ShootoutManager::onMatchStartReceived(
     const uint8_t* duelistA, const uint8_t* duelistB,
     uint8_t matchIndex, uint8_t seqId) {
     if (isCoordinator()) return;
-    if (seqId != 0 && seqId == lastObservedMatchStartSeqId_) {
-        sendShootoutAck(ShootoutCmd::MATCH_START, seqId, coordinatorMac_.data());
+    if (seqId != 0 && seqId == lastObservedMatchStartSeqId) {
+        sendShootoutAck(ShootoutCmd::MATCH_START, seqId, coordinatorMac.data());
         return;
     }
     bool sameMatch = isSameMatch(matchIndex, duelistA, duelistB);
-    lastObservedMatchStartSeqId_ = seqId;
+    lastObservedMatchStartSeqId = seqId;
     if (sameMatch) {
-        sendShootoutAck(ShootoutCmd::MATCH_START, seqId, coordinatorMac_.data());
+        sendShootoutAck(ShootoutCmd::MATCH_START, seqId, coordinatorMac.data());
         return;
     }
-    currentMatchIndex_ = matchIndex;
-    memcpy(currentDuelistA_.data(), duelistA, 6);
-    memcpy(currentDuelistB_.data(), duelistB, 6);
-    phase_ = Phase::MATCH_IN_PROGRESS;
-    reportedLocalWin_ = false;
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    currentMatchIndex = matchIndex;
+    memcpy(currentDuelistA.data(), duelistA, 6);
+    memcpy(currentDuelistB.data(), duelistB, 6);
+    phase = Phase::MATCH_IN_PROGRESS;
+    reportedLocalWin = false;
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
     if (isLocalDuelist() && selfMac != nullptr) {
         const uint8_t* opp = (memcmp(selfMac, duelistA, 6) == 0) ? duelistB : duelistA;
-        memcpy(opponentMac_.data(), opp, 6);
+        memcpy(opponentMac.data(), opp, 6);
         primeMatchManagerForMatch();
     }
-    sendShootoutAck(ShootoutCmd::MATCH_START, seqId, coordinatorMac_.data());
+    sendShootoutAck(ShootoutCmd::MATCH_START, seqId, coordinatorMac.data());
 }
 
 void ShootoutManager::sendShootoutAck(ShootoutCmd cmd, uint8_t seqId, const uint8_t* toMac) {
     ShootoutAckPayload ack{cmd, seqId};
-    wirelessManager_->sendEspNowData(toMac, PktType::kShootoutCommandAck,
-                                     reinterpret_cast<uint8_t*>(&ack), sizeof(ack));
+    wirelessManager->sendEspNowData(toMac, PktType::kShootoutCommandAck,
+                                    reinterpret_cast<uint8_t*>(&ack), sizeof(ack));
 }
 
 bool ShootoutManager::isEliminated(const uint8_t* mac) const {
-    for (const auto& m : eliminated_) {
+    for (const auto& m : eliminated) {
         if (memcmp(m.data(), mac, 6) == 0) return true;
     }
     return false;
@@ -664,23 +667,23 @@ void ShootoutManager::applyMatchResult(const uint8_t* winner, const uint8_t* los
     if (!isEliminated(loser)) {
         std::array<uint8_t, 6> mac;
         memcpy(mac.data(), loser, 6);
-        eliminated_.push_back(mac);
+        eliminated.push_back(mac);
     }
     // Restore pre-tournament role at each match boundary. primeMatchManagerForMatch
     // re-applies the per-match override on the next match start if this device is a
     // duelist again. Prevents role from staying flipped when the tournament ends.
-    if (originalIsHunter_ && player_) {
-        player_->setIsHunter(*originalIsHunter_);
+    if (originalIsHunter && player) {
+        player->setIsHunter(*originalIsHunter);
     }
-    phase_ = Phase::BETWEEN_MATCHES;
-    matchStartWatchdog_.invalidate();
+    phase = Phase::BETWEEN_MATCHES;
+    matchStartWatchdog.invalidate();
 }
 
 std::vector<uint8_t> ShootoutManager::buildMatchResultPacket(
     const uint8_t* winner, const uint8_t* loser, uint8_t matchIndex) const {
     std::vector<uint8_t> packet;
     packet.push_back(static_cast<uint8_t>(ShootoutCmd::MATCH_RESULT));
-    packet.push_back(lastMatchResultSeqId_);
+    packet.push_back(lastMatchResultSeqId);
     packet.insert(packet.end(), winner, winner + 6);
     packet.insert(packet.end(), loser, loser + 6);
     packet.push_back(matchIndex);
@@ -689,23 +692,23 @@ std::vector<uint8_t> ShootoutManager::buildMatchResultPacket(
 
 void ShootoutManager::sendMatchResultToPeers(
     const uint8_t* winner, const uint8_t* loser, uint8_t matchIndex) {
-    lastMatchResultSeqId_ = nextSeqId();
-    memcpy(lastMatchResult_.winner.data(), winner, 6);
-    memcpy(lastMatchResult_.loser.data(), loser, 6);
-    lastMatchResult_.matchIndex = matchIndex;
+    lastMatchResultSeqId = nextSeqId();
+    memcpy(lastMatchResult.winner.data(), winner, 6);
+    memcpy(lastMatchResult.loser.data(), loser, 6);
+    lastMatchResult.matchIndex = matchIndex;
     auto packet = buildMatchResultPacket(winner, loser, matchIndex);
-    // Targets confirmedSet_ to reach already-eliminated players too.
-    sendReliablyToPeers(matchResultPendingAcks_, confirmedSet_, packet.data(), packet.size());
+    // Targets confirmedSet to reach already-eliminated players too.
+    sendReliablyToPeers(matchResultPendingAcks, confirmedSet, packet.data(), packet.size());
 }
 
 void ShootoutManager::reportLocalWin() {
-    const uint8_t* selfMac = wirelessManager_->getMacAddress();
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
     if (selfMac == nullptr) return;
-    if (reportedLocalWin_) return;
-    reportedLocalWin_ = true;
-    LOG_W(TAG, "reportLocalWin matchIndex=%d", currentMatchIndex_);
-    sendMatchResultToPeers(selfMac, opponentMac_.data(), static_cast<uint8_t>(currentMatchIndex_));
-    applyMatchResult(selfMac, opponentMac_.data());
+    if (reportedLocalWin) return;
+    reportedLocalWin = true;
+    LOG_W(TAG, "reportLocalWin matchIndex=%d", currentMatchIndex);
+    sendMatchResultToPeers(selfMac, opponentMac.data(), static_cast<uint8_t>(currentMatchIndex));
+    applyMatchResult(selfMac, opponentMac.data());
     if (isCoordinator()) maybeStartNextMatch();
 }
 
@@ -725,16 +728,16 @@ void ShootoutManager::onMatchResultReceived(
 }
 
 void ShootoutManager::onMatchResultAckReceived(const uint8_t* fromMac, uint8_t seqId) {
-    if (seqId != lastMatchResultSeqId_) return;
-    eraseFromPending(matchResultPendingAcks_, fromMac);
+    if (seqId != lastMatchResultSeqId) return;
+    eraseFromPending(matchResultPendingAcks, fromMac);
 }
 
 size_t ShootoutManager::getMatchResultPendingAckCount() const {
-    return matchResultPendingAcks_.size();
+    return matchResultPendingAcks.size();
 }
 
 std::array<uint8_t, 6> ShootoutManager::findLastRemaining() const {
-    for (const auto& m : bracket_) {
+    for (const auto& m : bracket) {
         if (!isEliminated(m.data())) return m;
     }
     return {};
@@ -742,44 +745,44 @@ std::array<uint8_t, 6> ShootoutManager::findLastRemaining() const {
 
 void ShootoutManager::sendTournamentEndToPeers(const uint8_t* winner) {
     LOG_W(TAG, "tournamentEnd winner=%s", MacToString(winner));
-    lastTournamentEndSeqId_ = nextSeqId();
+    lastTournamentEndSeqId = nextSeqId();
     uint8_t packet[8];
     packet[0] = static_cast<uint8_t>(ShootoutCmd::TOURNAMENT_END);
-    packet[1] = lastTournamentEndSeqId_;
+    packet[1] = lastTournamentEndSeqId;
     memcpy(&packet[2], winner, 6);
-    // Targets confirmedSet_ rather than bracket_: eliminated players need the
+    // Targets confirmedSet rather than bracket: eliminated players need the
     // tournament-end transition or they stall in BETWEEN_MATCHES.
-    sendReliablyToPeers(tournamentEndPendingAcks_, confirmedSet_, packet, sizeof(packet));
-    memcpy(tournamentWinner_.data(), winner, 6);
-    phase_ = Phase::ENDED;
+    sendReliablyToPeers(tournamentEndPendingAcks, confirmedSet, packet, sizeof(packet));
+    memcpy(tournamentWinner.data(), winner, 6);
+    phase = Phase::ENDED;
 }
 
 void ShootoutManager::onTournamentEndAckReceived(const uint8_t* fromMac, uint8_t seqId) {
-    if (seqId != lastTournamentEndSeqId_) return;
-    eraseFromPending(tournamentEndPendingAcks_, fromMac);
+    if (seqId != lastTournamentEndSeqId) return;
+    eraseFromPending(tournamentEndPendingAcks, fromMac);
 }
 
 void ShootoutManager::onTournamentEndReceived(const uint8_t* winner, uint8_t seqId) {
-    if (seqId != 0 && seqId == lastObservedTournamentEndSeqId_) {
+    if (seqId != 0 && seqId == lastObservedTournamentEndSeqId) {
         auto coord = getCoordinatorMac();
         sendShootoutAck(ShootoutCmd::TOURNAMENT_END, seqId, coord.data());
         return;
     }
-    lastObservedTournamentEndSeqId_ = seqId;
-    memcpy(tournamentWinner_.data(), winner, 6);
-    phase_ = Phase::ENDED;
+    lastObservedTournamentEndSeqId = seqId;
+    memcpy(tournamentWinner.data(), winner, 6);
+    phase = Phase::ENDED;
     auto coord = getCoordinatorMac();
     sendShootoutAck(ShootoutCmd::TOURNAMENT_END, seqId, coord.data());
 }
 
 void ShootoutManager::onAbortReceived() {
-    if (phase_ == Phase::ABORTED || phase_ == Phase::IDLE) return;
+    if (phase == Phase::ABORTED || phase == Phase::IDLE) return;
     resetToIdle();
-    phase_ = Phase::ABORTED;
+    phase = Phase::ABORTED;
 }
 
 std::vector<std::array<uint8_t, 6>> ShootoutManager::buildLoopMemberSet() const {
-    if (!cdm_->isLoop()) return {};
+    if (!cdm->isLoop()) return {};
 
     std::vector<std::array<uint8_t, 6>> out;
     auto addUnique = [&out](const uint8_t* mac) {
@@ -792,12 +795,12 @@ std::vector<std::array<uint8_t, 6>> ShootoutManager::buildLoopMemberSet() const 
         out.push_back(copy);
     };
 
-    addUnique(wirelessManager_->getMacAddress());
-    addUnique(rdc_->getPeerMac(SerialIdentifier::OUTPUT_JACK));
-    addUnique(rdc_->getPeerMac(SerialIdentifier::INPUT_JACK));
+    addUnique(wirelessManager->getMacAddress());
+    addUnique(rdc->getPeerMac(SerialIdentifier::OUTPUT_JACK));
+    addUnique(rdc->getPeerMac(SerialIdentifier::INPUT_JACK));
 
     for (auto jack : {SerialIdentifier::OUTPUT_JACK, SerialIdentifier::INPUT_JACK}) {
-        PortState state = rdc_->getPortState(jack);
+        PortState state = rdc->getPortState(jack);
         for (const auto& peer : state.peerMacAddresses) {
             addUnique(peer.data());
         }

--- a/src/pdn/game/shootout-manager.cpp
+++ b/src/pdn/game/shootout-manager.cpp
@@ -96,29 +96,24 @@ void ShootoutManager::broadcastCommand(const uint8_t* packet, size_t len) {
                                     PktType::kShootoutCommand, packet, len);
 }
 
-void ShootoutManager::sendToPeers(const std::vector<std::array<uint8_t, 6>>& peers,
-                                  const uint8_t* packet, size_t len) {
+void ShootoutManager::broadcastToRing(const std::vector<std::array<uint8_t, 6>>& peers,
+                                      const uint8_t* packet, size_t len) {
     // A ring fan-out is one broadcast frame, not one unicast per member: the
     // ESP-NOW peer table holds 20 entries, so unicast addressing cannot reach a
-    // ring larger than that at all, whereas the broadcast slot is registered
-    // once at radio init. Receivers drop commands naming MACs outside their own
-    // ring, which is the filtering the destination address used to provide.
+    // ring larger than that at all, whereas the broadcast slot is registered once
+    // at radio init. Receivers must drop commands naming MACs outside their own ring.
     const uint8_t* selfMac = wirelessManager->getMacAddress();
-    bool hasPeer = false;
-    for (const std::array<uint8_t, 6>& m : peers) {
-        if (selfMac == nullptr || memcmp(m.data(), selfMac, 6) != 0) {
-            hasPeer = true;
-            break;
-        }
+    if (!std::any_of(peers.begin(), peers.end(), [selfMac](const std::array<uint8_t, 6>& m) {
+            return selfMac == nullptr || memcmp(m.data(), selfMac, 6) != 0;
+        })) {
+        return;
     }
-    if (!hasPeer) return;
     broadcastCommand(packet, len);
 }
 
 void ShootoutManager::sendReliablyToPeers(std::vector<BracketPending>& pending,
                                           const std::vector<std::array<uint8_t, 6>>& peers,
                                           const uint8_t* packet, size_t len) {
-    sendToPeers(peers, packet, len);
     const uint8_t* selfMac = wirelessManager->getMacAddress();
     pending.clear();
     for (const std::array<uint8_t, 6>& m : peers) {
@@ -128,18 +123,12 @@ void ShootoutManager::sendReliablyToPeers(std::vector<BracketPending>& pending,
         p.timer.setTimer(ackTimeoutForRetry(0));
         pending.push_back(p);
     }
+    if (!pending.empty()) broadcastCommand(packet, len);
 }
 
 bool ShootoutManager::retryPendingRound(std::vector<BracketPending>& pending,
                                         const uint8_t* packet, size_t len) {
-    bool anyExpired = false;
-    for (BracketPending& p : pending) {
-        if (p.timer.expired()) {
-            anyExpired = true;
-            break;
-        }
-    }
-    if (!anyExpired) return false;
+    if (std::none_of(pending.begin(), pending.end(), [](BracketPending& p) { return p.timer.expired(); })) return false;
 
     bool exhausted = false;
     for (auto it = pending.begin(); it != pending.end();) {
@@ -267,14 +256,7 @@ void ShootoutManager::onConfirmReceived(const uint8_t* fromMac, const char* name
     // Fast path: already-confirmed peers bypass the loop-membership scan (this
     // is the common case during 1Hz rebroadcasts — the gate only needs to
     // block first-time stray CONFIRMs from outside the ring).
-    if (!hasConfirmed(fromMac)) {
-        auto members = getLoopMembers();
-        bool inLoop = false;
-        for (const auto& m : members) {
-            if (memcmp(m.data(), fromMac, 6) == 0) { inLoop = true; break; }
-        }
-        if (!inLoop) return;
-    }
+    if (!hasConfirmed(fromMac) && !containsMac(getLoopMembers(), fromMac)) return;
     recordName(fromMac, name);
     bool added = !hasConfirmed(fromMac);
     if (added) {
@@ -427,7 +409,7 @@ void ShootoutManager::abortTournament() {
     packet[0] = static_cast<uint8_t>(ShootoutCmd::ABORT);
     packet[1] = 0;
     const std::vector<std::array<uint8_t, 6>>& targets = bracket.empty() ? confirmedSet : bracket;
-    sendToPeers(targets, packet, sizeof(packet));
+    broadcastToRing(targets, packet, sizeof(packet));
 
     resetToIdle();
     phase = Phase::ABORTED;
@@ -447,7 +429,7 @@ void ShootoutManager::sendLocalConfirm() {
         memcpy(&payload[8], n.data(), copyLen);
     }
 
-    sendToPeers(getLoopMembers(), payload, sizeof(payload));
+    broadcastToRing(getLoopMembers(), payload, sizeof(payload));
     confirmRebroadcastTimer.setTimer(kConfirmRebroadcastMs);
 }
 
@@ -560,7 +542,7 @@ void ShootoutManager::onLocalRDCDisconnect(const uint8_t* lostMac) {
     packet[1] = 0;
     memcpy(&packet[2], lostMac, 6);
     const std::vector<std::array<uint8_t, 6>>& targets = bracket.empty() ? confirmedSet : bracket;
-    sendToPeers(targets, packet, sizeof(packet));
+    broadcastToRing(targets, packet, sizeof(packet));
     // Locally observed: this device's own jack went quiet, so no ring filter.
     applyPeerLoss(lostMac);
 }
@@ -809,9 +791,8 @@ void ShootoutManager::onTournamentEndReceived(const uint8_t* winner, uint8_t seq
 }
 
 void ShootoutManager::onAbortReceived(const uint8_t* fromMac) {
-    // ABORT carries no MACs of its own, so the sender is the only thing that
-    // identifies the ring it belongs to. Without this a neighbouring ring's
-    // abort would tear down every tournament in radio range.
+    // Without this filter a neighbouring ring's abort would tear down every
+    // tournament in radio range.
     if (!isRingMember(fromMac)) return;
     if (phase == Phase::ABORTED || phase == Phase::IDLE) return;
     resetToIdle();
@@ -823,10 +804,7 @@ std::vector<std::array<uint8_t, 6>> ShootoutManager::buildLoopMemberSet() const 
 
     std::vector<std::array<uint8_t, 6>> out;
     auto addUnique = [&out](const uint8_t* mac) {
-        if (mac == nullptr) return;
-        for (const auto& existing : out) {
-            if (memcmp(existing.data(), mac, 6) == 0) return;
-        }
+        if (mac == nullptr || containsMac(out, mac)) return;
         std::array<uint8_t, 6> copy;
         memcpy(copy.data(), mac, 6);
         out.push_back(copy);

--- a/src/pdn/game/shootout-manager.cpp
+++ b/src/pdn/game/shootout-manager.cpp
@@ -76,13 +76,43 @@ uint8_t ShootoutManager::nextSeqId() {
     return id;
 }
 
+bool ShootoutManager::containsMac(const std::vector<std::array<uint8_t, 6>>& set,
+                                  const uint8_t* mac) {
+    if (mac == nullptr) return false;
+    for (const std::array<uint8_t, 6>& entry : set) {
+        if (memcmp(entry.data(), mac, 6) == 0) return true;
+    }
+    return false;
+}
+
+bool ShootoutManager::isRingMember(const uint8_t* mac) const {
+    if (containsMac(bracket, mac)) return true;
+    if (containsMac(confirmedSet, mac)) return true;
+    return containsMac(getLoopMembers(), mac);
+}
+
+void ShootoutManager::broadcastCommand(const uint8_t* packet, size_t len) {
+    wirelessManager->sendEspNowData(wirelessManager->getBroadcastAddress(),
+                                    PktType::kShootoutCommand, packet, len);
+}
+
 void ShootoutManager::sendToPeers(const std::vector<std::array<uint8_t, 6>>& peers,
                                   const uint8_t* packet, size_t len) {
+    // A ring fan-out is one broadcast frame, not one unicast per member: the
+    // ESP-NOW peer table holds 20 entries, so unicast addressing cannot reach a
+    // ring larger than that at all, whereas the broadcast slot is registered
+    // once at radio init. Receivers drop commands naming MACs outside their own
+    // ring, which is the filtering the destination address used to provide.
     const uint8_t* selfMac = wirelessManager->getMacAddress();
-    for (const auto& m : peers) {
-        if (selfMac != nullptr && memcmp(m.data(), selfMac, 6) == 0) continue;
-        wirelessManager->sendEspNowData(m.data(), PktType::kShootoutCommand, packet, len);
+    bool hasPeer = false;
+    for (const std::array<uint8_t, 6>& m : peers) {
+        if (selfMac == nullptr || memcmp(m.data(), selfMac, 6) != 0) {
+            hasPeer = true;
+            break;
+        }
     }
+    if (!hasPeer) return;
+    broadcastCommand(packet, len);
 }
 
 void ShootoutManager::sendReliablyToPeers(std::vector<BracketPending>& pending,
@@ -91,13 +121,46 @@ void ShootoutManager::sendReliablyToPeers(std::vector<BracketPending>& pending,
     sendToPeers(peers, packet, len);
     const uint8_t* selfMac = wirelessManager->getMacAddress();
     pending.clear();
-    for (const auto& m : peers) {
+    for (const std::array<uint8_t, 6>& m : peers) {
         if (selfMac != nullptr && memcmp(m.data(), selfMac, 6) == 0) continue;
         BracketPending p;
         p.peer = m;
         p.timer.setTimer(ackTimeoutForRetry(0));
         pending.push_back(p);
     }
+}
+
+bool ShootoutManager::retryPendingRound(std::vector<BracketPending>& pending,
+                                        const uint8_t* packet, size_t len) {
+    bool anyExpired = false;
+    for (BracketPending& p : pending) {
+        if (p.timer.expired()) {
+            anyExpired = true;
+            break;
+        }
+    }
+    if (!anyExpired) return false;
+
+    bool exhausted = false;
+    for (auto it = pending.begin(); it != pending.end();) {
+        if (it->retries >= kMaxShootoutAckRetries) {
+            LOG_W(TAG, "shootout ack retries exhausted for %s", MacToString(it->peer.data()));
+            it = pending.erase(it);
+            exhausted = true;
+        } else {
+            ++it;
+        }
+    }
+    if (pending.empty()) return exhausted;
+
+    // One frame covers every member still owing an ack; a per-peer unicast
+    // retry would need a peer-table slot each.
+    broadcastCommand(packet, len);
+    for (BracketPending& p : pending) {
+        p.retries++;
+        p.timer.setTimer(ackTimeoutForRetry(p.retries));
+    }
+    return exhausted;
 }
 
 void ShootoutManager::eraseFromPending(std::vector<BracketPending>& pending,
@@ -255,10 +318,7 @@ std::string ShootoutManager::getNameForMac(const uint8_t* mac) const {
 }
 
 bool ShootoutManager::hasConfirmed(const uint8_t* mac) const {
-    for (const auto& existing : confirmedSet) {
-        if (memcmp(existing.data(), mac, 6) == 0) return true;
-    }
-    return false;
+    return containsMac(confirmedSet, mac);
 }
 
 bool ShootoutManager::allMembersConfirmed() const {
@@ -358,21 +418,6 @@ void ShootoutManager::onBracketAckReceived(const uint8_t* fromMac, uint8_t seqId
     eraseFromPending(bracketPendingAcks, fromMac);
 }
 
-bool ShootoutManager::retryBracketForPeer(BracketPending& p) {
-    if (p.retries >= kMaxShootoutAckRetries) {
-        // Caller is iterating bracketPendingAcks; don't abort here (that
-        // clears the vector and invalidates the iterator). Signal and let
-        // the caller abort after exiting the loop.
-        return true;
-    }
-    auto packet = buildBracketPacket();
-    wirelessManager->sendEspNowData(p.peer.data(), PktType::kShootoutCommand,
-                                    packet.data(), packet.size());
-    p.retries++;
-    p.timer.setTimer(ackTimeoutForRetry(p.retries));
-    return false;
-}
-
 void ShootoutManager::abortTournament() {
     if (phase == Phase::ABORTED) return;
     LOG_W(TAG, "abortTournament from phase=%d", static_cast<int>(phase));
@@ -416,16 +461,15 @@ void ShootoutManager::sync() {
         }
     }
 
-    bool shouldAbort = false;
-    for (auto& p : bracketPendingAcks) {
-        if (p.timer.expired()) {
-            if (retryBracketForPeer(p)) {
-                shouldAbort = true;
-                break;
-            }
+    if (!bracketPendingAcks.empty()) {
+        std::vector<uint8_t> packet = buildBracketPacket();
+        // A member that never acks the bracket would sit out the tournament it
+        // is physically wired into, so an exhausted budget aborts rather than
+        // dropping that member.
+        if (retryPendingRound(bracketPendingAcks, packet.data(), packet.size())) {
+            abortTournament();
         }
     }
-    if (shouldAbort) abortTournament();
 
     maybeStartNextMatch();
 
@@ -440,44 +484,14 @@ void ShootoutManager::sync() {
         packet[0] = static_cast<uint8_t>(ShootoutCmd::TOURNAMENT_END);
         packet[1] = lastTournamentEndSeqId;
         memcpy(&packet[2], tournamentWinner.data(), 6);
-        for (auto it = tournamentEndPendingAcks.begin();
-             it != tournamentEndPendingAcks.end();) {
-            if (!it->timer.expired()) { ++it; continue; }
-            if (it->retries >= kMaxShootoutAckRetries) {
-                LOG_W(TAG, "TOURNAMENT_END retries exhausted for %s",
-                      MacToString(it->peer.data()));
-                it = tournamentEndPendingAcks.erase(it);
-                continue;
-            }
-            wirelessManager->sendEspNowData(it->peer.data(),
-                                            PktType::kShootoutCommand,
-                                            packet, sizeof(packet));
-            it->retries++;
-            it->timer.setTimer(ackTimeoutForRetry(it->retries));
-            ++it;
-        }
+        retryPendingRound(tournamentEndPendingAcks, packet, sizeof(packet));
     }
 
     if (!matchResultPendingAcks.empty()) {
-        auto packet = buildMatchResultPacket(
+        std::vector<uint8_t> packet = buildMatchResultPacket(
             lastMatchResult.winner.data(), lastMatchResult.loser.data(),
             lastMatchResult.matchIndex);
-        for (auto it = matchResultPendingAcks.begin();
-             it != matchResultPendingAcks.end();) {
-            if (!it->timer.expired()) { ++it; continue; }
-            if (it->retries >= kMaxShootoutAckRetries) {
-                LOG_W(TAG, "MATCH_RESULT retries exhausted for %s",
-                      MacToString(it->peer.data()));
-                it = matchResultPendingAcks.erase(it);
-                continue;
-            }
-            wirelessManager->sendEspNowData(it->peer.data(),
-                                            PktType::kShootoutCommand,
-                                            packet.data(), packet.size());
-            it->retries++;
-            it->timer.setTimer(ackTimeoutForRetry(it->retries));
-            ++it;
-        }
+        retryPendingRound(matchResultPendingAcks, packet.data(), packet.size());
     }
 }
 
@@ -547,11 +561,19 @@ void ShootoutManager::onLocalRDCDisconnect(const uint8_t* lostMac) {
     memcpy(&packet[2], lostMac, 6);
     const std::vector<std::array<uint8_t, 6>>& targets = bracket.empty() ? confirmedSet : bracket;
     sendToPeers(targets, packet, sizeof(packet));
-    onPeerLostReceived(lostMac);
+    // Locally observed: this device's own jack went quiet, so no ring filter.
+    applyPeerLoss(lostMac);
 }
 
 void ShootoutManager::onPeerLostReceived(const uint8_t* lostMac) {
-    LOG_W(TAG, "onPeerLostReceived %s phase=%d",
+    // A broadcast PEER_LOST reaches every ring in range; only a loss inside ours
+    // may end our tournament.
+    if (!isRingMember(lostMac)) return;
+    applyPeerLoss(lostMac);
+}
+
+void ShootoutManager::applyPeerLoss(const uint8_t* lostMac) {
+    LOG_W(TAG, "applyPeerLoss %s phase=%d",
           MacToString(lostMac), static_cast<int>(phase));
     if (phase == Phase::IDLE || phase == Phase::ABORTED || phase == Phase::ENDED) return;
     if (rdc && rdc->canReachPeer(lostMac)) return;
@@ -608,6 +630,10 @@ std::array<uint8_t, 6> ShootoutManager::lowestMacIn(
 void ShootoutManager::onBracketReceived(
     const std::vector<std::array<uint8_t, 6>>& offeredBracket, uint8_t seqId) {
     if (isCoordinator()) return;
+    // A broadcast bracket reaches every ring in radio range; the roster itself
+    // says whether it is ours. Ack nothing we are not part of, or a neighbouring
+    // ring's coordinator would count us as one of its members.
+    if (!containsMac(offeredBracket, wirelessManager->getMacAddress())) return;
     if (seqId != 0 && seqId == lastObservedBracketSeqId) {
         std::array<uint8_t, 6> coord = lowestMacIn(offeredBracket);
         sendShootoutAck(ShootoutCmd::BRACKET, seqId, coord.data());
@@ -626,6 +652,9 @@ void ShootoutManager::onMatchStartReceived(
     const uint8_t* duelistA, const uint8_t* duelistB,
     uint8_t matchIndex, uint8_t seqId) {
     if (isCoordinator()) return;
+    // Both duelists come from our own bracket, so a pair naming anyone outside
+    // it belongs to another ring's broadcast.
+    if (!containsMac(bracket, duelistA) || !containsMac(bracket, duelistB)) return;
     if (seqId != 0 && seqId == lastObservedMatchStartSeqId) {
         sendShootoutAck(ShootoutCmd::MATCH_START, seqId, coordinatorMac.data());
         return;
@@ -657,10 +686,7 @@ void ShootoutManager::sendShootoutAck(ShootoutCmd cmd, uint8_t seqId, const uint
 }
 
 bool ShootoutManager::isEliminated(const uint8_t* mac) const {
-    for (const auto& m : eliminated) {
-        if (memcmp(m.data(), mac, 6) == 0) return true;
-    }
-    return false;
+    return containsMac(eliminated, mac);
 }
 
 void ShootoutManager::applyMatchResult(const uint8_t* winner, const uint8_t* loser) {
@@ -715,6 +741,10 @@ void ShootoutManager::reportLocalWin() {
 void ShootoutManager::onMatchResultReceived(
     const uint8_t* winner, const uint8_t* loser,
     uint8_t matchIndex, uint8_t seqId, const uint8_t* fromMac) {
+    // Winner and loser are both drawn from our own bracket, so a result naming
+    // anyone outside it came from another ring's broadcast — and must not be
+    // acked, or that ring's sender stops retrying to its real audience.
+    if (!containsMac(bracket, winner) || !containsMac(bracket, loser)) return;
     // Always ack so the sender stops retrying, even when this is a duplicate.
     sendShootoutAck(ShootoutCmd::MATCH_RESULT, seqId, fromMac);
     // Dedup by loser-MAC rather than seqId: non-coord senders have independent
@@ -763,6 +793,9 @@ void ShootoutManager::onTournamentEndAckReceived(const uint8_t* fromMac, uint8_t
 }
 
 void ShootoutManager::onTournamentEndReceived(const uint8_t* winner, uint8_t seqId) {
+    // The winner is a member of our bracket; anyone else won another ring's
+    // tournament and must not end ours.
+    if (!containsMac(bracket, winner)) return;
     if (seqId != 0 && seqId == lastObservedTournamentEndSeqId) {
         auto coord = getCoordinatorMac();
         sendShootoutAck(ShootoutCmd::TOURNAMENT_END, seqId, coord.data());
@@ -775,7 +808,11 @@ void ShootoutManager::onTournamentEndReceived(const uint8_t* winner, uint8_t seq
     sendShootoutAck(ShootoutCmd::TOURNAMENT_END, seqId, coord.data());
 }
 
-void ShootoutManager::onAbortReceived() {
+void ShootoutManager::onAbortReceived(const uint8_t* fromMac) {
+    // ABORT carries no MACs of its own, so the sender is the only thing that
+    // identifies the ring it belongs to. Without this a neighbouring ring's
+    // abort would tear down every tournament in radio range.
+    if (!isRingMember(fromMac)) return;
     if (phase == Phase::ABORTED || phase == Phase::IDLE) return;
     resetToIdle();
     phase = Phase::ABORTED;

--- a/src/pdn/game/shootout-manager.hpp
+++ b/src/pdn/game/shootout-manager.hpp
@@ -151,12 +151,14 @@ private:
     uint8_t nextSeqId();
     static bool containsMac(const std::vector<std::array<uint8_t, 6>>& set,
                             const uint8_t* mac);
-    // True when mac takes part in this device's tournament: the formed bracket
-    // when there is one, otherwise the confirmed set or the physical loop.
+    // Any of the three, because which set knows the ring depends on the phase:
+    // the bracket after reveal, the confirmed set during the proposal, the
+    // physical loop before either exists. A follower's bracket is not a subset
+    // of its confirmed set, so none of the three subsumes the others.
     bool isRingMember(const uint8_t* mac) const;
     void broadcastCommand(const uint8_t* packet, size_t len);
-    void sendToPeers(const std::vector<std::array<uint8_t, 6>>& peers,
-                     const uint8_t* packet, size_t len);
+    void broadcastToRing(const std::vector<std::array<uint8_t, 6>>& peers,
+                         const uint8_t* packet, size_t len);
     void sendReliablyToPeers(std::vector<BracketPending>& pending,
                              const std::vector<std::array<uint8_t, 6>>& peers,
                              const uint8_t* packet, size_t len);

--- a/src/pdn/game/shootout-manager.hpp
+++ b/src/pdn/game/shootout-manager.hpp
@@ -93,6 +93,8 @@ public:
     bool isEliminated(const uint8_t* mac) const;
 
     void onLocalRDCDisconnect(const uint8_t* lostMac);
+    /// Tears down on a peer's PEER_LOST, after checking the named MAC is one of
+    /// this device's ring members.
     void onPeerLostReceived(const uint8_t* lostMac);
     uint8_t getLastMatchStartSeqId() const;
 
@@ -101,7 +103,10 @@ public:
     size_t getTournamentEndPendingAckCount() const;
     /// seqId of the TOURNAMENT_END this device most recently sent.
     uint8_t getLastTournamentEndSeqId() const { return lastTournamentEndSeqId; }
-    void onAbortReceived();
+    /// Tears down on a peer's ABORT. fromMac identifies the sending ring: the
+    /// command carries no MACs of its own, and a broadcast reaches every ring
+    /// in radio range.
+    void onAbortReceived(const uint8_t* fromMac);
     std::array<uint8_t, 6> getTournamentWinner() const;
 
     // Reset all tournament state back to IDLE phase so a subsequent loop
@@ -143,6 +148,12 @@ private:
     void primeMatchManagerForMatch();
 
     uint8_t nextSeqId();
+    static bool containsMac(const std::vector<std::array<uint8_t, 6>>& set,
+                            const uint8_t* mac);
+    // True when mac takes part in this device's tournament: the formed bracket
+    // when there is one, otherwise the confirmed set or the physical loop.
+    bool isRingMember(const uint8_t* mac) const;
+    void broadcastCommand(const uint8_t* packet, size_t len);
     void sendToPeers(const std::vector<std::array<uint8_t, 6>>& peers,
                      const uint8_t* packet, size_t len);
     void sendReliablyToPeers(std::vector<BracketPending>& pending,
@@ -150,6 +161,11 @@ private:
                              const uint8_t* packet, size_t len);
     static void eraseFromPending(std::vector<BracketPending>& pending,
                                  const uint8_t* fromMac);
+    // Re-broadcasts `packet` once when any pending ack has timed out, advancing
+    // every surviving entry's retry counter. Drops entries whose budget is
+    // spent and returns true if any was dropped.
+    bool retryPendingRound(std::vector<BracketPending>& pending,
+                           const uint8_t* packet, size_t len);
 
     std::vector<std::array<uint8_t, 6>> testLoopMembers;
     bool testLoopMembersOverride = false;
@@ -178,9 +194,6 @@ private:
     static constexpr uint8_t kMaxShootoutAckRetries = 3;
 
     void sendBracketToPeers();
-    // Returns true iff the retry budget is exhausted for this peer and the
-    // caller should abort the tournament after exiting its iteration.
-    bool retryBracketForPeer(BracketPending& p);
     std::vector<uint8_t> buildBracketPacket() const;
     static std::array<uint8_t, 6> lowestMacIn(
         const std::vector<std::array<uint8_t, 6>>& set);
@@ -206,6 +219,9 @@ private:
     std::vector<uint8_t> buildMatchStartPacket(int matchIndex) const;
 
     std::vector<std::array<uint8_t, 6>> eliminated;
+    // Ends the tournament for a departed participant. Callers own the question of
+    // whether the MAC is one of ours; a locally observed jack loss already is.
+    void applyPeerLoss(const uint8_t* lostMac);
     bool isActiveDuelist(const uint8_t* mac) const;
     bool isSameMatch(int matchIndex, const uint8_t* a, const uint8_t* b) const;
     bool reportedLocalWin = false;

--- a/src/pdn/game/shootout-manager.hpp
+++ b/src/pdn/game/shootout-manager.hpp
@@ -7,6 +7,7 @@
 #include "game/player.hpp"
 #include "game/chain-duel-manager.hpp"
 #include "device/remote-device-coordinator.hpp"
+#include "device/drivers/peer-comms-types.hpp"
 #include "device/wireless-manager.hpp"
 #include "utils/simple-timer.hpp"
 
@@ -121,10 +122,10 @@ public:
     static constexpr unsigned long kConfirmRebroadcastMs = 1000;
     static constexpr unsigned long kBracketRevealMs = 5000;
     static constexpr unsigned long kMatchWatchdogMs = 10000;
-    // Absolute upper bound on bracket size. RDC peer-table capacity and
-    // kMaxChainPeersPerPort=18 cap real hardware tournaments well below this;
-    // value is a packet-validation clamp to reject malformed BRACKET packets.
-    static constexpr uint8_t kMaxBracketSize = 32;
+    // Packet-validation clamp on an inbound BRACKET's member count. A ring can
+    // hold as many devices as the chain does, so it tracks MAX_CHAIN_MEMBERS;
+    // one ESP-NOW v2 frame carries that bracket several times over.
+    static constexpr uint8_t MAX_BRACKET_SIZE = MAX_CHAIN_MEMBERS;
 
 private:
     struct BracketPending {

--- a/src/pdn/game/shootout-manager.hpp
+++ b/src/pdn/game/shootout-manager.hpp
@@ -33,10 +33,10 @@ public:
                     ChainDuelManager* cdm);
     ~ShootoutManager() = default;
 
-    // Optional MatchManager injection. When set, Shootout primes the
-    // MatchManager with the duelist pair on each MATCH_START so duel
-    // states find a ready match. Tests leave this unset.
-    void setMatchManager(MatchManager* matchManager) { matchManager_ = matchManager; }
+    /// Optional MatchManager injection. When set, Shootout primes the
+    /// MatchManager with the duelist pair on each MATCH_START so duel
+    /// states find a ready match. Tests leave this unset.
+    void setMatchManager(MatchManager* manager) { matchManager = manager; }
 
     bool active() const;
     Phase getPhase() const;
@@ -74,7 +74,9 @@ public:
     std::pair<std::array<uint8_t,6>, std::array<uint8_t,6>> getCurrentMatchPair() const;
     void onMatchStartAckReceived(const uint8_t* fromMac, uint8_t seqId);
 
-    void onBracketReceived(const std::vector<std::array<uint8_t, 6>>& bracket, uint8_t seqId);
+    /// Adopts a bracket announced by the coordinator and acks it.
+    void onBracketReceived(const std::vector<std::array<uint8_t, 6>>& offeredBracket,
+                           uint8_t seqId);
     void onMatchStartReceived(const uint8_t* duelistA, const uint8_t* duelistB,
                               uint8_t matchIndex, uint8_t seqId);
     bool isLocalDuelist() const;
@@ -86,7 +88,8 @@ public:
                                const uint8_t* fromMac);
     void onMatchResultAckReceived(const uint8_t* fromMac, uint8_t seqId);
     size_t getMatchResultPendingAckCount() const;
-    uint8_t getLastMatchResultSeqId() const { return lastMatchResultSeqId_; }
+    /// seqId of the MATCH_RESULT this device most recently sent.
+    uint8_t getLastMatchResultSeqId() const { return lastMatchResultSeqId; }
     bool isEliminated(const uint8_t* mac) const;
 
     void onLocalRDCDisconnect(const uint8_t* lostMac);
@@ -96,7 +99,8 @@ public:
     void onTournamentEndReceived(const uint8_t* winner, uint8_t seqId);
     void onTournamentEndAckReceived(const uint8_t* fromMac, uint8_t seqId);
     size_t getTournamentEndPendingAckCount() const;
-    uint8_t getLastTournamentEndSeqId() const { return lastTournamentEndSeqId_; }
+    /// seqId of the TOURNAMENT_END this device most recently sent.
+    uint8_t getLastTournamentEndSeqId() const { return lastTournamentEndSeqId; }
     void onAbortReceived();
     std::array<uint8_t, 6> getTournamentWinner() const;
 
@@ -129,12 +133,12 @@ private:
         std::string name;
     };
 
-    Player* player_;
-    WirelessManager* wirelessManager_;
-    RemoteDeviceCoordinator* rdc_;
-    ChainDuelManager* cdm_;
-    MatchManager* matchManager_ = nullptr;
-    Phase phase_ = Phase::IDLE;
+    Player* player;
+    WirelessManager* wirelessManager;
+    RemoteDeviceCoordinator* rdc;
+    ChainDuelManager* cdm;
+    MatchManager* matchManager = nullptr;
+    Phase phase = Phase::IDLE;
 
     void primeMatchManagerForMatch();
 
@@ -147,11 +151,11 @@ private:
     static void eraseFromPending(std::vector<BracketPending>& pending,
                                  const uint8_t* fromMac);
 
-    std::vector<std::array<uint8_t, 6>> testLoopMembers_;
-    bool testLoopMembersOverride_ = false;
-    std::vector<std::array<uint8_t, 6>> confirmedSet_;
+    std::vector<std::array<uint8_t, 6>> testLoopMembers;
+    bool testLoopMembersOverride = false;
+    std::vector<std::array<uint8_t, 6>> confirmedSet;
 
-    std::vector<NameEntry> names_;
+    std::vector<NameEntry> names;
     void recordName(const uint8_t* mac, const char* name);
 
     std::vector<std::array<uint8_t, 6>> buildLoopMemberSet() const;
@@ -160,17 +164,17 @@ private:
     void advanceToBracketReveal();
     void generateBracket();
 
-    std::vector<std::array<uint8_t, 6>> bracket_;
-    // Coord-only working set: starts equal to bracket_, replaced by survivors at
-    // each round boundary. bracket_ stays immutable so getBracket() remains
+    std::vector<std::array<uint8_t, 6>> bracket;
+    // Coord-only working set: starts equal to bracket, replaced by survivors at
+    // each round boundary. bracket stays immutable so getBracket() remains
     // stable and non-coord position lookups don't desync.
-    std::vector<std::array<uint8_t, 6>> currentRound_;
+    std::vector<std::array<uint8_t, 6>> currentRound;
 
-    SimpleTimer confirmRebroadcastTimer_;
+    SimpleTimer confirmRebroadcastTimer;
 
-    std::vector<BracketPending> bracketPendingAcks_;
-    uint8_t lastBracketSeqId_ = 0;
-    uint8_t nextShootoutSeqId_ = 1;
+    std::vector<BracketPending> bracketPendingAcks;
+    uint8_t lastBracketSeqId = 0;
+    uint8_t nextShootoutSeqId = 1;
     static constexpr uint8_t kMaxShootoutAckRetries = 3;
 
     void sendBracketToPeers();
@@ -181,39 +185,39 @@ private:
     static std::array<uint8_t, 6> lowestMacIn(
         const std::vector<std::array<uint8_t, 6>>& set);
 
-    // Stable post-bracket-formation. Used in place of lowestMacIn(bracket_)
+    // Stable post-bracket-formation. Used in place of lowestMacIn(bracket)
     // which would otherwise rescan the bracket on every ack path.
-    std::array<uint8_t, 6> coordinatorMac_{};
+    std::array<uint8_t, 6> coordinatorMac{};
 
-    std::array<uint8_t, 6> opponentMac_{};
+    std::array<uint8_t, 6> opponentMac{};
     void sendShootoutAck(ShootoutCmd cmd, uint8_t seqId, const uint8_t* toMac);
 
-    int currentMatchIndex_ = -1;
-    // bracket_ shrinks on round advancement (coordinator only), so cache the
+    int currentMatchIndex = -1;
+    // bracket shrinks on round advancement (coordinator only), so cache the
     // duelist pair separately to stay valid on non-coordinators too.
-    std::array<uint8_t, 6> currentDuelistA_{};
-    std::array<uint8_t, 6> currentDuelistB_{};
-    uint8_t lastMatchStartSeqId_ = 0;
-    SimpleTimer bracketRevealTimer_;
-    std::vector<BracketPending> matchStartPendingAcks_;
+    std::array<uint8_t, 6> currentDuelistA{};
+    std::array<uint8_t, 6> currentDuelistB{};
+    uint8_t lastMatchStartSeqId = 0;
+    SimpleTimer bracketRevealTimer;
+    std::vector<BracketPending> matchStartPendingAcks;
     void maybeStartNextMatch();
-    bool inMaybeStartNextMatch_ = false;
+    bool inMaybeStartNextMatch = false;
     void sendMatchStartToPeers(int matchIndex);
     std::vector<uint8_t> buildMatchStartPacket(int matchIndex) const;
 
-    std::vector<std::array<uint8_t, 6>> eliminated_;
+    std::vector<std::array<uint8_t, 6>> eliminated;
     bool isActiveDuelist(const uint8_t* mac) const;
     bool isSameMatch(int matchIndex, const uint8_t* a, const uint8_t* b) const;
-    bool reportedLocalWin_ = false;
-    uint8_t lastMatchResultSeqId_ = 0;
+    bool reportedLocalWin = false;
+    uint8_t lastMatchResultSeqId = 0;
     // Per-command last-observed seqId for ESP-NOW link-layer dedup.
-    uint8_t lastObservedBracketSeqId_ = 0;
-    uint8_t lastObservedMatchStartSeqId_ = 0;
-    uint8_t lastObservedTournamentEndSeqId_ = 0;
-    SimpleTimer matchStartWatchdog_;
+    uint8_t lastObservedBracketSeqId = 0;
+    uint8_t lastObservedMatchStartSeqId = 0;
+    uint8_t lastObservedTournamentEndSeqId = 0;
+    SimpleTimer matchStartWatchdog;
     void sendMatchResultToPeers(const uint8_t* winner, const uint8_t* loser,
                               uint8_t matchIndex);
-    std::vector<BracketPending> matchResultPendingAcks_;
+    std::vector<BracketPending> matchResultPendingAcks;
     // Cached so sync() can rebuild the packet for retry. Senders aren't
     // always the coordinator, so a per-sender cache is required.
     struct LastMatchResult {
@@ -221,7 +225,7 @@ private:
         std::array<uint8_t, 6> loser{};
         uint8_t matchIndex = 0;
     };
-    LastMatchResult lastMatchResult_;
+    LastMatchResult lastMatchResult;
     void applyMatchResult(const uint8_t* winner, const uint8_t* loser);
     std::vector<uint8_t> buildMatchResultPacket(const uint8_t* winner,
                                                 const uint8_t* loser,
@@ -229,14 +233,14 @@ private:
 
     static unsigned long ackTimeoutForRetry(uint8_t retries);
 
-    std::array<uint8_t, 6> tournamentWinner_{};
-    uint8_t lastTournamentEndSeqId_ = 0;
+    std::array<uint8_t, 6> tournamentWinner{};
+    uint8_t lastTournamentEndSeqId = 0;
 
-    // Snapshot of player_->isHunter() at tournament entry: primeMatchManagerForMatch
+    // Snapshot of player->isHunter() at tournament entry: primeMatchManagerForMatch
     // overrides isHunter by MAC ordering, and without restore the override leaks
     // into the post-tournament duel.
-    std::optional<bool> originalIsHunter_;
+    std::optional<bool> originalIsHunter;
     void sendTournamentEndToPeers(const uint8_t* winner);
-    std::vector<BracketPending> tournamentEndPendingAcks_;
+    std::vector<BracketPending> tournamentEndPendingAcks;
     std::array<uint8_t, 6> findLastRemaining() const;
 };

--- a/test/test_core/chain-duel-multi-device-fixture.hpp
+++ b/test/test_core/chain-duel-multi-device-fixture.hpp
@@ -288,8 +288,7 @@ protected:
     void dispatch(const PendingPacket& p) {
         // A broadcast frame lands on every node in range except its sender,
         // which is what the radio does with the permanent broadcast peer.
-        static const std::array<uint8_t, 6> BROADCAST_MAC = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-        if (p.toMac == BROADCAST_MAC) {
+        if (memcmp(p.toMac.data(), MockDevice::BROADCAST_MAC, 6) == 0) {
             for (size_t i = 0; i < nodes.size(); ++i) {
                 if (i == p.fromIndex) continue;
                 PendingPacket unicast = p;

--- a/test/test_core/chain-duel-multi-device-fixture.hpp
+++ b/test/test_core/chain-duel-multi-device-fixture.hpp
@@ -286,6 +286,18 @@ protected:
     }
 
     void dispatch(const PendingPacket& p) {
+        // A broadcast frame lands on every node in range except its sender,
+        // which is what the radio does with the permanent broadcast peer.
+        static const std::array<uint8_t, 6> BROADCAST_MAC = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+        if (p.toMac == BROADCAST_MAC) {
+            for (size_t i = 0; i < nodes.size(); ++i) {
+                if (i == p.fromIndex) continue;
+                PendingPacket unicast = p;
+                memcpy(unicast.toMac.data(), nodes[i]->mac, 6);
+                dispatch(unicast);
+            }
+            return;
+        }
         size_t toIdx = indexOfMac(p.toMac.data());
         if (toIdx == SIZE_MAX) return;  // MAC unknown — drop (mirrors real ESP-NOW gating).
 
@@ -466,7 +478,7 @@ protected:
                         if (payloadLen >= 6) m->onPeerLostReceived(payload);
                         break;
                     case ShootoutCmd::ABORT:
-                        m->onAbortReceived();
+                        m->onAbortReceived(fromMac);
                         break;
                 }
             },

--- a/test/test_core/device-mock.hpp
+++ b/test/test_core/device-mock.hpp
@@ -296,6 +296,8 @@ public:
 
 class MockDevice : public PDN {
 public:
+    static constexpr uint8_t BROADCAST_MAC[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
     MockDevice() : PDN() {
         // Initialize mock pointers
         mockDisplay = new MockDisplay();
@@ -308,6 +310,10 @@ public:
         lightManager = new LightManager(fakeLightStrip);
         serialManager = new SerialManager(&outputJackSerial, &inputJackSerial);
         wirelessManager = new WirelessManager(mockPeerComms, mockHttpClient);
+        // The real driver registers a permanent broadcast peer at radio init and
+        // hands its address back here; broadcast fan-out is unreachable without it.
+        ON_CALL(*mockPeerComms, getGlobalBroadcastAddress())
+            .WillByDefault(testing::Return(BROADCAST_MAC));
     }
 
     ~MockDevice() {

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -2658,9 +2658,9 @@ inline void rdcResendContextSendsOncePerPeer(RDCHelloTests* suite) {
     EXPECT_EQ(contextSends.size(), beforeResend + 1);
 }
 
-// The cap now sits at the event envelope, not at a v1 frame: a chain longer than
-// the old 18 must roster in full, and its whole roster must still hand off in one
-// HeadTransfer frame (the frame budget is asserted at compile time in the driver).
+// The cap sits at the event envelope, not at a v1 frame: a chain filled to the cap
+// must roster in full, and its whole roster must still hand off in one HeadTransfer
+// frame (the frame budget is asserted at compile time in the driver).
 inline void rdcRosterHoldsFullEventChain(RDCHelloTests* suite) {
     EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
 

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -2657,3 +2657,81 @@ inline void rdcResendContextSendsOncePerPeer(RDCHelloTests* suite) {
 
     EXPECT_EQ(contextSends.size(), beforeResend + 1);
 }
+
+// The cap now sits at the event envelope, not at a v1 frame: a chain longer than
+// the old 18 must roster in full, and its whole roster must still hand off in one
+// HeadTransfer frame (the frame budget is asserted at compile time in the driver).
+inline void rdcRosterHoldsFullEventChain(RDCHelloTests* suite) {
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    ASSERT_GT(MAX_CHAIN_MEMBERS, 18) << "cap must exceed the retired v1-frame value";
+    for (uint8_t i = 0; i < MAX_CHAIN_MEMBERS; ++i) {
+        uint8_t member[6] = {0x30, static_cast<uint8_t>(i), 0x03, 0x04, 0x05, 0x06};
+        uint8_t upstream[6] = {0x80, static_cast<uint8_t>(i), 0x03, 0x04, 0x05, 0x06};
+        std::vector<uint8_t> a = announceBytes(upstream, 1);
+        suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, member,
+                                            a.data(), a.size());
+    }
+    EXPECT_EQ(suite->rdc.getChainMembers().size(), static_cast<size_t>(MAX_CHAIN_MEMBERS));
+}
+
+// Overflow contract, head side: past the cap the announce is dropped and the
+// member never joins the roster. The member's own HELLO confirmed bit still rises
+// (SEND_SUCCESS already fired on a frame the head then discarded) — the head
+// cannot observe or correct that, which is why the cap sits past any real chain.
+inline void rdcAnnounceOverCapIsDroppedNotAdmitted(RDCHelloTests* suite) {
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    for (uint8_t i = 0; i < MAX_CHAIN_MEMBERS; ++i) {
+        uint8_t member[6] = {0x30, static_cast<uint8_t>(i), 0x03, 0x04, 0x05, 0x06};
+        uint8_t upstream[6] = {0x80, static_cast<uint8_t>(i), 0x03, 0x04, 0x05, 0x06};
+        std::vector<uint8_t> a = announceBytes(upstream, 1);
+        suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, member,
+                                            a.data(), a.size());
+    }
+    ASSERT_EQ(suite->rdc.getChainMembers().size(), static_cast<size_t>(MAX_CHAIN_MEMBERS));
+
+    // One past the cap, on an upstream no existing member claims (so eviction
+    // cannot free a slot for it).
+    const uint8_t overflowMember[6] = {0xFE, 0x02, 0x03, 0x04, 0x05, 0x06};
+    const uint8_t freeUpstream[6] = {0xFD, 0x02, 0x03, 0x04, 0x05, 0x06};
+    std::vector<uint8_t> a = announceBytes(freeUpstream, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, overflowMember,
+                                        a.data(), a.size());
+
+    std::vector<std::array<uint8_t, 6>> members = suite->rdc.getChainMembers();
+    EXPECT_EQ(members.size(), static_cast<size_t>(MAX_CHAIN_MEMBERS));
+    bool admitted = false;
+    for (const auto& m : members) {
+        if (memcmp(m.data(), overflowMember, 6) == 0) admitted = true;
+    }
+    EXPECT_FALSE(admitted);
+}
+
+// A full-cap roster travels in one HeadTransfer payload, so a successor inherits
+// every member instead of the first 18.
+inline void rdcHeadTransferCarriesFullCapRoster(RDCHelloTests* suite) {
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+
+    const uint8_t oldHead[6] = {0x77, 0x02, 0x03, 0x04, 0x05, 0x06};
+    std::vector<std::pair<std::array<uint8_t, 6>, std::array<uint8_t, 6>>> entries;
+    for (uint8_t i = 0; i < MAX_CHAIN_MEMBERS; ++i) {
+        std::array<uint8_t, 6> member = {0x40, i, 0x03, 0x04, 0x05, 0x06};
+        std::array<uint8_t, 6> upstream = {0x90, i, 0x03, 0x04, 0x05, 0x06};
+        entries.push_back({member, upstream});
+    }
+    std::vector<uint8_t> handoff = headTransferBytes(entries, 5);
+    suite->transport()->deliverIncoming(PktType::kHeadTransfer, oldHead,
+                                        handoff.data(), handoff.size());
+
+    EXPECT_EQ(suite->rdc.getChainMembers().size(), static_cast<size_t>(MAX_CHAIN_MEMBERS));
+}

--- a/test/test_core/serial-frame-parser-tests.hpp
+++ b/test/test_core/serial-frame-parser-tests.hpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "device/remote-device-coordinator.hpp"
 #include "device/serial-frame-parser.hpp"
 #include "utility-tests.hpp"
 #include "utils/simple-timer.hpp"
@@ -211,6 +212,48 @@ TEST_F(SerialFrameParserTests, midFrameTimeoutResets) {
 
     feed(buildFrame(OP_HELLO, helloPayload()));
     EXPECT_EQ(frameCount, 1);
+}
+
+TEST_F(SerialFrameParserTests, truncatedFrameCostsOnlyItsOwnFrame) {
+    int frameCount = 0;
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; ++frameCount; });
+
+    // The regime the wire actually produces: a frame cut short, then the next
+    // HELLO one cadence later. 20ms never trips the 50ms mid-frame timeout, and
+    // the driver drains the whole RX FIFO in one loop so the two frames can
+    // arrive with no gap at all. The short frame therefore eats the start of the
+    // good one, and only re-scanning the bytes it swallowed recovers the good
+    // frame — otherwise one dropped byte costs two frames, not one.
+    std::vector<uint8_t> truncated = buildFrame(OP_HELLO, helloPayload(0x01));
+    truncated.resize(truncated.size() - 3);
+    feed(truncated);
+
+    fakeClock->advance(RemoteDeviceCoordinator::HELLO_CADENCE_MS);
+    feed(buildFrame(OP_HELLO, helloPayload(0xA2)));
+
+    ASSERT_EQ(frameCount, 1);
+    EXPECT_EQ(got.source[0], 0xA2);
+}
+
+TEST_F(SerialFrameParserTests, droppedPayloadByteCostsOnlyItsOwnFrame) {
+    int frameCount = 0;
+    HelloPayload got{};
+    parser.setHelloFrameHandler([&](const HelloPayload& h) { got = h; ++frameCount; });
+
+    // One byte lost mid-payload: the frame keeps its preamble but is a byte
+    // short, so it reads two bytes of the next frame as its CRC. The bytes it
+    // swallowed end in the next frame's 0xAA, so the replay must leave the
+    // parser mid-preamble for the 0x55 that arrives after it.
+    std::vector<uint8_t> shortByOne = buildFrame(OP_HELLO, helloPayload(0x01));
+    shortByOne.erase(shortByOne.begin() + 8);
+    feed(shortByOne);
+
+    fakeClock->advance(RemoteDeviceCoordinator::HELLO_CADENCE_MS);
+    feed(buildFrame(OP_HELLO, helloPayload(0xA3)));
+
+    ASSERT_EQ(frameCount, 1);
+    EXPECT_EQ(got.source[0], 0xA3);
 }
 
 TEST_F(SerialFrameParserTests, backwardClockKeepsPartialFrameAlive) {

--- a/test/test_core/shootout-manager-tests.hpp
+++ b/test/test_core/shootout-manager-tests.hpp
@@ -149,16 +149,26 @@ inline void coordinatorBroadcastsBracketOnAdvance(ShootoutManagerTests* suite) {
     };
     suite->shootout->setLoopMembersForTest(members);
 
-    EXPECT_CALL(*suite->device.mockPeerComms,
-        sendData(testing::_, PktType::kShootoutCommand, testing::_, testing::_))
-        .Times(testing::AtLeast(2))
-        .WillRepeatedly(testing::Return(1));
+    // The fan-out is a single broadcast frame, not one unicast per member, and
+    // it still owes an ack from each of the two peers.
+    std::vector<std::array<uint8_t, 6>> destinations;
+    ON_CALL(*suite->device.mockPeerComms,
+            sendData(testing::_, PktType::kShootoutCommand, testing::_, testing::_))
+        .WillByDefault(testing::Invoke(
+            [&destinations](const uint8_t* dst, PktType, const uint8_t*, const size_t) {
+                std::array<uint8_t, 6> mac{};
+                memcpy(mac.data(), dst, 6);
+                destinations.push_back(mac);
+                return 1;
+            }));
 
     suite->shootout->startProposal();
     for (auto& m : members) suite->shootout->onConfirmReceived(m.data());
     suite->shootout->confirmLocal();
     EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::BRACKET_REVEAL);
     EXPECT_EQ(suite->shootout->getBracketPendingAckCount(), 2u);
+    ASSERT_EQ(destinations.size(), 1u);
+    EXPECT_EQ(memcmp(destinations[0].data(), MockDevice::BROADCAST_MAC, 6), 0);
 }
 
 inline void bracketAckClearsPendingForThatPeer(ShootoutManagerTests* suite) {
@@ -867,4 +877,148 @@ inline void shootoutBracketRevealDebouncesTransientLoopBreak(ShootoutManagerTest
     state.onStateLoop(nullptr);
     EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::ABORTED);
     EXPECT_TRUE(state.transitionToAborted());
+}
+
+// The ESP-NOW peer table holds 20 entries, so a unicast fan-out cannot address a
+// larger ring at all. One broadcast frame reaches every member regardless of
+// ring size, while each member still owes its own unicast ack.
+inline void bracketFanOutIsOneFrameBeyondPeerTable(ShootoutManagerTests* suite) {
+    constexpr size_t RING_SIZE = 30;
+    uint8_t selfMac[6] = {0x01, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+
+    std::vector<std::array<uint8_t, 6>> members;
+    for (size_t i = 0; i < RING_SIZE; i++) {
+        members.push_back({static_cast<uint8_t>(0x01 + i), 0, 0, 0, 0, 0});
+    }
+    suite->shootout->setLoopMembersForTest(members);
+
+    std::vector<std::array<uint8_t, 6>> destinations;
+    ON_CALL(*suite->device.mockPeerComms,
+            sendData(testing::_, PktType::kShootoutCommand, testing::_, testing::_))
+        .WillByDefault(testing::Invoke(
+            [&destinations](const uint8_t* dst, PktType, const uint8_t*, const size_t) {
+                std::array<uint8_t, 6> mac{};
+                memcpy(mac.data(), dst, 6);
+                destinations.push_back(mac);
+                return 1;
+            }));
+
+    suite->shootout->startProposal();
+    for (auto& m : members)
+        suite->shootout->onConfirmReceived(m.data());
+
+    ASSERT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::BRACKET_REVEAL);
+    EXPECT_EQ(suite->shootout->getBracket().size(), RING_SIZE);
+    EXPECT_EQ(suite->shootout->getBracketPendingAckCount(), RING_SIZE - 1);
+    ASSERT_EQ(destinations.size(), 1u);
+    EXPECT_EQ(memcmp(destinations[0].data(), MockDevice::BROADCAST_MAC, 6), 0);
+}
+
+// A retry round is one frame for every member still owing an ack, not one frame
+// each: per-peer retries would spend a peer-table slot per member.
+inline void bracketRetryIsOneFramePerRound(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x01, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+    std::vector<std::array<uint8_t, 6>> members = {
+        {0x01, 0, 0, 0, 0, 0}, {0x02, 0, 0, 0, 0, 0}, {0x03, 0, 0, 0, 0, 0}, {0x04, 0, 0, 0, 0, 0}};
+    suite->shootout->setLoopMembersForTest(members);
+    ON_CALL(*suite->device.mockPeerComms,
+            sendData(testing::_, testing::_, testing::_, testing::_))
+        .WillByDefault(testing::Return(1));
+
+    suite->shootout->startProposal();
+    for (auto& m : members)
+        suite->shootout->onConfirmReceived(m.data());
+    ASSERT_EQ(suite->shootout->getBracketPendingAckCount(), 3u);
+
+    int sends = 0;
+    ON_CALL(*suite->device.mockPeerComms,
+            sendData(testing::_, PktType::kShootoutCommand, testing::_, testing::_))
+        .WillByDefault(testing::Invoke(
+            [&sends](const uint8_t*, PktType, const uint8_t*, const size_t) {
+                sends++;
+                return 1;
+            }));
+
+    // First backoff is ackTimeoutForRetry(0) = 100ms and every pending entry was
+    // armed together, so one round covers all three.
+    suite->fakeClock->advance(150);
+    suite->shootout->sync();
+    EXPECT_EQ(sends, 1);
+    EXPECT_EQ(suite->shootout->getBracketPendingAckCount(), 3u);
+}
+
+// Rings share the radio channel, so a broadcast bracket lands on devices that
+// are not in it. A device absent from the roster must neither adopt it nor ack
+// it — an ack would enrol it in a neighbouring ring's tournament.
+inline void foreignBracketIsNeitherAdoptedNorAcked(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x0A, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+    ON_CALL(*suite->device.mockPeerComms,
+            sendData(testing::_, testing::_, testing::_, testing::_))
+        .WillByDefault(testing::Return(1));
+    suite->shootout->setLoopMembersForTest({{0x0A, 0, 0, 0, 0, 0}, {0x0B, 0, 0, 0, 0, 0}});
+    suite->shootout->startProposal();
+
+    EXPECT_CALL(*suite->device.mockPeerComms,
+                sendData(testing::_, PktType::kShootoutCommandAck, testing::_, testing::_))
+        .Times(0);
+
+    suite->shootout->onBracketReceived({{0x01, 0, 0, 0, 0, 0},
+                                        {0x02, 0, 0, 0, 0, 0},
+                                        {0x03, 0, 0, 0, 0, 0}},
+                                       1);
+    EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::PROPOSAL);
+    EXPECT_TRUE(suite->shootout->getBracket().empty());
+}
+
+// Every other shootout command is broadcast too, so each must ignore a sender or
+// a named MAC from outside this device's ring. Without this a neighbouring ring
+// could start matches in, or abort, a tournament it has no part in.
+inline void strayRingCommandsLeaveTournamentUntouched(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x02, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> me = {0x02, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> coord = {0x01, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> other = {0x03, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> alienA = {0xA1, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> alienB = {0xA2, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+    ON_CALL(*suite->device.mockPeerComms,
+            sendData(testing::_, testing::_, testing::_, testing::_))
+        .WillByDefault(testing::Return(1));
+
+    suite->shootout->setLoopMembersForTest({coord, me, other});
+    suite->shootout->startProposal();
+    for (auto& m : {coord, me, other})
+        suite->shootout->onConfirmReceived(m.data());
+    suite->shootout->onBracketReceived({me, other, coord}, 1);
+    suite->shootout->onMatchStartReceived(me.data(), other.data(), 0, 2);
+    ASSERT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::MATCH_IN_PROGRESS);
+    ASSERT_EQ(suite->shootout->getCurrentMatchIndex(), 0);
+
+    suite->shootout->onMatchStartReceived(alienA.data(), alienB.data(), 5, 3);
+    EXPECT_EQ(suite->shootout->getCurrentMatchIndex(), 0);
+    EXPECT_TRUE(suite->shootout->isLocalDuelist());
+
+    suite->shootout->onMatchResultReceived(alienA.data(), alienB.data(), 5, 4, alienA.data());
+    EXPECT_FALSE(suite->shootout->isEliminated(alienB.data()));
+    EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::MATCH_IN_PROGRESS);
+
+    suite->shootout->onPeerLostReceived(alienA.data());
+    EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::MATCH_IN_PROGRESS);
+
+    suite->shootout->onTournamentEndReceived(alienA.data(), 5);
+    EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::MATCH_IN_PROGRESS);
+
+    suite->shootout->onAbortReceived(alienA.data());
+    EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::MATCH_IN_PROGRESS);
+
+    // A ring member's ABORT still lands.
+    suite->shootout->onAbortReceived(coord.data());
+    EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::ABORTED);
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1775,6 +1775,10 @@ TEST_F(ShootoutManagerTests, isHunterRestoredAfterTournament) { isHunterRestored
 TEST_F(ShootoutManagerTests, localRDCDisconnectIsIdempotent) { localRDCDisconnectIsIdempotent(this); }
 TEST_F(ShootoutManagerTests, shootoutProposalDebouncesTransientLoopBreak) { shootoutProposalDebouncesTransientLoopBreak(this); }
 TEST_F(ShootoutManagerTests, shootoutBracketRevealDebouncesTransientLoopBreak) { shootoutBracketRevealDebouncesTransientLoopBreak(this); }
+TEST_F(ShootoutManagerTests, bracketFanOutIsOneFrameBeyondPeerTable) { bracketFanOutIsOneFrameBeyondPeerTable(this); }
+TEST_F(ShootoutManagerTests, bracketRetryIsOneFramePerRound) { bracketRetryIsOneFramePerRound(this); }
+TEST_F(ShootoutManagerTests, foreignBracketIsNeitherAdoptedNorAcked) { foreignBracketIsNeitherAdoptedNorAcked(this); }
+TEST_F(ShootoutManagerTests, strayRingCommandsLeaveTournamentUntouched) { strayRingCommandsLeaveTournamentUntouched(this); }
 
 // ============================================
 // MAIN

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1478,6 +1478,15 @@ TEST_F(RDCHelloTests, fullRosterEvictsStaleThenAdmits) {
 TEST_F(RDCHelloTests, duplicateReannounceDoesNotEvict) {
     rdcDuplicateReannounceDoesNotEvict(this);
 }
+TEST_F(RDCHelloTests, rosterHoldsFullEventChain) {
+    rdcRosterHoldsFullEventChain(this);
+}
+TEST_F(RDCHelloTests, announceOverCapIsDroppedNotAdmitted) {
+    rdcAnnounceOverCapIsDroppedNotAdmitted(this);
+}
+TEST_F(RDCHelloTests, headTransferCarriesFullCapRoster) {
+    rdcHeadTransferCarriesFullCapRoster(this);
+}
 TEST_F(RDCHelloTests, staleTransferDoesNotReforkClaimedUpstream) {
     rdcStaleTransferDoesNotReforkClaimedUpstream(this);
 }


### PR DESCRIPTION
Steps 1-3 of #218, plus the serial parser resync the baud step turns out to
depend on. No timing constant changes in this PR.

## Broadcast bracket

The shootout ring fan-out was one unicast per member. The ESP-NOW peer table holds
20 entries, so a ring wider than that could not be addressed at all. `sendToPeers`
now emits one broadcast frame (the broadcast peer is registered once at radio init),
and the retry path emits one frame per round instead of one per pending peer. Acks
stay unicast, one per member, and per-member pending-ack tracking is unchanged.
This supersedes the parked LRU peer-table eviction patch.

I widened this past the bracket itself. All five ring fan-outs — CONFIRM, BRACKET,
MATCH_START, MATCH_RESULT, TOURNAMENT_END, plus PEER_LOST/ABORT — already route
through `sendToPeers`/`sendReliablyToPeers`, so broadcasting there is a smaller
change than special-casing BRACKET, and special-casing BRACKET would leave the
identical peer-table wall at MATCH_START one packet later.

The fragile part is the consequence, not the send. A broadcast lands on every ring
in radio range, so each receive handler now has to reject another tournament's
commands — that filtering used to come free from the destination MAC:

- BRACKET: our own MAC must be in the offered roster. Rejected before the ack, or a
  neighbouring coordinator counts us as one of its members.
- MATCH_START / MATCH_RESULT / TOURNAMENT_END: the MACs they name must be in our
  bracket. MATCH_RESULT's ack moved after this check.
- PEER_LOST: the named MAC must be a ring member.
- ABORT: carries no MACs, so `onAbortReceived` now takes `fromMac`. Without it a
  neighbouring ring's abort tears down every tournament in range.

Two places to look hard at. First, MATCH_RESULT and TOURNAMENT_END gate on
`bracket`, so one arriving ahead of BRACKET is now dropped and re-sent rather than
applied against an empty bracket — the retry budget (3 rounds, 100/200/400 ms)
against the 5 s BRACKET_REVEAL window is what makes that safe. Second, a locally
observed jack loss keeps its old unfiltered path (`applyPeerLoss`); only the remote
PEER_LOST is filtered, because during PROPOSAL a not-yet-confirmed peer is in
neither `confirmedSet` nor an already-broken loop set.

The first commit is a mechanical rename with no behaviour change. `check_style.py`
flags any added line carrying a legacy trailing-underscore member, so touching
shootout-manager at all forced it; separating it keeps the second commit readable.

## Roster cap

MAX_CHAIN_MEMBERS 18 → 64. The 18 came from fitting HeadTransferPayload into one
v1 250-byte frame, but the thing that actually bound the payload was
`DataPktHdr::pktLen` being uint8_t. It is uint16_t now, and MAX_PKT_DATA_SIZE
derives from ESP_NOW_MAX_DATA_LEN_V2 (1470) instead of the length field. A
64-member HeadTransfer is 770 bytes, a 64-member bracket 387. `kMaxBracketSize`
became `MAX_BRACKET_SIZE = MAX_CHAIN_MEMBERS`; left at 32 it would have rejected a
large ring's BRACKET at parse.

Overflow contract — named, not fixed. Past the cap the head drops the announce and
the member cannot learn that: SEND_SUCCESS on the announce is the only delivery
signal the no-ack design has, and the radio acks a frame the head then discards, so
the member's HELLO confirmed bit rises while it is absent from the roster. Closing
that needs an admission reply the no-ack decision excludes. So: the cap now sits
past any real chain, the drop logs at error level naming the consequence, and
`announceOverCapIsDroppedNotAdmitted` pins the head-side half (the member-side bit
is not observable from the head). The head-transfer overflow is a different case and
self-heals — the head change that triggers the transfer clears each member's
confirmed bit and makes it re-announce.

## Receive-side pktLen check

Widening `pktLen` also widened what a wrong value can ask for. It comes off the
wire, it is what bounds the copy handed to the packet handlers, and nothing
compared it against what the radio actually delivered. The recv callback now
drops a frame whose declared length disagrees with `data_len`, or that claims to
be shorter than the header. That second case underflowed `handleSinglePacket`'s
length subtraction to roughly SIZE_MAX. `sendData` is the only writer and sets
the two equal, so nothing legitimate is rejected.

## Parser resync after a CRC failure

Worth reading before the baud discussion below, because it invalidates the
premise the issue raises the rate on. #218 assumes 115200 buys a higher drop rate
at unchanged integrity. That only holds if a dropped byte costs one frame, and it
did not. On a CRC mismatch `SerialFrameParser` reset to scan-for-sync and threw
away every byte it had consumed. A truncated frame keeps reading into the next
frame's bytes, fails CRC on those, and takes the good HELLO behind it down with
it. Two frames per drop.

The mid-frame timeout cannot rescue that. The ESP32 driver drains the whole RX
FIFO in one `while (Serial1.available() > 0)` loop and hands each byte straight
to the parser, so the short frame and the good one behind it can arrive with no
gap at all. At a 20 ms cadence against a 100 ms silent-link timeout that is a
real bite out of the margin, taken exactly when the drop rate rises.

The parser now replays the buffered payload plus the CRC bytes back through
scan-for-sync instead of discarding them, so an embedded 0xAA 0x55 restarts
framing at the true frame start. The disproven preamble and opcode are not
replayed, which is also what bounds the re-entry: the replay is 16 bytes and a
whole frame is 19, so it can never reach a second CRC comparison. A trailing lone
0xAA leaves the parser in GOT_AA and pairs with whatever byte arrives next, which
is the common shape when the byte that went missing was mid-payload.

`midFrameTimeoutResets` advances 60 ms, a gap the 20 ms cadence never produces,
so it never covered any of this. The two new tests advance one cadence: a
truncated frame then a good one, and a frame with a payload byte dropped then a
good one. Both expect exactly one decode and both fail if the replay is removed.

## BAUDRATE type

uint16_t → uint32_t. 115200 wrapped to 49664 in 16 bits, which would have silently
configured the UART for a different speed. Live and latent independently of whether
the rate changes. A `static_assert` now fails the build if the type narrows again.

## Deferred to the hardware sweep (step 4 — not done here)

Three values are deliberately unchanged. Each is a timing constant on
hardware-proven code and each needs bench evidence this run cannot produce. The
parser resync is a prerequisite for that sweep rather than a part of it: run the
sweep without it and every dropped byte reads as two lost HELLOs, which lands on
the TRS contacts in the results instead of on the parser.

- **BAUDRATE 19200 → 115200.** A framed HELLO is 19 bytes (2 preamble + 1 opcode +
  14 payload + 2 CRC). At 19200 8N1 that is 190 bits / 19200 = **9.9 ms**; at 115200
  it is **1.65 ms**. Hop propagation stops being frame-bound and becomes
  cadence-bound. Needs TRS-contact reliability at 115200 measured, not assumed.
- **HELLO_CADENCE_MS 20.** At 115200 a hop costs cadence + 1.65 ms, so a 10 ms
  cadence puts a hop at ~11.65 ms.
- **RING_EVIDENCE_TIMEOUT_MS 500.** Today 500 / (20 + 9.9) ≈ **16 hops**, which is
  what its comment claims. At a 10 ms cadence and 1.65 ms frame time,
  500 / 11.65 ≈ **43 hops** — the same 500 ms already covers a 64-device ring, so
  this one likely needs no change at all. Whichever cadence is picked,
  HELLO_SILENT_LINK_MS must stay several cadences (100 ms is 5 × 20 ms today; a
  10 ms cadence wants ~50 ms, not less).

The sweep they wait on: TRS contacts at 115200, long-chain head propagation, a
big-ring close, and one full broadcast-bracket round. **Steps 1-3 are done. Step 4
is not.**

Two ceilings also stay put, because they are peer-table pressure rather than framing
and lowering that pressure wants the same hardware run: `kMaxChainPeersPerPort` is
18 per port (each daisy-chained peer takes an ESP-NOW slot via
`RemoteDeviceCoordinator::registerPeer`), and the shootout's loop-member set — the
set the bracket is built from — is still assembled from those per-port lists. A
64-member head roster is now representable; a 64-device *ring* is not yet reachable
through discovery.

Closes #218
