### PR TITLE
rdc: wire public API — peer identity, chain-role edges, gated head adoption

### DIFF
--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -72,11 +72,22 @@ public:
         context->peerMac = {};
     }
 
-    void arm() { transitionToConnectingState = true; }
+    /// The armed peer is published on the way out, not when it arrives: the
+    /// jack is down for as long as this state is current, and peer() promises
+    /// all-zero there. Dismount runs before Connecting mounts, so the peer is in
+    /// place for the context request that mount fires.
+    void onStateDismounted(Device*) override { context->peerMac = armedPeer; }
+
+    /// Opens the link on the next tick, with `source` as the peer it tracks.
+    void arm(const uint8_t* source) {
+        memcpy(armedPeer.data(), source, 6);
+        transitionToConnectingState = true;
+    }
     bool transitionToConnecting() { return transitionToConnectingState; }
 
 private:
     HelloLinkContext* context = nullptr;
+    std::array<uint8_t, 6> armedPeer{};
     bool transitionToConnectingState = false;
 };
 
@@ -170,9 +181,11 @@ public:
             skipToState(nullptr, 0);
         }
         context.lastHelloMs = context.nowMs();
-        memcpy(context.peerMac.data(), hello.source, 6);
+        // A live link past the guard above already tracks this source, so the peer
+        // identity only ever changes here: Idle takes it and publishes it as it
+        // dismounts into Connecting.
         if (currentState && currentState->getStateId() == HELLO_LINK_IDLE) {
-            static_cast<HelloIdleState*>(currentState)->arm();
+            static_cast<HelloIdleState*>(currentState)->arm(hello.source);
         }
     }
 

--- a/lib/core/include/device/hello-link-machine.hpp
+++ b/lib/core/include/device/hello-link-machine.hpp
@@ -42,7 +42,7 @@ struct HelloLinkContext {
     unsigned long contextTimeoutMs = 500;
 
     unsigned long lastHelloMs = 0;
-    std::array<uint8_t, 6> peerMac{};  // source MAC last heard; consumed by #157
+    std::array<uint8_t, 6> peerMac{};  // source MAC last heard; the owner's per-jack peer identity
 
     // Silent-link gap with a defensive underflow clamp: HELLO processing is
     // main-loop-only today, but any backwards step between stamp and read (a
@@ -176,7 +176,7 @@ public:
         }
     }
 
-    // #157 drives this when the context exchange completes; only meaningful while
+    // Driven when the context exchange completes; only meaningful while
     // Connecting (mirrors the enum's state guard).
     void onContextExchangeComplete() {
         if (currentState && currentState->getStateId() == HELLO_LINK_CONNECTING) {

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -107,7 +107,9 @@ public:
 
     /// The direct peer's 4-digit player id for the given port, lifted from the
     /// PlayerProfile its context exchange delivered; PEER_USER_ID_NONE until then.
+    /// Gated on getPeerMac so the two never disagree about the port having a peer.
     virtual uint16_t getPeerUserId(SerialIdentifier port) const {
+        if (getPeerMac(port) == nullptr) return PEER_USER_ID_NONE;
         return helloByPort[portIndex(port)].peerUserId;
     }
 

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -153,7 +153,7 @@ public:
 
     static constexpr unsigned long HELLO_CADENCE_MS = 20;
     static constexpr unsigned long HELLO_SILENT_LINK_MS = 100;
-    // A link stuck mid-context-exchange past this falls back to IDLE (#157).
+    // A link stuck mid-context-exchange past this falls back to IDLE.
     static constexpr unsigned long CONTEXT_EXCHANGE_TIMEOUT_MS = 500;
     // A ring latch is evidence-based: it survives a higher-MAC head claim only
     // while this device's own MAC keeps returning on INPUT within this window.
@@ -226,8 +226,8 @@ public:
     void connectivityTaskBody();
 #endif
 
-    /// #157 drives this once the context exchange completes: CONNECTING->CONNECTED
-    /// and fires the jack-connect observer.
+    /// Driven by a completed context exchange: CONNECTING->CONNECTED, whose mount
+    /// fires the jack-connect observer.
     void onContextExchangeComplete(SerialIdentifier jack);
 
     /// This jack's HELLO link state (observability / tests).
@@ -461,8 +461,8 @@ private:
 
     // ---- Device-level chain state machine (#156) ----
     // headMac (48 bits) + a confirmed bit packed into one atomic: the emit task
-    // reads it while the main loop writes it. confirmed is wired but always 0
-    // until #157's context exchange populates it.
+    // reads it while the main loop writes it. The confirmed bit rises only when the
+    // announce to the head currently held is delivered.
     static constexpr uint64_t HEAD_MAC_MASK = 0xFFFFFFFFFFFFULL;
     static constexpr uint64_t CONFIRMED_BIT = 1ULL << 48;
     std::atomic<uint64_t> chainHeadState{0};

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -91,8 +91,13 @@ public:
     /// Status plus the peer MACs reachable via the port.
     PortState getPortState(SerialIdentifier port);
 
+    /// No peer id known: an FDN peer, an unregistered player, or no peer at all.
+    static constexpr uint16_t PEER_USER_ID_NONE = 0xFFFF;
+
     /**
-     * Returns a pointer to the peer's MAC address for the given port, or nullptr if no peer is connected.
+     * Returns a pointer to the port's direct peer MAC address, or nullptr when the
+     * port tracks no peer. Known from the first HELLO, so it is served from
+     * CONNECTING onward, not only once CONNECTED.
      * Prefer this over getPortState() when only the MAC address is needed.
      */
     virtual const uint8_t* getPeerMac(SerialIdentifier port) const;
@@ -100,10 +105,11 @@ public:
     /// The direct peer's hardware kind (PDN/FDN) for the given port.
     virtual DeviceType getPeerDeviceType(SerialIdentifier port) const;
 
-    /// The direct peer's 4-digit player id for the given port; 0xFFFF when
-    /// unregistered or no peer. STUB until the context exchange lands (#157):
-    /// always 0xFFFF.
-    virtual uint16_t getPeerUserId(SerialIdentifier port) const { return 0xFFFF; }
+    /// The direct peer's 4-digit player id for the given port, lifted from the
+    /// PlayerProfile its context exchange delivered; PEER_USER_ID_NONE until then.
+    virtual uint16_t getPeerUserId(SerialIdentifier port) const {
+        return helloByPort[portIndex(port)].peerUserId;
+    }
 
     /// Returns true iff `mac` matches the direct peer on either jack.
     virtual bool isDirectPeer(const uint8_t* mac) const;
@@ -361,6 +367,9 @@ private:
         DeviceType peerDeviceType = DeviceType::UNKNOWN;
         std::array<uint8_t, MAX_PEER_PROFILE_BYTES> peerProfile{};
         size_t peerProfileLen = 0;
+        // The only PlayerProfile field lifted onto the port surface; the rest of
+        // the profile stays opaque and reaches the game layer as raw bytes.
+        uint16_t peerUserId = PEER_USER_ID_NONE;
         // Last recovery resend to this jack's peer (0 = never); throttles the
         // CONNECTED-state resend so two CONNECTED sides can't volley at radio RTT.
         unsigned long lastContextResendMs = 0;

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -369,8 +369,8 @@ private:
         DeviceType peerDeviceType = DeviceType::UNKNOWN;
         std::array<uint8_t, MAX_PEER_PROFILE_BYTES> peerProfile{};
         size_t peerProfileLen = 0;
-        // The only PlayerProfile field lifted onto the port surface; the rest of
-        // the profile stays opaque and reaches the game layer as raw bytes.
+        // The only profile field lifted onto the port surface; the profile itself
+        // stays opaque and reaches the game layer as raw bytes.
         uint16_t peerUserId = PEER_USER_ID_NONE;
         // Last recovery resend to this jack's peer (0 = never); throttles the
         // CONNECTED-state resend so two CONNECTED sides can't volley at radio RTT.
@@ -409,6 +409,7 @@ private:
         std::array<uint8_t, 6> mac{};
         DeviceType peerType = DeviceType::UNKNOWN;
         uint8_t chainRole = 0;
+        uint16_t peerUserId = PEER_USER_ID_NONE;
         std::array<uint8_t, MAX_PEER_PROFILE_BYTES> profile{};
         size_t len = 0;
         unsigned long arrivedAtMs = 0;
@@ -426,18 +427,18 @@ private:
     // Serialize + reliably send this device's context to `mac` per selfDeviceType.
     void sendSelfContext(const uint8_t* mac);
     // Cache a received peer context by MAC, then apply it to jacks (rationale in .cpp).
-    void onContextReceived(const uint8_t* fromMac, DeviceType peerType,
-                           uint8_t chainRole, const uint8_t* profile, size_t len);
+    void onContextReceived(const uint8_t* fromMac, DeviceType peerType, uint8_t chainRole,
+                           uint16_t peerUserId, const uint8_t* profile, size_t len);
     // Completes every jack currently CONNECTING to `fromMac` (live receive path).
-    void applyContextToJacks(const uint8_t* fromMac, DeviceType peerType,
-                             uint8_t chainRole, const uint8_t* profile, size_t len);
+    void applyContextToJacks(const uint8_t* fromMac, DeviceType peerType, uint8_t chainRole,
+                             uint16_t peerUserId, const uint8_t* profile, size_t len);
     // Assumes `jack` is CONNECTING to this peer; both timing paths route through here,
     // so the context callback fires exactly once per jack.
     void completeJackContext(SerialIdentifier jack, DeviceType peerType, uint8_t chainRole,
-                             const uint8_t* profile, size_t len);
+                             uint16_t peerUserId, const uint8_t* profile, size_t len);
     // Holds a context whose jack is not yet CONNECTING; evicts oldest when full.
     void bufferContext(const uint8_t* fromMac, DeviceType peerType, uint8_t chainRole,
-                       const uint8_t* profile, size_t len);
+                       uint16_t peerUserId, const uint8_t* profile, size_t len);
     // Applies any cached context for `jack`'s peer to `jack` as it connects. Leaves
     // the cache entry for the peer's other jack (2-node ring); the TTL clears it.
     void drainBufferedContext(SerialIdentifier jack, const uint8_t* mac);

--- a/lib/core/include/device/remote-device-coordinator.hpp
+++ b/lib/core/include/device/remote-device-coordinator.hpp
@@ -133,8 +133,9 @@ public:
     /// Head-only chain member roster; empty for a child or standalone device.
     virtual std::vector<std::array<uint8_t, 6>> getChainMembers() const;
 
-    /// Registers the per-jack connect/disconnect observer. The disconnect fires
-    /// before chain-state teardown, so handlers must not read chain state here;
+    /// Registers the per-jack connect/disconnect observer. The connect fires
+    /// after the chain state it implies is in place; the disconnect fires BEFORE
+    /// chain-state teardown, so handlers must not read chain state there —
     /// consistent chain facts arrive via setOnChainRoleChange.
     void setOnJackChange(JackChangeCallback callback) {
         jackChangeCallback = std::move(callback);
@@ -479,10 +480,19 @@ private:
     mutable std::array<uint8_t, 6> headMacScratch{};
     // Last role reported to chainRoleChangeCallback, for edge-triggered firing.
     ChainRole lastChainRole = ChainRole::STANDALONE;
+    // The effective head the INPUT peer last advertised (all-zero = none), kept
+    // apart from chainHeadState: a HELLO can advertise a head long before the
+    // link carrying it is established, and only the latter may be acted on.
+    std::array<uint8_t, 6> upstreamAdvertisedHead{};
 
     static uint64_t packHead(const uint8_t* mac, bool confirmed);
     static void unpackMac(uint64_t value, uint8_t* out);
+    // Ring detection and the latched-head conflict, driven by any INPUT HELLO;
+    // taking on a foreign head is left to adoptUpstreamHead.
     void applyUpstreamHead(const HelloPayload& hello);
+    // Adopts upstreamAdvertisedHead once the INPUT link reports CONNECTED: claims
+    // the head's radio slot, hands over the roster, announces. No-op before that.
+    void adoptUpstreamHead();
     void onLinkLost(SerialIdentifier port);
     void maybeFireChainRoleChange();
     // Drops a former head's radio slot (and its dead roster retries) unless an

--- a/lib/core/include/wireless/direct-peer-table.hpp
+++ b/lib/core/include/wireless/direct-peer-table.hpp
@@ -15,7 +15,6 @@ struct DirectPeer {
     std::array<uint8_t, 6> macAddr;
     SerialIdentifier sid;
     DeviceType deviceType;
-    uint16_t userId = 0xFFFF;  // 4-digit player code; 0xFFFF = not yet registered
 };
 
 // Tracks the direct cable peer on each jack and owns the ESP-NOW peer slot

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -290,6 +290,12 @@ void RemoteDeviceCoordinator::sync(Device* PDN) {
             HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
             if (machine) machine->onStateLoop(PDN);
         }
+        // Edge-trigger the role observer here, after the links have settled, rather
+        // than at each site that can move the role: a link commits to CONNECTED in
+        // the loop above, dies through the Idle mount inside it, and latches a ring
+        // during HELLO parsing between ticks. Polling the derived role once per tick
+        // catches all three; per-site firing drops whichever site is forgotten.
+        maybeFireChainRoleChange();
         return;
     }
 
@@ -548,6 +554,19 @@ PortStatus RemoteDeviceCoordinator::mapHandshakeStateToStatus(SerialIdentifier p
 }
 
 const uint8_t* RemoteDeviceCoordinator::getPeerMac(SerialIdentifier port) const {
+    // Same split as getPortStatus: under HELLO the peer identity lives on the
+    // per-jack link machine, and the quiesced handshake's peer table is never
+    // populated, so reading it there would report every jack as peerless.
+    if (isHelloJack(port)) {
+        const HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
+        // An Idle jack has no peer. It can already hold the MAC that arms next
+        // tick's commit to Connecting, and serving that would contradict the same
+        // jack reporting DISCONNECTED.
+        if (machine == nullptr || machine->currentStateId() == HELLO_LINK_IDLE) {
+            return nullptr;
+        }
+        return machine->peer().data();
+    }
     const Peer* peer = handshakeWirelessManager.getMacPeer(port);
     return peer ? peer->macAddr.data() : nullptr;
 }
@@ -755,7 +774,6 @@ void RemoteDeviceCoordinator::onHelloReceived(SerialIdentifier jack, const Hello
     if (jack == SerialIdentifier::INPUT_JACK) {
         applyUpstreamHead(hello);
     }
-    maybeFireChainRoleChange();
 }
 
 void RemoteDeviceCoordinator::initiateContextExchange(SerialIdentifier jack) {
@@ -875,6 +893,12 @@ void RemoteDeviceCoordinator::completeJackContext(SerialIdentifier jack, DeviceT
     // is not exactly sizeof(P), so both callers pass a compile-time size that fits.
     link.peerProfileLen = std::min(len, link.peerProfile.size());
     memcpy(link.peerProfile.data(), profile, link.peerProfileLen);
+    // Lift the peer's userId onto the port and nothing else: PlayerProfile leads
+    // with it, and an FDN profile carries no id at all. memcpy because the bytes
+    // arrive from a packed struct / byte buffer with no alignment guarantee.
+    if (peerType == DeviceType::PDN && link.peerProfileLen >= sizeof(link.peerUserId)) {
+        memcpy(&link.peerUserId, link.peerProfile.data(), sizeof(link.peerUserId));
+    }
     if (contextReceivedCallback) contextReceivedCallback(jack, peerType, profile, len);
     onContextExchangeComplete(jack);
     // The upstream exchange completing is the join moment: announce to the head (#158).
@@ -929,6 +953,7 @@ void RemoteDeviceCoordinator::releaseHelloPeer(SerialIdentifier jack, const uint
     // peer's chainRole during its CONNECTING window (#156 reads it then).
     helloByPort[portIndex(jack)].peerChainRole = 0;
     helloByPort[portIndex(jack)].peerDeviceType = DeviceType::UNKNOWN;
+    helloByPort[portIndex(jack)].peerUserId = PEER_USER_ID_NONE;
     helloByPort[portIndex(jack)].peerProfileLen = 0;
     // Defence in depth: the zeroed length already hides the bytes from
     // getPeerProfile, but a departed peer's identity should not sit in RAM.

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -405,10 +405,13 @@ PortStatus RemoteDeviceCoordinator::getPortStatus(SerialIdentifier port) {
 PortState RemoteDeviceCoordinator::getPortState(SerialIdentifier port) {
     std::vector<std::array<uint8_t, 6>> peerAddresses;
 
-    const Peer* macPeer = handshakeWirelessManager.getMacPeer(port);
-
-    if (macPeer != nullptr) {
-        peerAddresses.push_back(macPeer->macAddr);
+    // Composed from getPeerMac so a jack cannot report one direct peer here and a
+    // different one there; it owns the HELLO / handshake split.
+    const uint8_t* directPeer = getPeerMac(port);
+    if (directPeer != nullptr) {
+        std::array<uint8_t, 6> mac;
+        memcpy(mac.data(), directPeer, 6);
+        peerAddresses.push_back(mac);
     }
 
     const auto& daisyChained = daisyChainedByPort_[portIndex(port)];
@@ -963,9 +966,8 @@ void RemoteDeviceCoordinator::releaseHelloPeer(SerialIdentifier jack, const uint
     // link, so any other jack tracking this MAC keeps the slot alive.
     for (SerialIdentifier port : HELLO_JACKS) {
         if (port == jack) continue;
-        const HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
-        if (machine == nullptr || machine->currentStateId() == HELLO_LINK_IDLE) continue;
-        if (memcmp(machine->peer().data(), mac, 6) == 0) return;
+        const uint8_t* peer = getPeerMac(port);
+        if (peer != nullptr && memcmp(peer, mac, 6) == 0) return;
     }
     // A MAC still routed through a daisy chain keeps its slot too.
     for (const std::vector<std::array<uint8_t, 6>>& chain : daisyChainedByPort_) {
@@ -1166,9 +1168,8 @@ void RemoteDeviceCoordinator::releaseHeadPeer(uint64_t headMac48) {
     // Same keep-slot guards as releaseHelloPeer: an adjacent link or a daisy
     // record still using this MAC keeps the radio slot alive.
     for (SerialIdentifier port : HELLO_JACKS) {
-        const HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
-        if (machine == nullptr || machine->currentStateId() == HELLO_LINK_IDLE) continue;
-        if (memcmp(machine->peer().data(), mac, 6) == 0) return;
+        const uint8_t* peer = getPeerMac(port);
+        if (peer != nullptr && memcmp(peer, mac, 6) == 0) return;
     }
     for (const std::vector<std::array<uint8_t, 6>>& chain : daisyChainedByPort_) {
         for (const std::array<uint8_t, 6>& m : chain) {

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -284,17 +284,15 @@ void RemoteDeviceCoordinator::sync(Device* PDN) {
     if (helloConnectivityEnabled) {
         // The handshake is quiesced on HELLO jacks: skipping its onStateLoop is
         // what keeps it off the UART (it neither consumes RX nor writes TX). The
-        // chain-announcement machinery below rides handshake CONNECTED state, so
-        // it stays dormant here too until HELLO drives its own peer identity (#157).
+        // chain-announcement machinery below rides the handshake peer table, so it
+        // stays dormant here too.
         for (SerialIdentifier port : HELLO_JACKS) {
             HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
             if (machine) machine->onStateLoop(PDN);
         }
-        // Edge-trigger the role observer here, after the links have settled, rather
-        // than at each site that can move the role: a link commits to CONNECTED in
-        // the loop above, dies through the Idle mount inside it, and latches a ring
-        // during HELLO parsing between ticks. Polling the derived role once per tick
-        // catches all three; per-site firing drops whichever site is forgotten.
+        // Three separate sites move the derived role: a link commits to CONNECTED in
+        // the loop above, dies through the Idle mount inside it, or latches a ring
+        // during HELLO parsing between ticks. Poll once per tick to catch all three.
         maybeFireChainRoleChange();
         return;
     }
@@ -740,7 +738,8 @@ void RemoteDeviceCoordinator::emitHello() {
     hello.deviceType = static_cast<uint8_t>(selfDeviceType);
     // Single atomic load: the main loop is the sole writer, so one snapshot of the
     // packed head/confirmed word is internally consistent. All-zero headMac means
-    // "I am the head/standalone". confirmed stays 0 until #157's context exchange.
+    // "I am the head/standalone"; confirmed rises only once the announce to that
+    // head is delivered.
     const uint64_t head = chainHeadState.load();
     const uint64_t mac48 = head & HEAD_MAC_MASK;
     if (mac48 != 0) unpackMac(mac48, hello.headMac);

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -294,6 +294,9 @@ void RemoteDeviceCoordinator::sync(Device* PDN) {
         // Three separate sites move the derived role: a link commits to CONNECTED in
         // the loop above, dies through the Idle mount inside it, or latches a ring
         // during HELLO parsing between ticks. Poll once per tick to catch all three.
+        // onRingClosed keeps firing at its own decision site (it is the shootout
+        // coordinator claim point), so a ring closure and the RING role it implies
+        // can be up to one tick apart.
         maybeFireChainRoleChange();
         return;
     }
@@ -702,6 +705,10 @@ void RemoteDeviceCoordinator::enableHelloConnectivity() {
             initiateContextExchange(j);
         };
         context.onJackChange = [this](SerialIdentifier j, bool connected) {
+            // The upstream link reaching Connected is the moment its advertised
+            // head becomes adoptable, and the game layer must see the resulting
+            // chain state on the connect it is told about — so adopt first (#158).
+            if (connected && j == SerialIdentifier::INPUT_JACK) adoptUpstreamHead();
             // Copied before the call: a handler that reacts by dismounting its own
             // state clears this slot, which would destroy the std::function whose
             // operator() frame is still live.
@@ -899,8 +906,6 @@ void RemoteDeviceCoordinator::completeJackContext(SerialIdentifier jack, DeviceT
     link.peerUserId = peerUserId;
     if (contextReceivedCallback) contextReceivedCallback(jack, peerType, profile, len);
     onContextExchangeComplete(jack);
-    // The upstream exchange completing is the join moment: announce to the head (#158).
-    if (jack == SerialIdentifier::INPUT_JACK) maybeAnnounceToHead();
 }
 
 void RemoteDeviceCoordinator::bufferContext(const uint8_t* fromMac, DeviceType peerType,
@@ -1036,10 +1041,6 @@ ChainRole RemoteDeviceCoordinator::getChainRole() const {
 }
 
 const uint8_t* RemoteDeviceCoordinator::getHeadMac() const {
-    // A head adopted from a first HELLO whose link never finished connecting must
-    // not leak through the role: HEAD and STANDALONE promise "no head above us".
-    const ChainRole role = getChainRole();
-    if (role == ChainRole::HEAD || role == ChainRole::STANDALONE) return nullptr;
     const uint64_t mac48 = chainHeadState.load() & HEAD_MAC_MASK;
     if (mac48 == 0) return nullptr;
     unpackMac(mac48, headMacScratch.data());
@@ -1109,27 +1110,42 @@ void RemoteDeviceCoordinator::applyUpstreamHead(const HelloPayload& hello) {
     // encodes as an absent head_mac); the ring case above already handled it.
     if (peerHeadIsSelf) return;
 
+    // Record what the upstream claims and let the link machine decide whether it
+    // counts: a HELLO is one-way evidence, adoption is not.
+    memcpy(upstreamAdvertisedHead.data(), peerEffectiveHead, 6);
+    adoptUpstreamHead();
+}
+
+void RemoteDeviceCoordinator::adoptUpstreamHead() {
+    // The INPUT link machine is the single authority on whether an upstream is
+    // real. A one-way cable delivers its HELLOs forever while this side never
+    // establishes; adopting off those would advertise a head no downstream can
+    // reach and hand this device's roster to a peer that cannot answer.
+    if (getHelloLinkState(SerialIdentifier::INPUT_JACK) != HelloLinkState::CONNECTED) return;
+    const uint64_t newHead = MacToUInt64(upstreamAdvertisedHead.data());
+    if (newHead == 0) return;
     const uint64_t previousHead = chainHeadState.load() & HEAD_MAC_MASK;
-    if (previousHead == MacToUInt64(peerEffectiveHead)) return;
+    if (previousHead == newHead) return;
+    const uint8_t* headMac = upstreamAdvertisedHead.data();
 
     // The head is a unicast target (announce/report/transfer) that is usually
     // not an adjacent HELLO peer, so its radio slot is managed here: claim the
     // successor's before any send below, drop the predecessor's after.
-    registerPeer(peerEffectiveHead);
+    registerPeer(headMac);
     // Adopt the upstream head, dropping to confirmed=0 until re-confirmed under
     // it. The new head then propagates in our own HELLO.
-    chainHeadState.store(packHead(peerEffectiveHead, false));
+    chainHeadState.store(packHead(headMac, false));
     // A demoted head hands its roster to the successor (#158); for a plain child
     // the roster is empty and this no-ops. Then announce under the new head so
     // confirmed can rise again.
-    transferRosterTo(peerEffectiveHead);
+    transferRosterTo(headMac);
     maybeAnnounceToHead();
     // releaseHeadPeer below cancels the report channel to the old head, and
     // nothing else re-triggers a report (the announce path re-announces, the
     // report path has no equivalent), so an undelivered report must chase the
     // successor head or its member stays a phantom in that roster.
     if (MacToUInt64(pendingReportMac.data()) != 0) {
-        sendDisconnectReport(peerEffectiveHead, pendingReportMac.data());
+        sendDisconnectReport(headMac, pendingReportMac.data());
     }
     releaseHeadPeer(previousHead);
 }
@@ -1148,6 +1164,9 @@ void RemoteDeviceCoordinator::onLinkLost(SerialIdentifier port) {
     if (port == SerialIdentifier::INPUT_JACK) {
         const uint64_t lostHead = chainHeadState.load() & HEAD_MAC_MASK;
         chainHeadState.store(0);
+        // The departed peer's claim dies with it, or the next upstream to reach
+        // Connected would be adopted as whatever this one last advertised.
+        upstreamAdvertisedHead.fill(0);
         // A downstream-loss report is owed only while we remain a child under a
         // head. Becoming our own head voids it: clear the pending re-send state so
         // a later head adoption (applyUpstreamHead's successor-chase) cannot ship
@@ -1219,15 +1238,11 @@ void RemoteDeviceCoordinator::maybeAnnounceToHead() {
     // No upstream head held: this device IS its chain's head (or standalone, or a
     // latched ring, which stores no head). Nothing to announce, no self-sends.
     if (headMac48 == 0) return;
+    // The announce names the upstream neighbour, which is known because a head is
+    // only ever held while that link is Connected (adoptUpstreamHead).
     const HelloLinkMachine* upstream =
         helloByPort[portIndex(SerialIdentifier::INPUT_JACK)].machine;
     if (upstream == nullptr) return;
-    // The announce names the upstream neighbour, so it is only meaningful once
-    // the upstream exchange completed (#144 ordering: announce, then confirmed).
-    if (upstream->currentStateId() != HELLO_LINK_CONNECTED &&
-        !upstream->didMarkContextComplete()) {
-        return;
-    }
     uint8_t headMac[6];
     unpackMac(headMac48, headMac);
     ConnectionAnnouncePayload announce{};

--- a/lib/core/src/device/remote-device-coordinator.cpp
+++ b/lib/core/src/device/remote-device-coordinator.cpp
@@ -137,7 +137,7 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
     if (pdnContextChannel != nullptr) {
         pdnContextChannel->onReceive(
             [this](const uint8_t* fromMac, const PdnConnectionContext& ctx) {
-                onContextReceived(fromMac, DeviceType::PDN, ctx.chainRole,
+                onContextReceived(fromMac, DeviceType::PDN, ctx.chainRole, ctx.player.userId,
                                   reinterpret_cast<const uint8_t*>(&ctx.player),
                                   sizeof(ctx.player));
             });
@@ -147,7 +147,8 @@ void RemoteDeviceCoordinator::initialize(WirelessManager* wirelessManager, Seria
     if (fdnContextChannel != nullptr) {
         fdnContextChannel->onReceive(
             [this](const uint8_t* fromMac, const FdnConnectionContext& ctx) {
-                onContextReceived(fromMac, DeviceType::FDN, ctx.chainRole,
+                // An FDN carries no player id, so its jack reports none.
+                onContextReceived(fromMac, DeviceType::FDN, ctx.chainRole, PEER_USER_ID_NONE,
                                   reinterpret_cast<const uint8_t*>(&ctx.fdn),
                                   sizeof(ctx.fdn));
             });
@@ -823,8 +824,8 @@ bool RemoteDeviceCoordinator::isContextSendPending(const uint8_t* mac) const {
 }
 
 void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceType peerType,
-                                                uint8_t chainRole, const uint8_t* profile,
-                                                size_t len) {
+                                                uint8_t chainRole, uint16_t peerUserId,
+                                                const uint8_t* profile, size_t len) {
     // Every jack sends its own context on connecting, so receiving the peer's just
     // completes our matching jack(s); no reply in the normal exchange. Cache it keyed by MAC AND
     // apply it now: caching (not only applying) covers a jack that reaches CONNECTING
@@ -832,13 +833,13 @@ void RemoteDeviceCoordinator::onContextReceived(const uint8_t* fromMac, DeviceTy
     // (ESP-NOW vs serial) so no jack is CONNECTING yet, and in a 2-node ring the two
     // jacks facing this peer enter CONNECTING one tick apart (sync() drives them in
     // order), so the later jack must still find the context. The TTL clears the cache.
-    bufferContext(fromMac, peerType, chainRole, profile, len);
-    applyContextToJacks(fromMac, peerType, chainRole, profile, len);
+    bufferContext(fromMac, peerType, chainRole, peerUserId, profile, len);
+    applyContextToJacks(fromMac, peerType, chainRole, peerUserId, profile, len);
 }
 
 void RemoteDeviceCoordinator::applyContextToJacks(const uint8_t* fromMac, DeviceType peerType,
-                                                  uint8_t chainRole, const uint8_t* profile,
-                                                  size_t len) {
+                                                  uint8_t chainRole, uint16_t peerUserId,
+                                                  const uint8_t* profile, size_t len) {
     // Live receive path: a 2-node ring points both our jacks at the same peer with
     // both already CONNECTING, so one context completes both. The peer is already a
     // radio slot (registered when our jack initiated), so nothing to register here.
@@ -847,7 +848,7 @@ void RemoteDeviceCoordinator::applyContextToJacks(const uint8_t* fromMac, Device
         HelloLinkMachine* machine = helloByPort[portIndex(port)].machine;
         if (machine == nullptr || machine->currentStateId() != HELLO_LINK_CONNECTING) continue;
         if (memcmp(machine->peer().data(), fromMac, 6) != 0) continue;
-        completeJackContext(port, peerType, chainRole, profile, len);
+        completeJackContext(port, peerType, chainRole, peerUserId, profile, len);
         appliedToConnectingJack = true;
     }
     if (appliedToConnectingJack) return;
@@ -878,8 +879,8 @@ void RemoteDeviceCoordinator::applyContextToJacks(const uint8_t* fromMac, Device
 }
 
 void RemoteDeviceCoordinator::completeJackContext(SerialIdentifier jack, DeviceType peerType,
-                                                  uint8_t chainRole, const uint8_t* profile,
-                                                  size_t len) {
+                                                  uint8_t chainRole, uint16_t peerUserId,
+                                                  const uint8_t* profile, size_t len) {
     // A second fresh-seqId context can land before the Connecting -> Connected
     // commit while the jack still reports CONNECTING; the game callback must
     // fire exactly once per connect.
@@ -895,12 +896,7 @@ void RemoteDeviceCoordinator::completeJackContext(SerialIdentifier jack, DeviceT
     // is not exactly sizeof(P), so both callers pass a compile-time size that fits.
     link.peerProfileLen = std::min(len, link.peerProfile.size());
     memcpy(link.peerProfile.data(), profile, link.peerProfileLen);
-    // Lift the peer's userId onto the port and nothing else: PlayerProfile leads
-    // with it, and an FDN profile carries no id at all. memcpy because the bytes
-    // arrive from a packed struct / byte buffer with no alignment guarantee.
-    if (peerType == DeviceType::PDN && link.peerProfileLen >= sizeof(link.peerUserId)) {
-        memcpy(&link.peerUserId, link.peerProfile.data(), sizeof(link.peerUserId));
-    }
+    link.peerUserId = peerUserId;
     if (contextReceivedCallback) contextReceivedCallback(jack, peerType, profile, len);
     onContextExchangeComplete(jack);
     // The upstream exchange completing is the join moment: announce to the head (#158).
@@ -908,8 +904,8 @@ void RemoteDeviceCoordinator::completeJackContext(SerialIdentifier jack, DeviceT
 }
 
 void RemoteDeviceCoordinator::bufferContext(const uint8_t* fromMac, DeviceType peerType,
-                                            uint8_t chainRole, const uint8_t* profile,
-                                            size_t len) {
+                                            uint8_t chainRole, uint16_t peerUserId,
+                                            const uint8_t* profile, size_t len) {
     const unsigned long now = nowMs();
     BufferedContext* slot = nullptr;
     BufferedContext* oldest = &contextBuffer[0];
@@ -927,6 +923,7 @@ void RemoteDeviceCoordinator::bufferContext(const uint8_t* fromMac, DeviceType p
     memcpy(slot->mac.data(), fromMac, 6);
     slot->peerType = peerType;
     slot->chainRole = chainRole;
+    slot->peerUserId = peerUserId;
     slot->len = len < slot->profile.size() ? len : slot->profile.size();
     memcpy(slot->profile.data(), profile, slot->len);
     slot->arrivedAtMs = now;
@@ -945,7 +942,7 @@ void RemoteDeviceCoordinator::drainBufferedContext(SerialIdentifier jack, const 
         // Apply to THIS jack only, and leave the entry valid: the peer's other jack (a
         // 2-node ring) drains its own copy when it connects a tick later. Applying
         // per-jack keeps the context callback firing exactly once per jack. TTL clears it.
-        completeJackContext(jack, e.peerType, e.chainRole, e.profile.data(), e.len);
+        completeJackContext(jack, e.peerType, e.chainRole, e.peerUserId, e.profile.data(), e.len);
     }
 }
 

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -2255,3 +2255,148 @@ inline void rdcStaleTransferDoesNotReforkClaimedUpstream(RDCHelloTests* suite) {
     ASSERT_EQ(members.size(), 1u);
     EXPECT_EQ(0, memcmp(members[0].data(), memberY, 6));
 }
+
+// ============================================
+// Public API surface (#159)
+// ============================================
+
+// getPeerMac must read the per-jack HELLO link, not the handshake peer table the
+// HELLO path never populates: the game layer addresses its neighbour with this.
+// Served from CONNECTING (the MAC is known from the first HELLO) and cleared on
+// link death, per jack.
+inline void rdcPeerMacReadsHelloLink(RDCHelloTests* suite) {
+    const uint8_t outPeer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_EQ(suite->rdc.getPeerMac(SerialIdentifier::OUTPUT_JACK), nullptr);
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTING);
+    ASSERT_NE(suite->rdc.getPeerMac(SerialIdentifier::OUTPUT_JACK), nullptr);
+    EXPECT_EQ(0, memcmp(suite->rdc.getPeerMac(SerialIdentifier::OUTPUT_JACK), outPeer, 6));
+    EXPECT_TRUE(suite->rdc.isDirectPeer(outPeer));
+    // The other jack has its own peer, unaffected.
+    EXPECT_EQ(suite->rdc.getPeerMac(SerialIdentifier::INPUT_JACK), nullptr);
+
+    suite->rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(0, memcmp(suite->rdc.getPeerMac(SerialIdentifier::OUTPUT_JACK), outPeer, 6));
+
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(suite->rdc.getPeerMac(SerialIdentifier::OUTPUT_JACK), nullptr);
+    EXPECT_FALSE(suite->rdc.isDirectPeer(outPeer));
+}
+
+// getPeerUserId lifts the userId out of the peer's PlayerProfile — absent until
+// the context lands, present while connected, gone again on link death so the
+// next peer on the jack cannot inherit it.
+inline void rdcPeerUserIdLiftedFromContext(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(suite->rdc.getPeerUserId(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::PEER_USER_ID_NONE);
+
+    std::vector<uint8_t> ctx = pdnContextBytes(/*chainRole=*/1, /*userId=*/4242, /*seqId=*/9);
+    suite->transport()->deliverIncoming(
+        PktType::kPdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_EQ(suite->rdc.getPeerUserId(SerialIdentifier::OUTPUT_JACK), 4242);
+    // Lifted per jack, not device-wide.
+    EXPECT_EQ(suite->rdc.getPeerUserId(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::PEER_USER_ID_NONE);
+
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(suite->rdc.getPeerUserId(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::PEER_USER_ID_NONE);
+}
+
+// An FDN peer carries no player id, so its context must leave the port's id
+// absent rather than lifting the first bytes of an FdnProfile.
+inline void rdcPeerUserIdAbsentForFdnContext(RDCHelloTests* suite) {
+    const uint8_t peer[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+
+    suite->deliverHello(suite->outJack, suite->helloFrame(0xA1));
+    suite->rdc.sync(&suite->device);
+
+    FdnConnectionContext fdn{};
+    fdn.seqId = 4;
+    fdn.chainRole = 1;
+    fdn.fdn.reserved = 0x7F;
+    std::vector<uint8_t> ctx(sizeof(fdn));
+    memcpy(ctx.data(), &fdn, sizeof(fdn));
+    suite->transport()->deliverIncoming(
+        PktType::kFdnConnectionContext, peer, ctx.data(), ctx.size());
+    suite->rdc.sync(&suite->device);
+
+    ASSERT_EQ(suite->rdc.getHelloLinkState(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_EQ(suite->rdc.getPeerUserId(SerialIdentifier::OUTPUT_JACK),
+              RemoteDeviceCoordinator::PEER_USER_ID_NONE);
+}
+
+// The role observer must fire on the way DOWN as well as up. A child whose
+// upstream link dies is STANDALONE again, and the game layer only learns that
+// from this callback — a missed edge leaves it acting as a chain member forever.
+inline void rdcChainRoleChangeFiresOnConnectAndLinkDeath(RDCHelloTests* suite) {
+    std::vector<ChainRole> roles;
+    suite->rdc.setOnChainRoleChange([&](ChainRole role) { roles.push_back(role); });
+
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK, suite->helloFrame(0xA1));
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::CHILD);
+    ASSERT_EQ(roles.size(), 1u);
+    EXPECT_EQ(roles[0], ChainRole::CHILD);
+
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->rdc.sync(&suite->device);
+
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::STANDALONE);
+    ASSERT_EQ(roles.size(), 2u);
+    EXPECT_EQ(roles[1], ChainRole::STANDALONE);
+
+    // Edge-triggered: a steady role re-fires nothing.
+    suite->rdc.sync(&suite->device);
+    EXPECT_EQ(roles.size(), 2u);
+}
+
+// Ring closure reaches the role observer too (the shootout coordinator claim
+// reads getChainRole() when onRingClosed fires), and the latch opening on a
+// broken loop reports the fallback role.
+inline void rdcChainRoleChangeReportsRingLatch(RDCHelloTests* suite) {
+    std::vector<ChainRole> roles;
+    suite->rdc.setOnChainRoleChange([&](ChainRole role) { roles.push_back(role); });
+    int ringClosedCount = 0;
+    suite->rdc.setOnRingClosed([&]() { ringClosedCount++; });
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    ASSERT_EQ(roles.size(), 1u);
+    EXPECT_EQ(roles[0], ChainRole::HEAD);
+
+    // Our own MAC returns as the INPUT peer's head: the loop closed through us.
+    const uint8_t lowNeighbour[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    suite->deliverHello(suite->inJack, chainHelloFrame(lowNeighbour, suite->localMac));
+    suite->rdc.sync(&suite->device);
+    suite->rdc.onContextExchangeComplete(SerialIdentifier::INPUT_JACK);
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(ringClosedCount, 1);
+    ASSERT_EQ(roles.size(), 2u);
+    EXPECT_EQ(roles[1], ChainRole::RING);
+
+    // The OUTPUT link dies: the loop is broken and only the INPUT link remains.
+    suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_SILENT_LINK_MS + 1);
+    suite->deliverHello(suite->inJack, chainHelloFrame(lowNeighbour, suite->localMac));
+    suite->rdc.sync(&suite->device);
+    ASSERT_EQ(roles.size(), 3u);
+    EXPECT_EQ(roles[2], ChainRole::CHILD);
+}

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -2276,7 +2276,7 @@ inline void rdcPeerMacReadsHelloLink(RDCHelloTests* suite) {
     ASSERT_NE(suite->rdc.getPeerMac(SerialIdentifier::OUTPUT_JACK), nullptr);
     EXPECT_EQ(0, memcmp(suite->rdc.getPeerMac(SerialIdentifier::OUTPUT_JACK), outPeer, 6));
     EXPECT_TRUE(suite->rdc.isDirectPeer(outPeer));
-    // The other jack has its own peer, unaffected.
+    // Per-jack: the OUTPUT peer must not show up on the INPUT jack.
     EXPECT_EQ(suite->rdc.getPeerMac(SerialIdentifier::INPUT_JACK), nullptr);
 
     suite->rdc.onContextExchangeComplete(SerialIdentifier::OUTPUT_JACK);

--- a/test/test_core/rdc-hello-tests.hpp
+++ b/test/test_core/rdc-hello-tests.hpp
@@ -1593,7 +1593,7 @@ inline void rdcRingLatchedNeverAnnouncesOrReportsToSelf(RDCHelloTests* suite) {
 }
 
 // Demotion: a head that adopts a new head above it hands its roster over in a
-// single unicast and clears it locally.
+// single unicast and clears it locally — once the link to that new head is up.
 inline void rdcDemotedHeadTransfersRoster(RDCHelloTests* suite) {
     const uint8_t memberA[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
     const uint8_t memberB[6] = {0xB2, 0x02, 0x03, 0x04, 0x05, 0x06};
@@ -1614,8 +1614,10 @@ inline void rdcDemotedHeadTransfersRoster(RDCHelloTests* suite) {
     ASSERT_EQ(suite->rdc.getChainMembers().size(), 2u);
     ASSERT_EQ(membershipChanges, 2);
 
-    // A standalone head plugs in above: its HELLO makes it our effective head.
-    suite->deliverHello(suite->inJack, chainHelloFrame(newHead, nullptr));
+    // A standalone head plugs in above and its link establishes: it becomes this
+    // device's effective head.
+    connectJack(suite, suite->inJack, SerialIdentifier::INPUT_JACK,
+                chainHelloFrame(newHead, nullptr));
 
     ASSERT_EQ(transfer.count, 1);
     EXPECT_EQ(0, memcmp(transfer.lastDst.data(), newHead, 6));
@@ -2399,4 +2401,49 @@ inline void rdcChainRoleChangeReportsRingLatch(RDCHelloTests* suite) {
     suite->rdc.sync(&suite->device);
     ASSERT_EQ(roles.size(), 3u);
     EXPECT_EQ(roles[2], ChainRole::CHILD);
+}
+
+// A one-way cable: the upstream's HELLOs arrive but this device's own side of the
+// exchange never completes, so its link cycles Connecting -> Idle forever. That
+// upstream is unproven, and a head with a roster must not act on it — no head
+// advertised downstream, no roster shipped to a peer that cannot answer.
+inline void rdcUnprovenUpstreamIsNeverAdopted(RDCHelloTests* suite) {
+    const uint8_t deafUpstream[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    const uint8_t member[6] = {0xA1, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).Times(testing::AnyNumber());
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_)).Times(testing::AnyNumber());
+    RosterSendCapture transfer;
+    captureSends(suite, PktType::kHeadTransfer, transfer);
+
+    connectJack(suite, suite->outJack, SerialIdentifier::OUTPUT_JACK, suite->helloFrame(0xB1));
+    std::vector<uint8_t> join = announceBytes(suite->localMac, 1);
+    suite->transport()->deliverIncoming(PktType::kConnectionAnnounce, member,
+                                        join.data(), join.size());
+    ASSERT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+    ASSERT_EQ(suite->rdc.getChainMembers().size(), 1u);
+
+    // Past two full context-exchange timeouts, so the INPUT link has cycled back
+    // to Idle and re-armed more than once.
+    unsigned long elapsed = 0;
+    while (elapsed <= 2 * RemoteDeviceCoordinator::CONTEXT_EXCHANGE_TIMEOUT_MS) {
+        suite->deliverHello(suite->inJack, chainHelloFrame(deafUpstream, nullptr));
+        suite->deliverHello(suite->outJack, suite->helloFrame(0xB1));
+        suite->rdc.sync(&suite->device);
+        suite->fakeClock->advance(RemoteDeviceCoordinator::HELLO_CADENCE_MS);
+        elapsed += RemoteDeviceCoordinator::HELLO_CADENCE_MS;
+    }
+
+    EXPECT_NE(suite->rdc.getHelloLinkState(SerialIdentifier::INPUT_JACK),
+              RemoteDeviceCoordinator::HelloLinkState::CONNECTED);
+    EXPECT_EQ(suite->rdc.getChainRole(), ChainRole::HEAD);
+    EXPECT_EQ(suite->rdc.getChainMembers().size(), 1u);
+    EXPECT_EQ(suite->rdc.getHeadMac(), nullptr);
+    EXPECT_EQ(transfer.count, 0);
+
+    // Nothing downstream may be told to route to that peer either.
+    suite->outJack.clearOutput();
+    suite->rdc.emitHello();
+    const uint8_t zero[6] = {0, 0, 0, 0, 0, 0};
+    EXPECT_EQ(0, memcmp(parseEmittedHello(suite->outJack.getOutput()).headMac, zero, 6));
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1550,6 +1550,26 @@ TEST_F(RDCHelloTests, chainRingYieldsToHigherHeadAfterEvidenceTimeout) {
 }
 
 // ============================================
+// RDC PUBLIC API SURFACE (#159)
+// ============================================
+
+TEST_F(RDCHelloTests, peerMacReadsHelloLink) {
+    rdcPeerMacReadsHelloLink(this);
+}
+TEST_F(RDCHelloTests, peerUserIdLiftedFromContext) {
+    rdcPeerUserIdLiftedFromContext(this);
+}
+TEST_F(RDCHelloTests, peerUserIdAbsentForFdnContext) {
+    rdcPeerUserIdAbsentForFdnContext(this);
+}
+TEST_F(RDCHelloTests, chainRoleChangeFiresOnConnectAndLinkDeath) {
+    rdcChainRoleChangeFiresOnConnectAndLinkDeath(this);
+}
+TEST_F(RDCHelloTests, chainRoleChangeReportsRingLatch) {
+    rdcChainRoleChangeReportsRingLatch(this);
+}
+
+// ============================================
 // CHAIN DUEL MANAGER TESTS
 // ============================================
 

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1568,6 +1568,9 @@ TEST_F(RDCHelloTests, chainRoleChangeFiresOnConnectAndLinkDeath) {
 TEST_F(RDCHelloTests, chainRoleChangeReportsRingLatch) {
     rdcChainRoleChangeReportsRingLatch(this);
 }
+TEST_F(RDCHelloTests, unprovenUpstreamIsNeverAdopted) {
+    rdcUnprovenUpstreamIsNeverAdopted(this);
+}
 
 // ============================================
 // CHAIN DUEL MANAGER TESTS


### PR DESCRIPTION
Closes #159.

Most of the surface was already real. `onJackChange` fires from the link machine, `getChainRole` / `getHeadMac` / `getChainMembers` / `getPortStatus` work, `onMembershipChange` fires at all five roster mutation sites behind `isRosterAuthority`, and `onRingClosed` fires at the ring latch. #161's five guards were each traced to a live call site and are present with coverage. What follows is what was actually missing or wrong.

## Peer identity had two sources

`getPeerMac` read only the handshake peer table, which `sync()` never populates under HELLO, so every jack reported peerless. It now mirrors the `isHelloJack` split `getPortStatus` already makes and reads the link's tracked peer, returning nullptr while the link is Idle so a jack cannot report DISCONNECTED and a peer at once.

`getPortState` was still reading the handshake table directly, which would have left one jack with two disagreeing peer identities. It now composes from `getPeerMac`, so exactly one function knows where a jack's peer lives. `releaseHelloPeer` and `releaseHeadPeer` route their keep-slot scans through it too.

`getPeerUserId` hard-returned `0xFFFF` behind a stale "#157 STUB" comment. The id is now threaded as a parameter beside `chainRole` through the context path rather than decoded out of the profile bytes by offset — the PktType already decided which struct arrived, so re-deriving it from a byte layout held together by a comment was the wrong shape. The RDC no longer reads into the profile at all. Only `userId` is lifted; the rest stays opaque.

## Chain-role edges were being dropped

`maybeFireChainRoleChange` had one call site, inside `onHelloReceived`, so every HEAD/CHILD → STANDALONE edge vanished and `lastChainRole` went stale until a new peer appeared. It is now one poll at the end of `sync()`'s HELLO branch, after the link machines settle. Per-site firing is the wrong shape here: role derives from two link states plus the ring latch, and those move in three different places — the CONNECTED commit inside the machine loop, the Idle mount teardown, and the ring latch during HELLO parsing between ticks. The base was also silently dropping the HEAD edge on connect, which the new tests catch.

`onRingClosed` deliberately still fires at its decision site rather than joining that poll. It is the shootout coordinator claim point (#169) and its timing was hardware-validated, so the two observers can disagree about whether a ring exists for at most one tick. Noted in a comment at the poll. Say if you would rather they were unified.

## Where to look: the upstream head was adopted from a link that never established

`applyUpstreamHead` ran on any INPUT HELLO with no link-state gate. It wrote the head word, claimed the ESP-NOW slot, and called `transferRosterTo`. On a faulty one-way cable that means a head with a real roster ships and clears it to an upstream that never comes up, roughly every 520ms, while still reporting STANDALONE. The three readers each compensated differently, which is how it stayed hidden: `getHeadMac` masked by role, `maybeAnnounceToHead` gated on CONNECTED, `emitHello` read the word raw.

The HELLO site now only records the peer's advertised head. A new `adoptUpstreamHead()` does the write, the slot claim, `transferRosterTo`, the announce and the report chase, and returns unless the INPUT link reports CONNECTED. It runs from a HELLO on an already-connected link and from the link's own Connected commit, adopting before the game callback so a connect handler sees consistent chain state. `onLinkLost(INPUT)` clears the recorded claim so a new upstream cannot inherit a departed peer's.

With one authority, two reader-side compensations became redundant and are gone: `getHeadMac`'s role mask and `maybeAnnounceToHead`'s gate. `emitHello`'s raw read needed no change, because the word is now only ever set for a proven upstream.

**Ring closure keeps its own pre-CONNECTED path.** Its evidence is our own MAC returning on the OUTPUT side, which does not depend on the INPUT link being established, and delaying it by a full context exchange would move the coordinator claim. The three ring-latch tests are untouched.

One existing test had its driving updated, assertions untouched: `rdcDemotedHeadTransfersRoster` demoted a head off a bare HELLO from an upstream that never established, which is literally the bug. It now connects the jack properly.

## Not done

Nothing under `src/` calls `enableHelloConnectivity()`, and this issue's scope does not add that caller — #160 owns the main.cpp switch-over. So this makes the API correct while it stays dormant in the shipping build, and none of it is hardware-validated.

`getPeerDeviceType` deliberately still reads the handshake table. #216 re-sources it from the context channel that decoded the profile, which is the right source: the HELLO `deviceType` byte arrives over serial while the profile arrives over ESP-NOW, and nothing cross-checks them. Expect a rebase over #216, which touches `JackHelloLink` and `completeJackContext` in these same files.

Every new test was falsified by reverting its own mechanism. No existing test was weakened or deleted.
