### PR TITLE
chain: event-driven supporter confirm backstop

### DIFF
--- a/src/pdn/game/chain-duel-manager.cpp
+++ b/src/pdn/game/chain-duel-manager.cpp
@@ -75,6 +75,14 @@ bool ChainDuelManager::isKnownGameEventSender(const uint8_t* fromMac) const {
     return false;
 }
 
+bool ChainDuelManager::isKnownConfirmRelay(const uint8_t* fromMac) const {
+    PortState sState = rdc->getPortState(supporterJack());
+    for (const auto& peer : sState.peerMacAddresses) {
+        if (memcmp(peer.data(), fromMac, 6) == 0) return true;
+    }
+    return false;
+}
+
 void ChainDuelManager::sendGameEventToSupporters(ChainGameEventType eventType) {
     if (!isChampion()) return;
 
@@ -185,25 +193,18 @@ void ChainDuelManager::onChainGameEventReceived(uint8_t eventType) {
     confirmSent = false;
 }
 
-void ChainDuelManager::bufferConfirm(const uint8_t* originatorMac) {
-    size_t count = bufferedConfirmCount.load();
-    if (count >= MAX_BUFFERED_CONFIRMS) return;
+void ChainDuelManager::recordConfirm(const uint8_t* originatorMac) {
+    size_t count = receivedConfirmCount.load();
     for (size_t i = 0; i < count; i++) {
-        if (memcmp(bufferedConfirms[i].data(), originatorMac, 6) == 0) return;
+        if (memcmp(receivedConfirms[i].data(), originatorMac, 6) == 0) return;
     }
-    memcpy(bufferedConfirms[count].data(), originatorMac, 6);
-    bufferedConfirmCount.store(count + 1);
-}
-
-void ChainDuelManager::drainBufferedConfirms() {
-    size_t count = bufferedConfirmCount.exchange(0);
-    if (count == 0) return;
-    // Iterating a copy: a rejected entry re-buffers into the member array from
-    // index 0 and would otherwise overwrite entries not yet re-offered.
-    std::array<std::array<uint8_t, 6>, MAX_BUFFERED_CONFIRMS> held = bufferedConfirms;
-    for (size_t i = 0; i < count && i < MAX_BUFFERED_CONFIRMS; i++) {
-        onConfirmReceived(held[i].data(), held[i].data(), 0);
+    if (count < MAX_RECEIVED_CONFIRMS) {
+        memcpy(receivedConfirms[count].data(), originatorMac, 6);
+        receivedConfirmCount.store(count + 1);
+        return;
     }
+    memcpy(receivedConfirms[receivedConfirmWrite].data(), originatorMac, 6);
+    receivedConfirmWrite = (receivedConfirmWrite + 1) % MAX_RECEIVED_CONFIRMS;
 }
 
 void ChainDuelManager::onConfirmReceived(
@@ -211,28 +212,11 @@ void ChainDuelManager::onConfirmReceived(
     const uint8_t* originatorMac,
     uint8_t seqId) {
     (void)fromMac; (void)seqId;
-    if (!isChampion()) {
-        bufferConfirm(originatorMac);
-        return;
-    }
-
-    auto peers = getSupporterChainPeers();
-    bool isMember = false;
-    for (const auto& peer : peers) {
-        if (memcmp(peer.data(), originatorMac, 6) == 0) { isMember = true; break; }
-    }
-    if (!isMember) {
-        bufferConfirm(originatorMac);
-        return;
-    }
-
-    for (const auto& existing : confirmedSupporters_) {
-        if (memcmp(existing.data(), originatorMac, 6) == 0) return;
-    }
-    std::array<uint8_t, 6> macArr;
-    memcpy(macArr.data(), originatorMac, 6);
-    confirmedSupporters_.push_back(macArr);
-    boostMs_ = confirmedSupporters_.size() * BOOST_PER_SUPPORTER_MS;
+    // Recorded unconditionally. Whether this originator is a chain member, and
+    // whether we are the champion who gets to count it, are both read live in
+    // getConfirmedSupporterCount — neither is knowable for certain at the moment
+    // a press arrives.
+    recordConfirm(originatorMac);
 }
 
 void ChainDuelManager::onChainStateChanged() {
@@ -242,10 +226,6 @@ void ChainDuelManager::onChainStateChanged() {
     // device unplugged mid-round and patched into another chain would re-send a
     // press it made to a champion it no longer follows.
     if (!isSupporter()) confirmSent = false;
-
-    // The roster is as settled as it gets right here, so anything held back for
-    // want of a roster entry gets its second look.
-    drainBufferedConfirms();
 }
 
 void ChainDuelManager::applyChainStateChange() {
@@ -339,17 +319,28 @@ void ChainDuelManager::setPeerRole(SerialIdentifier port, bool isHunter) {
 }
 
 unsigned long ChainDuelManager::getBoostMs() const {
-    return boostMs_;
+    return getConfirmedSupporterCount() * BOOST_PER_SUPPORTER_MS;
 }
 
 size_t ChainDuelManager::getConfirmedSupporterCount() const {
-    return confirmedSupporters_.size();
+    if (!isChampion()) return 0;
+    std::vector<std::array<uint8_t, 6>> peers = getSupporterChainPeers();
+    size_t count = receivedConfirmCount.load();
+    size_t confirmed = 0;
+    for (size_t i = 0; i < count; i++) {
+        for (const std::array<uint8_t, 6>& peer : peers) {
+            if (memcmp(peer.data(), receivedConfirms[i].data(), 6) == 0) {
+                confirmed++;
+                break;
+            }
+        }
+    }
+    return confirmed;
 }
 
 void ChainDuelManager::clearSupporterConfirms() {
-    confirmedSupporters_.clear();
-    boostMs_ = 0;
-    bufferedConfirmCount.store(0);
+    receivedConfirmCount.store(0);
+    receivedConfirmWrite = 0;
 }
 
 const uint8_t* ChainDuelManager::getChampionMac() const {

--- a/src/pdn/game/chain-duel-manager.cpp
+++ b/src/pdn/game/chain-duel-manager.cpp
@@ -78,10 +78,6 @@ bool ChainDuelManager::isKnownGameEventSender(const uint8_t* fromMac) const {
 void ChainDuelManager::sendGameEventToSupporters(ChainGameEventType eventType) {
     if (!isChampion()) return;
 
-    if (eventType == ChainGameEventType::COUNTDOWN) {
-        clearSupporterConfirms();
-    }
-
     // WIN/LOSS are state-terminal for the supporter UI and must arrive or
     // the supporter display sticks on a stale screen until the next chain
     // event. They get seqIds and retry tracking.
@@ -127,6 +123,12 @@ void ChainDuelManager::sendGameEventToSupporters(ChainGameEventType eventType) {
             reinterpret_cast<const uint8_t*>(&payload),
             sizeof(payload));
     }
+
+    // The roll call is wiped after the sends, never before: a recipient list
+    // derived from it would silently drop every multi-hop supporter.
+    if (eventType == ChainGameEventType::COUNTDOWN) {
+        clearSupporterConfirms();
+    }
 }
 
 void ChainDuelManager::sendGameEventAck(const uint8_t* toMac, uint8_t seqId) {
@@ -151,6 +153,11 @@ void ChainDuelManager::onChainGameEventAckReceived(const uint8_t* fromMac, uint8
 }
 
 void ChainDuelManager::sendConfirm() {
+    // Latched before the champion check, not after: a press that lands before
+    // the role cascade has named a champion still has to reach whoever the
+    // cascade names, and that is what resendConfirm is for.
+    confirmSent = true;
+
     if (!championMac_.has_value()) return;
 
     const uint8_t* selfMac = wirelessManager->getMacAddress();
@@ -168,19 +175,56 @@ void ChainDuelManager::sendConfirm() {
         sizeof(payload));
 }
 
+void ChainDuelManager::resendConfirm() {
+    if (!confirmSent) return;
+    sendConfirm();
+}
+
+void ChainDuelManager::onChainGameEventReceived(uint8_t eventType) {
+    if (static_cast<ChainGameEventType>(eventType) != ChainGameEventType::COUNTDOWN) return;
+    confirmSent = false;
+}
+
+void ChainDuelManager::bufferConfirm(const uint8_t* originatorMac) {
+    size_t count = bufferedConfirmCount.load();
+    if (count >= MAX_BUFFERED_CONFIRMS) return;
+    for (size_t i = 0; i < count; i++) {
+        if (memcmp(bufferedConfirms[i].data(), originatorMac, 6) == 0) return;
+    }
+    memcpy(bufferedConfirms[count].data(), originatorMac, 6);
+    bufferedConfirmCount.store(count + 1);
+}
+
+void ChainDuelManager::drainBufferedConfirms() {
+    size_t count = bufferedConfirmCount.exchange(0);
+    if (count == 0) return;
+    // Iterating a copy: a rejected entry re-buffers into the member array from
+    // index 0 and would otherwise overwrite entries not yet re-offered.
+    std::array<std::array<uint8_t, 6>, MAX_BUFFERED_CONFIRMS> held = bufferedConfirms;
+    for (size_t i = 0; i < count && i < MAX_BUFFERED_CONFIRMS; i++) {
+        onConfirmReceived(held[i].data(), held[i].data(), 0);
+    }
+}
+
 void ChainDuelManager::onConfirmReceived(
     const uint8_t* fromMac,
     const uint8_t* originatorMac,
     uint8_t seqId) {
     (void)fromMac; (void)seqId;
-    if (!isChampion()) return;
+    if (!isChampion()) {
+        bufferConfirm(originatorMac);
+        return;
+    }
 
     auto peers = getSupporterChainPeers();
     bool isMember = false;
     for (const auto& peer : peers) {
         if (memcmp(peer.data(), originatorMac, 6) == 0) { isMember = true; break; }
     }
-    if (!isMember) return;
+    if (!isMember) {
+        bufferConfirm(originatorMac);
+        return;
+    }
 
     for (const auto& existing : confirmedSupporters_) {
         if (memcmp(existing.data(), originatorMac, 6) == 0) return;
@@ -192,6 +236,19 @@ void ChainDuelManager::onConfirmReceived(
 }
 
 void ChainDuelManager::onChainStateChanged() {
+    applyChainStateChange();
+
+    // Leaving the supporter role voids the standing confirm. Without this, a
+    // device unplugged mid-round and patched into another chain would re-send a
+    // press it made to a champion it no longer follows.
+    if (!isSupporter()) confirmSent = false;
+
+    // The roster is as settled as it gets right here, so anything held back for
+    // want of a roster entry gets its second look.
+    drainBufferedConfirms();
+}
+
+void ChainDuelManager::applyChainStateChange() {
     PortState sState = rdc->getPortState(supporterJack());
     size_t count = sState.peerMacAddresses.size();
     if (lastSupporterChainCount_ > 0 && count == 0) {
@@ -292,6 +349,7 @@ size_t ChainDuelManager::getConfirmedSupporterCount() const {
 void ChainDuelManager::clearSupporterConfirms() {
     confirmedSupporters_.clear();
     boostMs_ = 0;
+    bufferedConfirmCount.store(0);
 }
 
 const uint8_t* ChainDuelManager::getChampionMac() const {
@@ -376,6 +434,10 @@ void ChainDuelManager::onRoleAnnounceReceived(
     championMac_ = newMac;
     if (changed) {
         broadcastRoleAndChampion();
+        // A head transfer swaps the champion without touching this device's own
+        // links, so nothing else here would tell the new champion that this
+        // supporter is already in.
+        resendConfirm();
     }
 }
 

--- a/src/pdn/game/chain-duel-manager.cpp
+++ b/src/pdn/game/chain-duel-manager.cpp
@@ -78,6 +78,12 @@ bool ChainDuelManager::isKnownGameEventSender(const uint8_t* fromMac) const {
 void ChainDuelManager::sendGameEventToSupporters(ChainGameEventType eventType) {
     if (!isChampion()) return;
 
+    // Recipients come from the RDC roster, not this roll call. Keep it that way
+    // or multi-hop supporters get dropped.
+    if (eventType == ChainGameEventType::COUNTDOWN) {
+        clearSupporterConfirms();
+    }
+
     // WIN/LOSS are state-terminal for the supporter UI and must arrive or
     // the supporter display sticks on a stale screen until the next chain
     // event. They get seqIds and retry tracking.
@@ -122,12 +128,6 @@ void ChainDuelManager::sendGameEventToSupporters(ChainGameEventType eventType) {
             PktType::kChainGameEvent,
             reinterpret_cast<const uint8_t*>(&payload),
             sizeof(payload));
-    }
-
-    // The roll call is wiped after the sends, never before: a recipient list
-    // derived from it would silently drop every multi-hop supporter.
-    if (eventType == ChainGameEventType::COUNTDOWN) {
-        clearSupporterConfirms();
     }
 }
 

--- a/src/pdn/game/chain-duel-manager.hpp
+++ b/src/pdn/game/chain-duel-manager.hpp
@@ -63,6 +63,11 @@ public:
     void onChainGameEventAckReceived(const uint8_t* fromMac, uint8_t seqId);
 
     bool isKnownGameEventSender(const uint8_t* fromMac) const;
+
+    /// True when `fromMac` is a peer reachable on the supporter side, the only
+    /// direction a confirm legitimately arrives from. Gates the packet handler
+    /// so an unrelated device on the channel cannot inject presses.
+    bool isKnownConfirmRelay(const uint8_t* fromMac) const;
     void onConfirmReceived(
         const uint8_t* fromMac,
         const uint8_t* originatorMac,
@@ -113,19 +118,14 @@ private:
     // also gets the confirm bookkeeping that has to follow it.
     void applyChainStateChange();
 
-    // Holds an originator whose confirm arrived before the topology could
-    // justify it; ignored when already held or when the buffer is full.
-    void bufferConfirm(const uint8_t* originatorMac);
-    // Re-offers every held originator to onConfirmReceived. Anything the
-    // topology still cannot justify lands straight back in the buffer.
-    void drainBufferedConfirms();
+    // Records an originator we heard a press from, deduped. Says nothing about
+    // whether it counts — that is decided when the count is read.
+    void recordConfirm(const uint8_t* originatorMac);
 
     // Returns the cached role of the direct peer on `port`, or nullopt if no
     // role announcement has been received from the current direct peer.
     std::optional<bool> peerIsHunter(SerialIdentifier port) const;
 
-    std::vector<std::array<uint8_t, 6>> confirmedSupporters_;
-    unsigned long boostMs_ = 0;
     size_t lastSupporterChainCount_ = 0;
 
     uint8_t nextConfirmSeqId_ = 1;  // skip 0 as sentinel
@@ -135,18 +135,24 @@ private:
     // written from the radio task (COUNTDOWN arrival), read from the main loop.
     std::atomic<bool> confirmSent{false};
 
-    // A confirm can beat the chain announcement that puts its originator in the
-    // roster, and the sender gets no signal that it was dropped, so its whole
-    // round of boost is lost. Held here instead and re-offered when the topology
-    // moves. Fixed slots with an atomic count rather than a vector: the radio
-    // task fills it while the main loop drains it, and a reallocation across
-    // that boundary is a crash. Junk from an on-channel stranger only occupies a
-    // slot until the next drain re-rejects it.
-    // Sized to RDC's kMaxChainPeersPerPort (18), the most chain peers that can
-    // legitimately be waiting on a roster update.
-    static constexpr size_t MAX_BUFFERED_CONFIRMS = 18;
-    std::array<std::array<uint8_t, 6>, MAX_BUFFERED_CONFIRMS> bufferedConfirms{};
-    std::atomic<size_t> bufferedConfirmCount{0};
+    // Every press we have heard this round, member or not. Membership is applied
+    // when the count is read, not here, because a confirm can beat the chain
+    // announcement that puts its originator in the roster and the sender gets no
+    // signal it was dropped. Deciding late means an early confirm starts counting
+    // the moment its announcement lands, and an unplugged supporter stops
+    // counting, with nothing to re-offer or evict on a topology event.
+    //
+    // Fixed slots with an atomic count rather than a vector: the radio task
+    // writes while the main loop reads, and a reallocation across that boundary
+    // is a crash. Sized to RDC's kMaxChainPeersPerPort (18), the most chain peers
+    // that can legitimately press in one round. Full means overwrite oldest, not
+    // refuse newest: refusing would let anything on the channel — no roster entry
+    // needed, the packet handler cannot prove one — wedge the slots shut and
+    // silence every real supporter for the round.
+    static constexpr size_t MAX_RECEIVED_CONFIRMS = 18;
+    std::array<std::array<uint8_t, 6>, MAX_RECEIVED_CONFIRMS> receivedConfirms{};
+    std::atomic<size_t> receivedConfirmCount{0};
+    size_t receivedConfirmWrite = 0;
 
     // Per-port direct peer role; cleared when the direct peer disconnects.
     std::array<std::optional<bool>, 2> peerRoleByPort_;

--- a/src/pdn/game/chain-duel-manager.hpp
+++ b/src/pdn/game/chain-duel-manager.hpp
@@ -142,6 +142,8 @@ private:
     // task fills it while the main loop drains it, and a reallocation across
     // that boundary is a crash. Junk from an on-channel stranger only occupies a
     // slot until the next drain re-rejects it.
+    // Sized to RDC's kMaxChainPeersPerPort (18), the most chain peers that can
+    // legitimately be waiting on a roster update.
     static constexpr size_t MAX_BUFFERED_CONFIRMS = 18;
     std::array<std::array<uint8_t, 6>, MAX_BUFFERED_CONFIRMS> bufferedConfirms{};
     std::atomic<size_t> bufferedConfirmCount{0};

--- a/src/pdn/game/chain-duel-manager.hpp
+++ b/src/pdn/game/chain-duel-manager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <optional>
 #include <vector>
 #include <cstdint>
@@ -40,6 +41,17 @@ public:
 
     void sendGameEventToSupporters(ChainGameEventType eventType);
     void sendConfirm();
+
+    /// Re-sends the confirm this device is standing on to whichever champion it
+    /// now holds. No-op until a press has produced one, so a topology event can
+    /// never register a supporter who never pressed.
+    void resendConfirm();
+
+    /// Supporter-side view of an inbound chain game event. A COUNTDOWN voids the
+    /// standing confirm: the champion wipes its roll call at that same moment, so
+    /// re-sending the old press would register a supporter for a round it has not
+    /// yet answered.
+    void onChainGameEventReceived(uint8_t eventType);
 
     // Supporter-side: ACK a received WIN/LOSS game event back to the
     // champion so it stops retransmitting. Called from Quickdraw's packet
@@ -97,6 +109,17 @@ private:
     SerialIdentifier opponentJack() const;
     SerialIdentifier supporterJack() const;
 
+    // The role/champion cascade. Wrapped by onChainStateChanged so every caller
+    // also gets the confirm bookkeeping that has to follow it.
+    void applyChainStateChange();
+
+    // Holds an originator whose confirm arrived before the topology could
+    // justify it; ignored when already held or when the buffer is full.
+    void bufferConfirm(const uint8_t* originatorMac);
+    // Re-offers every held originator to onConfirmReceived. Anything the
+    // topology still cannot justify lands straight back in the buffer.
+    void drainBufferedConfirms();
+
     // Returns the cached role of the direct peer on `port`, or nullopt if no
     // role announcement has been received from the current direct peer.
     std::optional<bool> peerIsHunter(SerialIdentifier port) const;
@@ -106,6 +129,22 @@ private:
     size_t lastSupporterChainCount_ = 0;
 
     uint8_t nextConfirmSeqId_ = 1;  // skip 0 as sentinel
+
+    // Set the moment a press produces a confirm, so the champion-changed and
+    // chain-settled triggers know there is something worth re-sending. Atomic:
+    // written from the radio task (COUNTDOWN arrival), read from the main loop.
+    std::atomic<bool> confirmSent{false};
+
+    // A confirm can beat the chain announcement that puts its originator in the
+    // roster, and the sender gets no signal that it was dropped, so its whole
+    // round of boost is lost. Held here instead and re-offered when the topology
+    // moves. Fixed slots with an atomic count rather than a vector: the radio
+    // task fills it while the main loop drains it, and a reallocation across
+    // that boundary is a crash. Junk from an on-channel stranger only occupies a
+    // slot until the next drain re-rejects it.
+    static constexpr size_t MAX_BUFFERED_CONFIRMS = 18;
+    std::array<std::array<uint8_t, 6>, MAX_BUFFERED_CONFIRMS> bufferedConfirms{};
+    std::atomic<size_t> bufferedConfirmCount{0};
 
     // Per-port direct peer role; cleared when the direct peer disconnects.
     std::array<std::optional<bool>, 2> peerRoleByPort_;

--- a/src/pdn/game/quickdraw.cpp
+++ b/src/pdn/game/quickdraw.cpp
@@ -219,6 +219,11 @@ void Quickdraw::onChainGameEventAckPacket(const uint8_t* fromMac, const uint8_t*
 void Quickdraw::onChainConfirmPacket(const uint8_t* fromMac, const uint8_t* data, size_t dataLen) {
     if (dataLen != sizeof(ChainConfirmPayload)) return;
     if (!chainDuelManager) return;
+    // Confirms relay hop by hop, so the sender must be a peer we can reach on
+    // the supporter side. originatorMac stays unvalidated on purpose — it names
+    // a device further up the chain that we have no direct link to — which is
+    // why the count intersects it against the roster rather than trusting it.
+    if (!chainDuelManager->isKnownConfirmRelay(fromMac)) return;
     const ChainConfirmPayload* payload = reinterpret_cast<const ChainConfirmPayload*>(data);
     chainDuelManager->onConfirmReceived(fromMac, payload->originatorMac, payload->seqId);
 }

--- a/src/pdn/game/quickdraw.cpp
+++ b/src/pdn/game/quickdraw.cpp
@@ -102,6 +102,14 @@ Quickdraw::Quickdraw(Player* player, Device* PDN, QuickdrawWirelessManager* quic
         onChainStateChanged();
     });
 
+    // A role edge is the one signal a head transfer or coordinator handoff always
+    // produces; the direct peers either side of this device can be unchanged
+    // across one, leaving a confirmed supporter registered with a champion that
+    // no longer runs the duel.
+    remoteDeviceCoordinator->setOnChainRoleChange([this](ChainRole) {
+        if (chainDuelManager) chainDuelManager->resendConfirm();
+    });
+
     remoteDeviceCoordinator->setPeerLostCallback([this](const uint8_t* lostMac) {
         if (shootoutManager && shootoutManager->active()) {
             shootoutManager->onLocalRDCDisconnect(lostMac);
@@ -180,6 +188,12 @@ void Quickdraw::onChainGameEventPacket(const uint8_t* fromMac, const uint8_t* da
     if (!chainDuelManager || !chainDuelManager->isKnownGameEventSender(fromMac)) return;
 
     const ChainGameEventPayload* payload = reinterpret_cast<const ChainGameEventPayload*>(data);
+
+    // Ahead of the state dispatch and independent of it: a COUNTDOWN wipes the
+    // champion's roll call whether or not this device is watching for it, and a
+    // confirm still held here would then re-register a press for a round the
+    // supporter has not answered.
+    chainDuelManager->onChainGameEventReceived(payload->event_type);
 
     // Out-of-state events dropped silently; champion's retry machine bounds traffic cost.
     if (supporterReadyState != nullptr && currentState != nullptr
@@ -293,6 +307,7 @@ Quickdraw::~Quickdraw() {
     // is deliberately absent: its ctx is the symbol manager, which outlives
     // Quickdraw, so clearing it here would deafen a live consumer.
     remoteDeviceCoordinator->setChainChangeCallback(nullptr);
+    remoteDeviceCoordinator->setOnChainRoleChange(nullptr);
     remoteDeviceCoordinator->setPeerLostCallback(nullptr);
     remoteDeviceCoordinator = nullptr;
     for (PktType handled : {PktType::kChainGameEvent, PktType::kChainGameEventAck,

--- a/test/test_core/chain-duel-manager-tests.hpp
+++ b/test/test_core/chain-duel-manager-tests.hpp
@@ -355,6 +355,38 @@ inline void cdmConfirmBufferedUntilOriginatorJoinsChain(ChainDuelManagerTests* s
     EXPECT_EQ(cdm.getBoostMs(), ChainDuelManager::BOOST_PER_SUPPORTER_MS);
 }
 
+// Saturating the confirm slots with strangers must not silence a real supporter.
+// The slots are fixed and the packet handler cannot prove an originator is a
+// member, so anything on the channel can fill them; refusing new entries when
+// full, or holding rejected entries forever, would turn that into a mute button
+// for the whole round.
+inline void cdmStrangerConfirmsCannotSilenceRealSupporter(ChainDuelManagerTests* suite) {
+    suite->setupHunterChampion();
+    ChainDuelManager cdm(&suite->player, suite->device.wirelessManager, &suite->rdc);
+    suite->applyHunterChampionRoles(cdm);
+    ASSERT_TRUE(cdm.isChampion());
+
+    // Twice the slot count, none of them ever in the roster.
+    for (int i = 0; i < 36; i++) {
+        uint8_t stranger[6] = {0xEE, 0xEE, 0xEE, 0xEE,
+                               static_cast<uint8_t>(i), static_cast<uint8_t>(i)};
+        cdm.onConfirmReceived(suite->supporterMac, stranger, 1);
+    }
+    ASSERT_EQ(cdm.getConfirmedSupporterCount(), 0u);
+
+    // A genuine multi-hop supporter presses afterwards and joins the roster.
+    uint8_t realMac[6] = {0x22, 0x33, 0x44, 0x55, 0x66, 0x77};
+    cdm.onConfirmReceived(suite->supporterMac, realMac, 1);
+    std::array<uint8_t, 6> realArr;
+    memcpy(realArr.data(), realMac, 6);
+    suite->rdc.onChainAnnouncementReceived(
+        suite->supporterMac, SerialIdentifier::INPUT_JACK, {realArr});
+    cdm.onChainStateChanged();
+
+    EXPECT_EQ(cdm.getConfirmedSupporterCount(), 1u);
+    EXPECT_EQ(cdm.getBoostMs(), ChainDuelManager::BOOST_PER_SUPPORTER_MS);
+}
+
 // Head transfer swaps the champion under a supporter that already pressed. The
 // standing confirm has to follow it or the press buys no boost.
 inline void cdmConfirmResentWhenChampionChanges(ChainDuelManagerTests* suite) {

--- a/test/test_core/chain-duel-manager-tests.hpp
+++ b/test/test_core/chain-duel-manager-tests.hpp
@@ -329,6 +329,163 @@ inline void cdmSendConfirmNoopWhenChampionMacInvalid(ChainDuelManagerTests* suit
     cdm.sendConfirm();
 }
 
+// A confirm can outrun the chain announcement that puts its originator in the
+// champion's supporter chain. Held rather than dropped, and admitted on the next
+// chain-state change — otherwise that supporter contributes nothing all round.
+inline void cdmConfirmBufferedUntilOriginatorJoinsChain(ChainDuelManagerTests* suite) {
+    suite->setupHunterChampion();
+    ChainDuelManager cdm(&suite->player, suite->device.wirelessManager, &suite->rdc);
+    suite->applyHunterChampionRoles(cdm);
+    ASSERT_TRUE(cdm.isChampion());
+
+    uint8_t multiHopMac[6] = {0x22, 0x33, 0x44, 0x55, 0x66, 0x77};
+    cdm.onConfirmReceived(suite->supporterMac, multiHopMac, 1);
+    ASSERT_EQ(cdm.getConfirmedSupporterCount(), 0u);
+
+    // The announcement lands: multiHopMac is now reachable behind the direct
+    // supporter-jack peer.
+    std::array<uint8_t, 6> multiHopArr;
+    memcpy(multiHopArr.data(), multiHopMac, 6);
+    suite->rdc.onChainAnnouncementReceived(
+        suite->supporterMac, SerialIdentifier::INPUT_JACK, {multiHopArr});
+
+    cdm.onChainStateChanged();
+
+    EXPECT_EQ(cdm.getConfirmedSupporterCount(), 1u);
+    EXPECT_EQ(cdm.getBoostMs(), ChainDuelManager::BOOST_PER_SUPPORTER_MS);
+}
+
+// Head transfer swaps the champion under a supporter that already pressed. The
+// standing confirm has to follow it or the press buys no boost.
+inline void cdmConfirmResentWhenChampionChanges(ChainDuelManagerTests* suite) {
+    suite->setupHunterChampion();
+    ChainDuelManager cdm(&suite->player, suite->device.wirelessManager, &suite->rdc);
+    EXPECT_CALL(*suite->device.mockPeerComms,
+                sendData(_, PktType::kRoleAnnounceAck, _, _))
+        .WillRepeatedly(Return(1));
+    EXPECT_CALL(*suite->device.mockPeerComms,
+                sendData(_, PktType::kRoleAnnounce, _, _))
+        .WillRepeatedly(Return(1));
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_)).WillRepeatedly(Return(0));
+
+    std::vector<std::array<uint8_t, 6>> confirmTargets;
+    EXPECT_CALL(*suite->device.mockPeerComms,
+                sendData(_, PktType::kChainConfirm, _, sizeof(ChainConfirmPayload)))
+        .WillRepeatedly([&](const uint8_t* mac, PktType, const uint8_t*, const size_t) {
+            std::array<uint8_t, 6> target;
+            memcpy(target.data(), mac, 6);
+            confirmTargets.push_back(target);
+            return 1;
+        });
+
+    uint8_t firstChampion[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    cdm.onRoleAnnounceReceived(suite->opponentMac, 1, firstChampion, 1);
+    ASSERT_TRUE(cdm.isSupporter());
+    cdm.sendConfirm();
+
+    uint8_t secondChampion[6] = {0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F};
+    cdm.onRoleAnnounceReceived(suite->opponentMac, 1, secondChampion, 2);
+
+    ASSERT_EQ(confirmTargets.size(), 2u);
+    EXPECT_EQ(memcmp(confirmTargets[0].data(), firstChampion, 6), 0);
+    EXPECT_EQ(memcmp(confirmTargets[1].data(), secondChampion, 6), 0);
+}
+
+// COUNTDOWN wipes the champion's roll call, so the press that preceded it is
+// spent. A champion change after one must not resurrect it.
+inline void cdmCountdownVoidsStandingConfirm(ChainDuelManagerTests* suite) {
+    suite->setupHunterChampion();
+    ChainDuelManager cdm(&suite->player, suite->device.wirelessManager, &suite->rdc);
+    EXPECT_CALL(*suite->device.mockPeerComms,
+                sendData(_, PktType::kRoleAnnounceAck, _, _))
+        .WillRepeatedly(Return(1));
+    EXPECT_CALL(*suite->device.mockPeerComms,
+                sendData(_, PktType::kRoleAnnounce, _, _))
+        .WillRepeatedly(Return(1));
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_)).WillRepeatedly(Return(0));
+
+    int confirmsSent = 0;
+    EXPECT_CALL(*suite->device.mockPeerComms,
+                sendData(_, PktType::kChainConfirm, _, _))
+        .WillRepeatedly([&](const uint8_t*, PktType, const uint8_t*, const size_t) {
+            confirmsSent++;
+            return 1;
+        });
+
+    uint8_t firstChampion[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    cdm.onRoleAnnounceReceived(suite->opponentMac, 1, firstChampion, 1);
+    ASSERT_TRUE(cdm.isSupporter());
+    cdm.sendConfirm();
+    ASSERT_EQ(confirmsSent, 1);
+
+    cdm.onChainGameEventReceived(static_cast<uint8_t>(ChainGameEventType::COUNTDOWN));
+
+    uint8_t secondChampion[6] = {0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F};
+    cdm.onRoleAnnounceReceived(suite->opponentMac, 1, secondChampion, 2);
+
+    EXPECT_EQ(confirmsSent, 1);
+}
+
+// Unplugging ends the round for this supporter. The press it made must not
+// follow it into whatever chain it is patched into next.
+inline void cdmSupporterRoleLossVoidsStandingConfirm(ChainDuelManagerTests* suite) {
+    suite->setupHunterChampion();
+    ChainDuelManager cdm(&suite->player, suite->device.wirelessManager, &suite->rdc);
+    // Tearing the links down makes the RDC emit its own traffic; a catch-all
+    // fallback keeps that off the confirm counter below.
+    EXPECT_CALL(*suite->device.mockPeerComms, sendData(_, _, _, _)).WillRepeatedly(Return(1));
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_)).WillRepeatedly(Return(0));
+
+    int confirmsSent = 0;
+    EXPECT_CALL(*suite->device.mockPeerComms,
+                sendData(_, PktType::kChainConfirm, _, _))
+        .WillRepeatedly([&](const uint8_t*, PktType, const uint8_t*, const size_t) {
+            confirmsSent++;
+            return 1;
+        });
+
+    uint8_t champion[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    cdm.onRoleAnnounceReceived(suite->opponentMac, 1, champion, 1);
+    ASSERT_TRUE(cdm.isSupporter());
+    cdm.sendConfirm();
+    ASSERT_EQ(confirmsSent, 1);
+
+    // Cable out on both jacks: the heartbeat lapses and the direct peers go.
+    suite->fakeClock->advance(5000);
+    suite->rdc.sync(&suite->device);
+    cdm.onChainStateChanged();
+    ASSERT_FALSE(cdm.isSupporter());
+
+    cdm.resendConfirm();
+    EXPECT_EQ(confirmsSent, 1);
+}
+
+// A supporter that never pressed holds nothing to re-send. Without this the
+// champion-changed trigger would register the whole chain as confirmed.
+inline void cdmChampionChangeWithoutPressSendsNoConfirm(ChainDuelManagerTests* suite) {
+    suite->setupHunterChampion();
+    ChainDuelManager cdm(&suite->player, suite->device.wirelessManager, &suite->rdc);
+    EXPECT_CALL(*suite->device.mockPeerComms,
+                sendData(_, PktType::kRoleAnnounceAck, _, _))
+        .WillRepeatedly(Return(1));
+    EXPECT_CALL(*suite->device.mockPeerComms,
+                sendData(_, PktType::kRoleAnnounce, _, _))
+        .WillRepeatedly(Return(1));
+    EXPECT_CALL(*suite->device.mockPeerComms, addEspNowPeer(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(*suite->device.mockPeerComms, removeEspNowPeer(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(*suite->device.mockPeerComms,
+                sendData(_, PktType::kChainConfirm, _, _))
+        .Times(0);
+
+    uint8_t firstChampion[6] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+    cdm.onRoleAnnounceReceived(suite->opponentMac, 1, firstChampion, 1);
+    uint8_t secondChampion[6] = {0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F};
+    cdm.onRoleAnnounceReceived(suite->opponentMac, 1, secondChampion, 2);
+    cdm.resendConfirm();
+}
 
 // onRoleAnnounceReceived updates peerRoleByPort_ and championMac_, acks sender,
 // registers champion as ESP-NOW peer.

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1661,6 +1661,26 @@ TEST_F(ChainDuelManagerTests, sendConfirmNoopWhenChampionMacInvalid) {
     cdmSendConfirmNoopWhenChampionMacInvalid(this);
 }
 
+TEST_F(ChainDuelManagerTests, confirmBufferedUntilOriginatorJoinsChain) {
+    cdmConfirmBufferedUntilOriginatorJoinsChain(this);
+}
+
+TEST_F(ChainDuelManagerTests, confirmResentWhenChampionChanges) {
+    cdmConfirmResentWhenChampionChanges(this);
+}
+
+TEST_F(ChainDuelManagerTests, countdownVoidsStandingConfirm) {
+    cdmCountdownVoidsStandingConfirm(this);
+}
+
+TEST_F(ChainDuelManagerTests, supporterRoleLossVoidsStandingConfirm) {
+    cdmSupporterRoleLossVoidsStandingConfirm(this);
+}
+
+TEST_F(ChainDuelManagerTests, championChangeWithoutPressSendsNoConfirm) {
+    cdmChampionChangeWithoutPressSendsNoConfirm(this);
+}
+
 TEST_F(ChainDuelManagerTests, roleAnnounceUpdatesChampionMac) {
     cdmRoleAnnounceUpdatesChampionMac(this);
 }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1665,6 +1665,10 @@ TEST_F(ChainDuelManagerTests, confirmBufferedUntilOriginatorJoinsChain) {
     cdmConfirmBufferedUntilOriginatorJoinsChain(this);
 }
 
+TEST_F(ChainDuelManagerTests, strangerConfirmsCannotSilenceRealSupporter) {
+    cdmStrangerConfirmsCannotSilenceRealSupporter(this);
+}
+
 TEST_F(ChainDuelManagerTests, confirmResentWhenChampionChanges) {
     cdmConfirmResentWhenChampionChanges(this);
 }


### PR DESCRIPTION
Closes #168.

## The Remove half was already done

All seven methods the issue names — `isInStableLoop`, `isRingSettledOpen`, `isTopologyStable`, `countChainBehind`, `deriveCoordinator`, `claimCoordinator`, `demoteCoordinator` — have zero occurrences anywhere in `src/`, `lib/` or `test/` at f74d4b4, as do `stableMinCycles`, `lastStableMin` and any 1Hz/backstop token in `chain-duel-manager.cpp`. The peer-graph rewrite deleted them already, and `ChainDuelManager` reads topology through the RDC accessors today. Nothing was deleted here and no deletions were invented to satisfy the checklist. All the work is the Add half.

## The confirm backstop, event-driven

Three triggers replace the poll. `Quickdraw` subscribes `setOnChainRoleChange` (the first real subscriber to any RDC observer under `src/`) and clears it in its destructor; `onRoleAnnounceReceived`'s champion-changed branch carries the same trigger, because a mid-chain supporter's own `ChainRole` stays CHILD across a head transfer and the role edge would never fire for it; and COUNTDOWN voids the standing confirm so the round's registration reopens with the button. A `confirmSent` latch gates every resend so a topology event cannot register a supporter who never pressed, and it clears whenever the device stops being a supporter.

**The role-change trigger is dormant in production.** RDC only reaches `maybeFireChainRoleChange()` inside `sync()`'s HELLO branch, and nothing under `src/` calls `enableHelloConnectivity()` yet, so that path goes live with #160. The `onRoleAnnounceReceived` trigger is the one that works today.

## Where to look: the confirm store was reshaped after review

The first cut buffered confirms that failed the membership check and re-offered them on topology change. Review found the buffer never evicted: the drain re-offers a held MAC to `onConfirmReceived`, whose non-member branch re-buffers it, so junk is permanent and 18 distinct MACs saturate the slots and drop every genuine confirm for the round. It was reachable from the air — `onChainConfirmPacket` had no sender validation at all, unlike `onChainGameEventPacket`'s `isKnownGameEventSender` gate — and it is a new hazard, since there is no buffer at f74d4b4 to regress from.

Rather than patch the buffer, membership is now decided when the count is **read**. `onConfirmReceived` records the originator; `getConfirmedSupporterCount` intersects what we heard against the live roster. That deletes `bufferConfirm`, `drainBufferedConfirms`, both re-buffer branches, the copy-to-iterate workaround, the drain call, and the cached `boostMs_`. An early confirm counts the instant its announcement lands, an unplugged supporter stops counting, and there is nothing to re-offer or evict.

Two supporting changes: the fixed slots overwrite oldest rather than refusing newest — refusing lets anything on the channel wedge them shut, and the packet handler cannot prove an originator is a member — and `isKnownConfirmRelay` now gates the handler on the sender being reachable on the supporter side. `originatorMac` stays unvalidated on purpose: it names a device further up the chain we have no direct link to, which is exactly why the count intersects it against the roster instead of trusting it.

## Two gaps left open, stated rather than hidden

- A `kChainConfirm` lost on the radio with the champion and topology both unchanged is unrecovered. The packet is fire-and-forget with no ack and no event fires to retrigger it. This is the one path the deleted 1Hz poll covered that the event set does not; closing it needs an ack or a `ReliableChannel`, which is larger than this issue.
- `getBoostMs` is read unconditionally by MatchManager's boost provider — there is no `currentMatchIsShootout` guard anywhere at f74d4b4 — so the chain-to-ring stale-boost leak is live at the base. Left alone as a separate concern rather than widening this PR.

Six tests added, each falsified by reverting exactly its mechanism and confirming that one test fails: buffered-confirm-admitted-on-join, resend-on-champion-change, COUNTDOWN-voids-confirm, role-loss-voids-confirm, no-press-no-resend, and stranger-confirms-cannot-silence-a-real-supporter. `isLoop()` untouched, no match-init added, no teardown inside `onStateLoop`, send-before-clear preserved. No existing test weakened or deleted. No hardware validation. `Closes #168` will not fire — the base is not the default branch.
