### PR TITLE
shootout: coordinator claims on RDC ring-closed, broadcasts roster

### DIFF
--- a/lib/core/include/device/drivers/peer-comms-types.hpp
+++ b/lib/core/include/device/drivers/peer-comms-types.hpp
@@ -106,8 +106,7 @@ struct ChainGameEventAckPayload
     uint8_t seqId;
 } __attribute__((packed));
 
-enum class ShootoutCmd : uint8_t
-{
+enum class ShootoutCmd : uint8_t {
     CONFIRM = 0,
     BRACKET = 1,
     MATCH_START = 2,
@@ -115,6 +114,9 @@ enum class ShootoutCmd : uint8_t
     TOURNAMENT_END = 4,
     PEER_LOST = 5,
     ABORT = 6,
+    // Coordinator -> members on ring closure. Carries the ring roster because
+    // only the head's RDC serves one; every other member gets its copy here.
+    RING_CLOSED = 7,
 };
 
 struct ShootoutPacket

--- a/src/pdn/game/quickdraw.cpp
+++ b/src/pdn/game/quickdraw.cpp
@@ -244,8 +244,7 @@ void Quickdraw::onChainJoinPacket(const uint8_t* fromMac, const uint8_t* data, s
 }
 
 namespace {
-// [count, count * 6-byte MAC] — the body BRACKET and RING_CLOSED share. Returns
-// false on a truncated or over-long list.
+// [count, count * 6-byte MAC] — the body BRACKET and RING_CLOSED share.
 bool decodeMacList(const uint8_t* payload, size_t payloadLen,
                    std::vector<std::array<uint8_t, 6>>& out) {
     if (payloadLen < 1) return false;

--- a/src/pdn/game/quickdraw.cpp
+++ b/src/pdn/game/quickdraw.cpp
@@ -17,9 +17,9 @@ Quickdraw::Quickdraw(Player* player, Device* PDN, QuickdrawWirelessManager* quic
     this->remoteDeviceCoordinator = PDN->getRemoteDeviceCoordinator();
 
     this->chainDuelManager = new ChainDuelManager(player, wirelessManager, remoteDeviceCoordinator);
-    // Reads chainDuelManager, which this constructor assigns in the body: hoisting
-    // this into the member-initializer list would read it uninitialized.
-    this->shootoutManager = new ShootoutManager(player, wirelessManager, remoteDeviceCoordinator, chainDuelManager);  // NOLINT(cppcoreguidelines-prefer-member-initializer)
+    // Reads wirelessManager and remoteDeviceCoordinator, both assigned in this
+    // body: an initializer-list hoist would read them uninitialized.
+    this->shootoutManager = new ShootoutManager(player, wirelessManager, remoteDeviceCoordinator);  // NOLINT(cppcoreguidelines-prefer-member-initializer)
     this->shootoutManager->setMatchManager(matchManager);
     matchManager->setShootoutManager(shootoutManager);
 
@@ -120,6 +120,11 @@ Quickdraw::Quickdraw(Player* player, Device* PDN, QuickdrawWirelessManager* quic
         if (shootoutManager && shootoutManager->active()) {
             shootoutManager->onLocalRDCDisconnect(lostMac);
         }
+    });
+
+    // Head-only, so whoever gets this call is the ring's coordinator.
+    remoteDeviceCoordinator->setOnRingClosed([this]() {
+        if (shootoutManager) shootoutManager->onRingClosed();
     });
 
     // The Player is the authority on this device's identity; RDC only carries it.
@@ -238,9 +243,28 @@ void Quickdraw::onChainJoinPacket(const uint8_t* fromMac, const uint8_t* data, s
     chainDuelManager->onChainJoinReceived(fromMac, payload->championMac);
 }
 
+namespace {
+// [count, count * 6-byte MAC] — the body BRACKET and RING_CLOSED share. Returns
+// false on a truncated or over-long list.
+bool decodeMacList(const uint8_t* payload, size_t payloadLen,
+                   std::vector<std::array<uint8_t, 6>>& out) {
+    if (payloadLen < 1) return false;
+    uint8_t count = payload[0];
+    if (count > ShootoutManager::MAX_BRACKET_SIZE) return false;
+    if (payloadLen < 1 + 6 * static_cast<size_t>(count)) return false;
+    out.reserve(count);
+    for (uint8_t i = 0; i < count; i++) {
+        std::array<uint8_t, 6> mac;
+        memcpy(mac.data(), payload + 1 + 6 * i, 6);
+        out.push_back(mac);
+    }
+    return true;
+}
+}  // namespace
+
 void Quickdraw::onShootoutCommandPacket(const uint8_t* fromMac, const uint8_t* data, size_t dataLen) {
     if (!shootoutManager || dataLen < 2) return;
-    if (data[0] > static_cast<uint8_t>(ShootoutCmd::ABORT)) return;
+    if (data[0] > static_cast<uint8_t>(ShootoutCmd::RING_CLOSED)) return;
     ShootoutCmd cmd = static_cast<ShootoutCmd>(data[0]);
     uint8_t seqId = data[1];
     const uint8_t* payload = data + 2;
@@ -254,18 +278,15 @@ void Quickdraw::onShootoutCommandPacket(const uint8_t* fromMac, const uint8_t* d
             break;
         }
         case ShootoutCmd::BRACKET: {
-            if (payloadLen < 1) break;
-            uint8_t count = payload[0];
-            if (count > ShootoutManager::MAX_BRACKET_SIZE) break;
-            if (payloadLen < 1 + 6 * static_cast<size_t>(count)) break;
             std::vector<std::array<uint8_t, 6>> bracket;
-            bracket.reserve(count);
-            for (uint8_t i = 0; i < count; i++) {
-                std::array<uint8_t, 6> mac;
-                memcpy(mac.data(), payload + 1 + 6 * i, 6);
-                bracket.push_back(mac);
-            }
-            shootoutManager->onBracketReceived(bracket, seqId);
+            if (!decodeMacList(payload, payloadLen, bracket)) break;
+            shootoutManager->onBracketReceived(fromMac, bracket, seqId);
+            break;
+        }
+        case ShootoutCmd::RING_CLOSED: {
+            std::vector<std::array<uint8_t, 6>> members;
+            if (!decodeMacList(payload, payloadLen, members)) break;
+            shootoutManager->onRingClosedReceived(fromMac, members);
             break;
         }
         case ShootoutCmd::MATCH_START:
@@ -402,20 +423,16 @@ void Quickdraw::populateStateMap() {
             std::bind(&AwakenSequence::transitionToIdle, awakenSequence),
             idle));
 
-    // Auto-trigger Shootout when the chain closes into a loop. Priority over
-    // DuelCountdown/SupporterReady: in a closed ring, adjacent H-B pairs
-    // otherwise look like a normal duel initiation, and the ring intent
-    // (tournament) would be silently demoted to a 1v1 duel.
+    // Auto-trigger Shootout on ring closure — the coordinator's own RDC event,
+    // every other member's RING_CLOSED. Priority over DuelCountdown/
+    // SupporterReady: in a closed ring, adjacent H-B pairs otherwise look like a
+    // normal duel initiation, and the ring intent (tournament) would be silently
+    // demoted to a 1v1 duel.
     {
-        ChainDuelManager* cdm = chainDuelManager;
         ShootoutManager* shMgr = shootoutManager;
         idle->addTransition(
             new StateTransition(
-                [cdm, shMgr]() {
-                    bool loop = cdm && cdm->isLoop();
-                    bool shActive = shMgr && shMgr->active();
-                    return loop && shMgr && !shActive;
-                },
+                [shMgr]() { return shMgr && shMgr->shouldEnterProposal(); },
                 shProposal));
     }
 

--- a/src/pdn/game/quickdraw.cpp
+++ b/src/pdn/game/quickdraw.cpp
@@ -344,6 +344,7 @@ Quickdraw::~Quickdraw() {
     remoteDeviceCoordinator->setChainChangeCallback(nullptr);
     remoteDeviceCoordinator->setOnChainRoleChange(nullptr);
     remoteDeviceCoordinator->setPeerLostCallback(nullptr);
+    remoteDeviceCoordinator->setOnRingClosed(nullptr);
     remoteDeviceCoordinator = nullptr;
     for (PktType handled : {PktType::kChainGameEvent, PktType::kChainGameEventAck,
                             PktType::kChainConfirm, PktType::kChainJoin,

--- a/src/pdn/game/shootout-manager.cpp
+++ b/src/pdn/game/shootout-manager.cpp
@@ -24,12 +24,10 @@ void deriveShootoutMatchId(int matchIndex, char* out, size_t outSize) {
 
 ShootoutManager::ShootoutManager(Player* player,
                                  WirelessManager* wirelessManager,
-                                 RemoteDeviceCoordinator* rdc,
-                                 ChainDuelManager* cdm)
+                                 RemoteDeviceCoordinator* rdc)
     : player(player)
     , wirelessManager(wirelessManager)
-    , rdc(rdc)
-    , cdm(cdm) {}
+    , rdc(rdc) {}
 
 bool ShootoutManager::active() const {
     return phase != Phase::IDLE;
@@ -191,6 +189,15 @@ std::vector<std::array<uint8_t, 6>> ShootoutManager::getLoopMembers() const {
 
 void ShootoutManager::resetToIdle() {
     LOG_W(TAG, "resetToIdle from phase=%d", static_cast<int>(phase));
+    resetTournamentState();
+    // The ring anchor goes too: this is the ring-open / terminal-screen exit, and
+    // an ex-coordinator that kept the anchor would ignore the next ring's bracket.
+    memset(coordinatorMac.data(), 0, 6);
+    ringMembers.clear();
+    ringClosedRebroadcastTimer.invalidate();
+}
+
+void ShootoutManager::resetTournamentState() {
     phase = Phase::IDLE;
     confirmedSet.clear();
     bracket.clear();
@@ -210,7 +217,6 @@ void ShootoutManager::resetToIdle() {
     memset(opponentMac.data(), 0, 6);
     memset(currentDuelistA.data(), 0, 6);
     memset(currentDuelistB.data(), 0, 6);
-    memset(coordinatorMac.data(), 0, 6);
     if (originalIsHunter && player) {
         player->setIsHunter(*originalIsHunter);
     }
@@ -219,11 +225,62 @@ void ShootoutManager::resetToIdle() {
 
 void ShootoutManager::startProposal() {
     LOG_W(TAG, "startProposal");
-    resetToIdle();
+    resetTournamentState();
     if (player) {
         originalIsHunter = player->isHunter();
     }
     phase = Phase::PROPOSAL;
+}
+
+void ShootoutManager::onRingClosed() {
+    if (phase != Phase::IDLE) {
+        LOG_W(TAG, "onRingClosed ignored; phase=%d", static_cast<int>(phase));
+        return;
+    }
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
+    if (selfMac == nullptr) {
+        LOG_E(TAG, "onRingClosed with no local MAC");
+        return;
+    }
+    // No election: the RDC fires this only on the device whose own MAC came back
+    // around the ring, and that head is the coordinator by construction.
+    memcpy(coordinatorMac.data(), selfMac, 6);
+    ringMembers = getLoopMembers();
+    LOG_W(TAG, "ring closed; coordinator=self members=%zu", ringMembers.size());
+    sendRingClosed();
+}
+
+void ShootoutManager::onRingClosedReceived(
+    const uint8_t* fromMac, const std::vector<std::array<uint8_t, 6>>& members) {
+    if (phase != Phase::IDLE) return;
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
+    if (selfMac == nullptr) {
+        LOG_E(TAG, "onRingClosedReceived with no local MAC");
+        return;
+    }
+    // A broadcast reaches every ring in radio range; the roster is what says
+    // whether this closure is ours.
+    if (!containsMac(members, selfMac)) return;
+    memcpy(coordinatorMac.data(), fromMac, 6);
+    ringMembers = members;
+    LOG_W(TAG, "ring closed by %s members=%zu", MacToString(fromMac), members.size());
+}
+
+bool ShootoutManager::shouldEnterProposal() const {
+    return phase == Phase::IDLE && !ringMembers.empty();
+}
+
+void ShootoutManager::sendRingClosed() {
+    std::vector<uint8_t> packet;
+    packet.push_back(static_cast<uint8_t>(ShootoutCmd::RING_CLOSED));
+    // seqId 0: receipt is idempotent and deduped by phase, so no ack round-trip.
+    packet.push_back(0);
+    packet.push_back(static_cast<uint8_t>(ringMembers.size()));
+    for (const std::array<uint8_t, 6>& m : ringMembers) {
+        packet.insert(packet.end(), m.begin(), m.end());
+    }
+    broadcastToRing(ringMembers, packet.data(), packet.size());
+    ringClosedRebroadcastTimer.setTimer(kConfirmRebroadcastMs);
 }
 
 void ShootoutManager::confirmLocal() {
@@ -305,7 +362,11 @@ bool ShootoutManager::hasConfirmed(const uint8_t* mac) const {
 
 bool ShootoutManager::allMembersConfirmed() const {
     auto members = getLoopMembers();
-    if (members.empty()) return false;
+    // A ring is two devices at minimum. The head's roster fills from announces
+    // that can still be in flight when the ring closes, and advancing on a
+    // one-entry roster would run a solo tournament that declares this device the
+    // winner the instant it starts.
+    if (members.size() < 2) return false;
     for (const auto& m : members) {
         if (!hasConfirmed(m.data())) return false;
     }
@@ -313,8 +374,7 @@ bool ShootoutManager::allMembersConfirmed() const {
 }
 
 std::array<uint8_t, 6> ShootoutManager::getCoordinatorMac() const {
-    if (!bracket.empty()) return coordinatorMac;
-    return lowestMacIn(confirmedSet);
+    return coordinatorMac;
 }
 
 bool ShootoutManager::isCoordinator() const {
@@ -326,7 +386,6 @@ bool ShootoutManager::isCoordinator() const {
 
 void ShootoutManager::generateBracket() {
     bracket = confirmedSet;
-    coordinatorMac = lowestMacIn(bracket);
     // std::random_device is deterministic under newlib on ESP32, so seed
     // from platform clock XOR self-MAC to get real variation.
     unsigned long seed = 0;
@@ -434,6 +493,18 @@ void ShootoutManager::sendLocalConfirm() {
 }
 
 void ShootoutManager::sync() {
+    // A member that missed the closure frame stays in Idle with nothing to poll,
+    // while the coordinator waits on a confirm it will never get. Re-announce
+    // until the whole roster has confirmed; RING_CLOSED needs no ack because a
+    // repeat is a no-op once the member is out of Phase::IDLE.
+    if (phase == Phase::PROPOSAL && ringClosedRebroadcastTimer.expired() &&
+        isCoordinator() && !allMembersConfirmed()) {
+        // Re-read the roster: a member whose announce to the head was still in
+        // flight at closure only appears in it now.
+        ringMembers = getLoopMembers();
+        sendRingClosed();
+    }
+
     // Check cheap conditions before allMembersConfirmed(), which rebuilds the
     // loop-member set each call.
     if (phase == Phase::PROPOSAL && confirmRebroadcastTimer.expired()) {
@@ -600,31 +671,39 @@ void ShootoutManager::maybeStartNextMatch() {
     phase = Phase::MATCH_IN_PROGRESS;
 }
 
-std::array<uint8_t, 6> ShootoutManager::lowestMacIn(
-    const std::vector<std::array<uint8_t, 6>>& set) {
-    std::array<uint8_t, 6> lowest = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    for (const auto& m : set) {
-        if (memcmp(m.data(), lowest.data(), 6) < 0) lowest = m;
-    }
-    return lowest;
-}
-
 void ShootoutManager::onBracketReceived(
-    const std::vector<std::array<uint8_t, 6>>& offeredBracket, uint8_t seqId) {
-    if (isCoordinator()) return;
+    const uint8_t* fromMac, const std::vector<std::array<uint8_t, 6>>& offeredBracket,
+    uint8_t seqId) {
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
+    if (isCoordinator()) {
+        // Merge-collision tiebreaker: two rings that each closed and claimed a
+        // head can be cabled together after both claimed. Lower MAC owns the
+        // merged tournament, so a bracket from below us demotes this device into
+        // a follower — dropping the self-built bracket, not just the anchor, or
+        // both sides keep running their own (split brain).
+        if (selfMac == nullptr || memcmp(fromMac, selfMac, 6) >= 0) return;
+        LOG_W(TAG, "coordinator stand-down to %s", MacToString(fromMac));
+        memset(coordinatorMac.data(), 0, 6);
+        bracket.clear();
+        currentRound.clear();
+        eliminated.clear();
+        bracketPendingAcks.clear();
+        matchStartPendingAcks.clear();
+        currentMatchIndex = -1;
+        reportedLocalWin = false;
+    }
     // A broadcast bracket reaches every ring in radio range; the roster itself
     // says whether it is ours. Ack nothing we are not part of, or a neighbouring
     // ring's coordinator would count us as one of its members.
-    if (!containsMac(offeredBracket, wirelessManager->getMacAddress())) return;
+    if (!containsMac(offeredBracket, selfMac)) return;
     if (seqId != 0 && seqId == lastObservedBracketSeqId) {
-        std::array<uint8_t, 6> coord = lowestMacIn(offeredBracket);
-        sendShootoutAck(ShootoutCmd::BRACKET, seqId, coord.data());
+        sendShootoutAck(ShootoutCmd::BRACKET, seqId, fromMac);
         return;
     }
     lastObservedBracketSeqId = seqId;
     bracket = offeredBracket;
     currentRound = offeredBracket;
-    coordinatorMac = lowestMacIn(bracket);
+    memcpy(coordinatorMac.data(), fromMac, 6);
     phase = Phase::BRACKET_REVEAL;
     bracketRevealTimer.setTimer(kBracketRevealMs);
     sendShootoutAck(ShootoutCmd::BRACKET, seqId, coordinatorMac.data());
@@ -800,26 +879,19 @@ void ShootoutManager::onAbortReceived(const uint8_t* fromMac) {
 }
 
 std::vector<std::array<uint8_t, 6>> ShootoutManager::buildLoopMemberSet() const {
-    if (!cdm->isLoop()) return {};
+    // The RDC serves a roster only where it is the authority, which inside a ring
+    // is the head that latched it. Everyone else holds the copy that head sent
+    // with RING_CLOSED rather than re-deriving the ring from its own two jacks.
+    if (rdc == nullptr || rdc->getChainRole() != ChainRole::RING) return ringMembers;
 
-    std::vector<std::array<uint8_t, 6>> out;
-    auto addUnique = [&out](const uint8_t* mac) {
-        if (mac == nullptr || containsMac(out, mac)) return;
-        std::array<uint8_t, 6> copy;
-        memcpy(copy.data(), mac, 6);
-        out.push_back(copy);
-    };
-
-    addUnique(wirelessManager->getMacAddress());
-    addUnique(rdc->getPeerMac(SerialIdentifier::OUTPUT_JACK));
-    addUnique(rdc->getPeerMac(SerialIdentifier::INPUT_JACK));
-
-    for (auto jack : {SerialIdentifier::OUTPUT_JACK, SerialIdentifier::INPUT_JACK}) {
-        PortState state = rdc->getPortState(jack);
-        for (const auto& peer : state.peerMacAddresses) {
-            addUnique(peer.data());
-        }
+    std::vector<std::array<uint8_t, 6>> members = rdc->getChainMembers();
+    // getChainMembers() enumerates the devices that announced to the head, never
+    // the head itself, and the coordinator is a participant like any other.
+    const uint8_t* selfMac = wirelessManager->getMacAddress();
+    if (selfMac != nullptr && !containsMac(members, selfMac)) {
+        std::array<uint8_t, 6> self;
+        memcpy(self.data(), selfMac, 6);
+        members.push_back(self);
     }
-
-    return out;
+    return members;
 }

--- a/src/pdn/game/shootout-manager.cpp
+++ b/src/pdn/game/shootout-manager.cpp
@@ -488,6 +488,17 @@ void ShootoutManager::sendLocalConfirm() {
 }
 
 void ShootoutManager::sync() {
+    // An abort that came from retry exhaustion or an inbound ABORT drops the ring
+    // anchor while the cables are untouched, and the RDC latch is edge-triggered
+    // so it never fires again. Without this the whole ring sits idle until
+    // somebody unplugs. Only the coordinator latches RING — the RDC sets it on
+    // the device whose own MAC came back around — so this re-claims on exactly
+    // one device, and the members follow its re-announce.
+    if (phase == Phase::IDLE && ringMembers.empty() && rdc != nullptr &&
+        rdc->getChainRole() == ChainRole::RING) {
+        onRingClosed();
+    }
+
     // A member that missed the closure frame stays in Idle with nothing to poll,
     // while the coordinator waits on a confirm it will never get. No ack needed:
     // a repeat is a no-op once the member is out of Phase::IDLE.
@@ -666,16 +677,36 @@ void ShootoutManager::maybeStartNextMatch() {
     phase = Phase::MATCH_IN_PROGRESS;
 }
 
+// True when the two rosters name at least one device in common.
+static bool sharesAnyMember(const std::vector<std::array<uint8_t, 6>>& a,
+                            const std::vector<std::array<uint8_t, 6>>& b) {
+    for (const std::array<uint8_t, 6>& entry : a) {
+        for (const std::array<uint8_t, 6>& other : b) {
+            if (memcmp(entry.data(), other.data(), 6) == 0) return true;
+        }
+    }
+    return false;
+}
+
 void ShootoutManager::onBracketReceived(
     const uint8_t* fromMac, const std::vector<std::array<uint8_t, 6>>& offeredBracket,
     uint8_t seqId) {
     const uint8_t* selfMac = wirelessManager->getMacAddress();
+    // BRACKET is a broadcast, so a tournament two rings away lands here too.
+    // Anything that neither names us nor overlaps our own bracket is somebody
+    // else's and must not touch our state — the stand-down below wipes the
+    // tournament, and nothing re-runs it once the phase has left IDLE.
+    const bool concernsUs =
+        containsMac(offeredBracket, selfMac) || sharesAnyMember(offeredBracket, bracket);
+    if (!concernsUs) return;
     if (isCoordinator()) {
         // Merge-collision tiebreaker: two rings that each closed and claimed a
         // head can be cabled together after both claimed. Lower MAC owns the
         // merged tournament, so a bracket from below us demotes this device into
         // a follower — dropping the self-built bracket, not just the anchor, or
-        // both sides keep running their own (split brain).
+        // both sides keep running their own (split brain). Overlap is what tells
+        // a merge from a stranger: merged rings share the members whose cables
+        // joined them.
         if (selfMac == nullptr || memcmp(fromMac, selfMac, 6) >= 0) return;
         LOG_W(TAG, "coordinator stand-down to %s", MacToString(fromMac));
         memset(coordinatorMac.data(), 0, 6);

--- a/src/pdn/game/shootout-manager.cpp
+++ b/src/pdn/game/shootout-manager.cpp
@@ -190,8 +190,8 @@ std::vector<std::array<uint8_t, 6>> ShootoutManager::getLoopMembers() const {
 void ShootoutManager::resetToIdle() {
     LOG_W(TAG, "resetToIdle from phase=%d", static_cast<int>(phase));
     resetTournamentState();
-    // The ring anchor goes too: this is the ring-open / terminal-screen exit, and
-    // an ex-coordinator that kept the anchor would ignore the next ring's bracket.
+    // Ring-open / terminal-screen exit: an ex-coordinator that kept the anchor
+    // would ignore the next ring's bracket.
     memset(coordinatorMac.data(), 0, 6);
     ringMembers.clear();
     ringClosedRebroadcastTimer.invalidate();
@@ -271,14 +271,8 @@ bool ShootoutManager::shouldEnterProposal() const {
 }
 
 void ShootoutManager::sendRingClosed() {
-    std::vector<uint8_t> packet;
-    packet.push_back(static_cast<uint8_t>(ShootoutCmd::RING_CLOSED));
     // seqId 0: receipt is idempotent and deduped by phase, so no ack round-trip.
-    packet.push_back(0);
-    packet.push_back(static_cast<uint8_t>(ringMembers.size()));
-    for (const std::array<uint8_t, 6>& m : ringMembers) {
-        packet.insert(packet.end(), m.begin(), m.end());
-    }
+    std::vector<uint8_t> packet = buildMacListPacket(ShootoutCmd::RING_CLOSED, 0, ringMembers);
     broadcastToRing(ringMembers, packet.data(), packet.size());
     ringClosedRebroadcastTimer.setTimer(kConfirmRebroadcastMs);
 }
@@ -362,10 +356,8 @@ bool ShootoutManager::hasConfirmed(const uint8_t* mac) const {
 
 bool ShootoutManager::allMembersConfirmed() const {
     auto members = getLoopMembers();
-    // A ring is two devices at minimum. The head's roster fills from announces
-    // that can still be in flight when the ring closes, and advancing on a
-    // one-entry roster would run a solo tournament that declares this device the
-    // winner the instant it starts.
+    // Roster announces can still be in flight when the ring closes; a one-entry
+    // roster would run a solo tournament this device wins the instant it starts.
     if (members.size() < 2) return false;
     for (const auto& m : members) {
         if (!hasConfirmed(m.data())) return false;
@@ -436,12 +428,14 @@ unsigned long ShootoutManager::ackTimeoutForRetry(uint8_t retries) {
     return kAckBackoffMs[retries];
 }
 
-std::vector<uint8_t> ShootoutManager::buildBracketPacket() const {
+std::vector<uint8_t> ShootoutManager::buildMacListPacket(
+    ShootoutCmd cmd, uint8_t seqId,
+    const std::vector<std::array<uint8_t, 6>>& macs) const {
     std::vector<uint8_t> packet;
-    packet.push_back(static_cast<uint8_t>(ShootoutCmd::BRACKET));
-    packet.push_back(lastBracketSeqId);
-    packet.push_back(static_cast<uint8_t>(bracket.size()));
-    for (const auto& m : bracket) {
+    packet.push_back(static_cast<uint8_t>(cmd));
+    packet.push_back(seqId);
+    packet.push_back(static_cast<uint8_t>(macs.size()));
+    for (const std::array<uint8_t, 6>& m : macs) {
         packet.insert(packet.end(), m.begin(), m.end());
     }
     return packet;
@@ -450,7 +444,8 @@ std::vector<uint8_t> ShootoutManager::buildBracketPacket() const {
 void ShootoutManager::sendBracketToPeers() {
     if (bracket.empty()) return;
     lastBracketSeqId = nextSeqId();
-    auto packet = buildBracketPacket();
+    std::vector<uint8_t> packet =
+        buildMacListPacket(ShootoutCmd::BRACKET, lastBracketSeqId, bracket);
     sendReliablyToPeers(bracketPendingAcks, bracket, packet.data(), packet.size());
 }
 
@@ -494,9 +489,8 @@ void ShootoutManager::sendLocalConfirm() {
 
 void ShootoutManager::sync() {
     // A member that missed the closure frame stays in Idle with nothing to poll,
-    // while the coordinator waits on a confirm it will never get. Re-announce
-    // until the whole roster has confirmed; RING_CLOSED needs no ack because a
-    // repeat is a no-op once the member is out of Phase::IDLE.
+    // while the coordinator waits on a confirm it will never get. No ack needed:
+    // a repeat is a no-op once the member is out of Phase::IDLE.
     if (phase == Phase::PROPOSAL && ringClosedRebroadcastTimer.expired() &&
         isCoordinator() && !allMembersConfirmed()) {
         // Re-read the roster: a member whose announce to the head was still in
@@ -515,7 +509,8 @@ void ShootoutManager::sync() {
     }
 
     if (!bracketPendingAcks.empty()) {
-        std::vector<uint8_t> packet = buildBracketPacket();
+        std::vector<uint8_t> packet =
+            buildMacListPacket(ShootoutCmd::BRACKET, lastBracketSeqId, bracket);
         // A member that never acks the bracket would sit out the tournament it
         // is physically wired into, so an exhausted budget aborts rather than
         // dropping that member.
@@ -880,8 +875,8 @@ void ShootoutManager::onAbortReceived(const uint8_t* fromMac) {
 
 std::vector<std::array<uint8_t, 6>> ShootoutManager::buildLoopMemberSet() const {
     // The RDC serves a roster only where it is the authority, which inside a ring
-    // is the head that latched it. Everyone else holds the copy that head sent
-    // with RING_CLOSED rather than re-deriving the ring from its own two jacks.
+    // is the head that latched it. Every other member holds the copy that head
+    // sent with RING_CLOSED.
     if (rdc == nullptr || rdc->getChainRole() != ChainRole::RING) return ringMembers;
 
     std::vector<std::array<uint8_t, 6>> members = rdc->getChainMembers();

--- a/src/pdn/game/shootout-manager.cpp
+++ b/src/pdn/game/shootout-manager.cpp
@@ -226,6 +226,18 @@ void ShootoutManager::resetTournamentState() {
 void ShootoutManager::startProposal() {
     LOG_W(TAG, "startProposal");
     resetTournamentState();
+    // An abort clears the anchor while the cables stay put, and the RDC latch is
+    // edge-triggered, so a ring that is still closed will never announce itself
+    // again. Re-make the claim here instead of waiting for an edge that is spent.
+    if (ringMembers.empty() && rdc != nullptr && rdc->getChainRole() == ChainRole::RING) {
+        const uint8_t* selfMac = wirelessManager->getMacAddress();
+        if (selfMac != nullptr) {
+            memcpy(coordinatorMac.data(), selfMac, 6);
+            ringMembers = getLoopMembers();
+            LOG_W(TAG, "ring still closed; re-claiming members=%zu", ringMembers.size());
+            sendRingClosed();
+        }
+    }
     if (player) {
         originalIsHunter = player->isHunter();
     }
@@ -242,8 +254,10 @@ void ShootoutManager::onRingClosed() {
         LOG_E(TAG, "onRingClosed with no local MAC");
         return;
     }
-    // No election: the RDC fires this only on the device whose own MAC came back
-    // around the ring, and that head is the coordinator by construction.
+    // No election: the RDC fires this on the device whose own MAC came back around
+    // the ring, and that head is the coordinator by construction. Two heads can
+    // hold that claim at once while a merge settles — onRingClosedReceived breaks
+    // the tie.
     memcpy(coordinatorMac.data(), selfMac, 6);
     ringMembers = getLoopMembers();
     LOG_W(TAG, "ring closed; coordinator=self members=%zu", ringMembers.size());
@@ -261,13 +275,23 @@ void ShootoutManager::onRingClosedReceived(
     // A broadcast reaches every ring in radio range; the roster is what says
     // whether this closure is ours.
     if (!containsMac(members, selfMac)) return;
+    // Both heads of a merging pair latch and both announce, so an unconditional
+    // adopt has A following B while B follows A and the ring runs with no
+    // coordinator at all — nothing generates a bracket and every member parks in
+    // BracketReveal. Same rule as the bracket stand-down: lower MAC owns the ring.
+    if (isCoordinator() && memcmp(fromMac, selfMac, 6) >= 0) return;
     memcpy(coordinatorMac.data(), fromMac, 6);
     ringMembers = members;
     LOG_W(TAG, "ring closed by %s members=%zu", MacToString(fromMac), members.size());
 }
 
 bool ShootoutManager::shouldEnterProposal() const {
-    return phase == Phase::IDLE && !ringMembers.empty();
+    if (phase != Phase::IDLE) return false;
+    // ringMembers is the copy RING_CLOSED leaves on a member. A coordinator that
+    // has been reset holds none, so the live RDC role is what re-opens the door
+    // there — a latched copy alone would keep a still-cabled ring shut forever.
+    if (!ringMembers.empty()) return true;
+    return rdc != nullptr && rdc->getChainRole() == ChainRole::RING;
 }
 
 void ShootoutManager::sendRingClosed() {
@@ -434,9 +458,18 @@ std::vector<uint8_t> ShootoutManager::buildMacListPacket(
     std::vector<uint8_t> packet;
     packet.push_back(static_cast<uint8_t>(cmd));
     packet.push_back(seqId);
-    packet.push_back(static_cast<uint8_t>(macs.size()));
-    for (const std::array<uint8_t, 6>& m : macs) {
-        packet.insert(packet.end(), m.begin(), m.end());
+    // The roster is the RDC's 64 plus self, so it can land one over what the
+    // decoder accepts — and an over-long frame is dropped by every receiver, not
+    // just the members past the cap. Truncating keeps the ring running.
+    size_t count = macs.size();
+    if (count > MAX_BRACKET_SIZE) {
+        LOG_E(TAG, "mac list %zu over cap %u; truncating", count,
+              static_cast<unsigned>(MAX_BRACKET_SIZE));
+        count = MAX_BRACKET_SIZE;
+    }
+    packet.push_back(static_cast<uint8_t>(count));
+    for (size_t i = 0; i < count; i++) {
+        packet.insert(packet.end(), macs[i].begin(), macs[i].end());
     }
     return packet;
 }
@@ -488,17 +521,6 @@ void ShootoutManager::sendLocalConfirm() {
 }
 
 void ShootoutManager::sync() {
-    // An abort that came from retry exhaustion or an inbound ABORT drops the ring
-    // anchor while the cables are untouched, and the RDC latch is edge-triggered
-    // so it never fires again. Without this the whole ring sits idle until
-    // somebody unplugs. Only the coordinator latches RING — the RDC sets it on
-    // the device whose own MAC came back around — so this re-claims on exactly
-    // one device, and the members follow its re-announce.
-    if (phase == Phase::IDLE && ringMembers.empty() && rdc != nullptr &&
-        rdc->getChainRole() == ChainRole::RING) {
-        onRingClosed();
-    }
-
     // A member that missed the closure frame stays in Idle with nothing to poll,
     // while the coordinator waits on a confirm it will never get. No ack needed:
     // a repeat is a no-op once the member is out of Phase::IDLE.
@@ -677,36 +699,21 @@ void ShootoutManager::maybeStartNextMatch() {
     phase = Phase::MATCH_IN_PROGRESS;
 }
 
-// True when the two rosters name at least one device in common.
-static bool sharesAnyMember(const std::vector<std::array<uint8_t, 6>>& a,
-                            const std::vector<std::array<uint8_t, 6>>& b) {
-    for (const std::array<uint8_t, 6>& entry : a) {
-        for (const std::array<uint8_t, 6>& other : b) {
-            if (memcmp(entry.data(), other.data(), 6) == 0) return true;
-        }
-    }
-    return false;
-}
-
 void ShootoutManager::onBracketReceived(
     const uint8_t* fromMac, const std::vector<std::array<uint8_t, 6>>& offeredBracket,
     uint8_t seqId) {
     const uint8_t* selfMac = wirelessManager->getMacAddress();
-    // BRACKET is a broadcast, so a tournament two rings away lands here too.
-    // Anything that neither names us nor overlaps our own bracket is somebody
-    // else's and must not touch our state — the stand-down below wipes the
-    // tournament, and nothing re-runs it once the phase has left IDLE.
-    const bool concernsUs =
-        containsMac(offeredBracket, selfMac) || sharesAnyMember(offeredBracket, bracket);
-    if (!concernsUs) return;
+    // BRACKET is a broadcast, so a tournament two rings away lands here too, and
+    // the roster is the only thing that says whether this one is ours. Ahead of
+    // the stand-down, not after it: standing down on a bracket we are not in
+    // drops our own and adopts nothing, and no phase past IDLE re-runs the claim.
+    if (!containsMac(offeredBracket, selfMac)) return;
     if (isCoordinator()) {
         // Merge-collision tiebreaker: two rings that each closed and claimed a
         // head can be cabled together after both claimed. Lower MAC owns the
         // merged tournament, so a bracket from below us demotes this device into
         // a follower — dropping the self-built bracket, not just the anchor, or
-        // both sides keep running their own (split brain). Overlap is what tells
-        // a merge from a stranger: merged rings share the members whose cables
-        // joined them.
+        // both sides keep running their own (split brain).
         if (selfMac == nullptr || memcmp(fromMac, selfMac, 6) >= 0) return;
         LOG_W(TAG, "coordinator stand-down to %s", MacToString(fromMac));
         memset(coordinatorMac.data(), 0, 6);
@@ -718,10 +725,6 @@ void ShootoutManager::onBracketReceived(
         currentMatchIndex = -1;
         reportedLocalWin = false;
     }
-    // A broadcast bracket reaches every ring in radio range; the roster itself
-    // says whether it is ours. Ack nothing we are not part of, or a neighbouring
-    // ring's coordinator would count us as one of its members.
-    if (!containsMac(offeredBracket, selfMac)) return;
     if (seqId != 0 && seqId == lastObservedBracketSeqId) {
         sendShootoutAck(ShootoutCmd::BRACKET, seqId, fromMac);
         return;

--- a/src/pdn/game/shootout-manager.hpp
+++ b/src/pdn/game/shootout-manager.hpp
@@ -5,7 +5,6 @@
 #include <optional>
 #include <vector>
 #include "game/player.hpp"
-#include "game/chain-duel-manager.hpp"
 #include "device/remote-device-coordinator.hpp"
 #include "device/drivers/peer-comms-types.hpp"
 #include "device/wireless-manager.hpp"
@@ -30,8 +29,7 @@ public:
 
     ShootoutManager(Player* player,
                     WirelessManager* wirelessManager,
-                    RemoteDeviceCoordinator* rdc,
-                    ChainDuelManager* cdm);
+                    RemoteDeviceCoordinator* rdc);
     ~ShootoutManager() = default;
 
     /// Optional MatchManager injection. When set, Shootout primes the
@@ -48,6 +46,18 @@ public:
 
     // Test-only: override the loop-member set. Pass an empty vector to clear.
     void setLoopMembersForTest(const std::vector<std::array<uint8_t, 6>>& members);
+
+    /// RDC ring-closed observer. The head that detected closure IS the
+    /// coordinator — there is no election — so this claims the role, snapshots
+    /// the ring roster and announces it to the other members.
+    void onRingClosed();
+    /// Inbound RING_CLOSED: adopt `fromMac` as coordinator and `members` as the
+    /// ring roster. The only proposal trigger a non-coordinator has.
+    void onRingClosedReceived(const uint8_t* fromMac,
+                              const std::vector<std::array<uint8_t, 6>>& members);
+    /// True once a ring closure has been observed and no tournament is running:
+    /// the Idle -> ShootoutProposal transition predicate.
+    bool shouldEnterProposal() const;
 
     void startProposal();
     void confirmLocal();
@@ -75,8 +85,11 @@ public:
     std::pair<std::array<uint8_t,6>, std::array<uint8_t,6>> getCurrentMatchPair() const;
     void onMatchStartAckReceived(const uint8_t* fromMac, uint8_t seqId);
 
-    /// Adopts a bracket announced by the coordinator and acks it.
-    void onBracketReceived(const std::vector<std::array<uint8_t, 6>>& offeredBracket,
+    /// Adopts a bracket announced by the coordinator and acks it. A bracket from
+    /// a lower-MAC coordinator also demotes this device (see the merge-collision
+    /// stand-down in the implementation).
+    void onBracketReceived(const uint8_t* fromMac,
+                           const std::vector<std::array<uint8_t, 6>>& offeredBracket,
                            uint8_t seqId);
     void onMatchStartReceived(const uint8_t* duelistA, const uint8_t* duelistB,
                               uint8_t matchIndex, uint8_t seqId);
@@ -142,11 +155,14 @@ private:
     Player* player;
     WirelessManager* wirelessManager;
     RemoteDeviceCoordinator* rdc;
-    ChainDuelManager* cdm;
     MatchManager* matchManager = nullptr;
     Phase phase = Phase::IDLE;
 
     void primeMatchManagerForMatch();
+    // Wipes everything scoped to one tournament. resetToIdle() adds the ring
+    // anchor on top; startProposal() does not, because the ring closure that
+    // drove the mount established that anchor moments earlier.
+    void resetTournamentState();
 
     uint8_t nextSeqId();
     static bool containsMac(const std::vector<std::array<uint8_t, 6>>& set,
@@ -174,6 +190,13 @@ private:
     bool testLoopMembersOverride = false;
     std::vector<std::array<uint8_t, 6>> confirmedSet;
 
+    // The ring roster as of closure. Read live from the RDC on the coordinator
+    // (the only device served a roster) and taken from its RING_CLOSED on every
+    // other member. Non-empty is also the "a ring closed" latch.
+    std::vector<std::array<uint8_t, 6>> ringMembers;
+    SimpleTimer ringClosedRebroadcastTimer;
+    void sendRingClosed();
+
     std::vector<NameEntry> names;
     void recordName(const uint8_t* mac, const char* name);
 
@@ -198,11 +221,9 @@ private:
 
     void sendBracketToPeers();
     std::vector<uint8_t> buildBracketPacket() const;
-    static std::array<uint8_t, 6> lowestMacIn(
-        const std::vector<std::array<uint8_t, 6>>& set);
 
-    // Stable post-bracket-formation. Used in place of lowestMacIn(bracket)
-    // which would otherwise rescan the bracket on every ack path.
+    // Anchored at ring closure: self on the head that detected it, the sender on
+    // every other member. All-zero means no ring has closed yet.
     std::array<uint8_t, 6> coordinatorMac{};
 
     std::array<uint8_t, 6> opponentMac{};

--- a/src/pdn/game/shootout-manager.hpp
+++ b/src/pdn/game/shootout-manager.hpp
@@ -86,8 +86,7 @@ public:
     void onMatchStartAckReceived(const uint8_t* fromMac, uint8_t seqId);
 
     /// Adopts a bracket announced by the coordinator and acks it. A bracket from
-    /// a lower-MAC coordinator also demotes this device (see the merge-collision
-    /// stand-down in the implementation).
+    /// a lower-MAC coordinator also demotes this device.
     void onBracketReceived(const uint8_t* fromMac,
                            const std::vector<std::array<uint8_t, 6>>& offeredBracket,
                            uint8_t seqId);
@@ -159,9 +158,9 @@ private:
     Phase phase = Phase::IDLE;
 
     void primeMatchManagerForMatch();
-    // Wipes everything scoped to one tournament. resetToIdle() adds the ring
-    // anchor on top; startProposal() does not, because the ring closure that
-    // drove the mount established that anchor moments earlier.
+    // resetToIdle() clears the ring anchor on top of this; startProposal() does
+    // not, because the ring closure that drove the mount established it moments
+    // earlier.
     void resetTournamentState();
 
     uint8_t nextSeqId();
@@ -220,7 +219,11 @@ private:
     static constexpr uint8_t kMaxShootoutAckRetries = 3;
 
     void sendBracketToPeers();
-    std::vector<uint8_t> buildBracketPacket() const;
+    // [cmd, seqId, count, count * 6-byte MAC] — the frame BRACKET and
+    // RING_CLOSED share.
+    std::vector<uint8_t> buildMacListPacket(
+        ShootoutCmd cmd, uint8_t seqId,
+        const std::vector<std::array<uint8_t, 6>>& macs) const;
 
     // Anchored at ring closure: self on the head that detected it, the sender on
     // every other member. All-zero means no ring has closed yet.

--- a/test/test_core/chain-duel-multi-device-fixture.hpp
+++ b/test/test_core/chain-duel-multi-device-fixture.hpp
@@ -127,9 +127,8 @@ public:
                                                           node->device->wirelessManager,
                                                           node->rdc.get());
             node->shootout = std::make_unique<ShootoutManager>(node->player.get(),
-                                                              node->device->wirelessManager,
-                                                              node->rdc.get(),
-                                                              node->cdm.get());
+                                                               node->device->wirelessManager,
+                                                               node->rdc.get());
             wireChainEventHandlers(*node);
             wireShootoutHandlers(*node);
 
@@ -201,6 +200,28 @@ public:
         for (size_t round = 0; round < nodes.size() + 8; ++round) {
             pumpHelloCycle();
             fakeClock->advance(RemoteDeviceCoordinator::HELLO_CADENCE_MS);
+        }
+    }
+
+    /// Ring closure the way production delivers it: the RDC fires its head-only
+    /// ring-closed callback on one node, which claims coordinator and announces
+    /// the roster; every other node enters proposal on that broadcast, where the
+    /// Idle -> ShootoutProposal transition mounts the state.
+    ///
+    /// The head's roster is injected because this fixture drives the legacy
+    /// serial handshake, which never latches the RDC ring that would serve one.
+    void claimRingOn(size_t headIndex) {
+        std::vector<std::array<uint8_t, 6>> roster;
+        for (auto& n : nodes) {
+            std::array<uint8_t, 6> mac;
+            memcpy(mac.data(), n->mac, 6);
+            roster.push_back(mac);
+        }
+        nodes[headIndex]->shootout->setLoopMembersForTest(roster);
+        nodes[headIndex]->shootout->onRingClosed();
+        deliverAllPackets();
+        for (auto& n : nodes) {
+            if (n->shootout->shouldEnterProposal()) n->shootout->startProposal();
         }
     }
 
@@ -459,17 +480,22 @@ protected:
                         m->onConfirmReceived(payload, name);
                         break;
                     }
-                    case ShootoutCmd::BRACKET: {
+                    case ShootoutCmd::BRACKET:
+                    case ShootoutCmd::RING_CLOSED: {
                         if (payloadLen < 1) break;
                         uint8_t count = payload[0];
                         if (payloadLen < 1 + 6u * static_cast<size_t>(count)) break;
-                        std::vector<std::array<uint8_t, 6>> bracket;
+                        std::vector<std::array<uint8_t, 6>> macs;
                         for (uint8_t i = 0; i < count; i++) {
                             std::array<uint8_t, 6> mac;
                             memcpy(mac.data(), payload + 1 + 6 * i, 6);
-                            bracket.push_back(mac);
+                            macs.push_back(mac);
                         }
-                        m->onBracketReceived(bracket, seqId);
+                        if (cmd == ShootoutCmd::BRACKET) {
+                            m->onBracketReceived(fromMac, macs, seqId);
+                        } else {
+                            m->onRingClosedReceived(fromMac, macs);
+                        }
                         break;
                     }
                     case ShootoutCmd::MATCH_START:
@@ -714,12 +740,12 @@ inline void shootoutFourDeviceConsensusAndMatchStart(ChainDuelMultiDeviceFixture
             << "node " << i << " does not see loop";
     }
 
-    // In the real flow, ShootoutProposal::onStateMounted calls startProposal
-    // when the Idle→ShootoutProposal transition fires. Simulate that here
-    // before dispatching button presses (confirmLocal).
+    suite->claimRingOn(0);
     for (size_t i = 0; i < suite->nodeCount(); ++i) {
-        suite->node(i).shootout->startProposal();
+        EXPECT_EQ(suite->node(i).shootout->getPhase(), ShootoutManager::Phase::PROPOSAL)
+            << "node " << i << " missed the ring-closed broadcast";
     }
+    EXPECT_TRUE(suite->node(0).shootout->isCoordinator());
 
     // Each device confirms. After four confirms propagate, every device
     // should reach BRACKET_REVEAL; the coordinator generates+broadcasts
@@ -775,9 +801,7 @@ inline void shootoutFourDeviceFullTournament(ChainDuelMultiDeviceFixture* suite)
     suite->deliverAllPackets();
     suite->closeRing();
 
-    for (size_t i = 0; i < suite->nodeCount(); ++i) {
-        suite->node(i).shootout->startProposal();
-    }
+    suite->claimRingOn(0);
     for (size_t i = 0; i < suite->nodeCount(); ++i) {
         suite->node(i).shootout->confirmLocal();
         suite->deliverAllPackets();
@@ -863,9 +887,7 @@ inline void shootoutEightDeviceFullTournament(ChainDuelMultiDeviceFixture* suite
         suite->node(i).player->setName(kNames[i]);
     }
 
-    for (size_t i = 0; i < suite->nodeCount(); ++i) {
-        suite->node(i).shootout->startProposal();
-    }
+    suite->claimRingOn(0);
     for (size_t i = 0; i < suite->nodeCount(); ++i) {
         suite->node(i).shootout->confirmLocal();
         suite->deliverAllPackets();
@@ -932,9 +954,7 @@ inline void shootoutFourDeviceTwoTournamentsBackToBack(ChainDuelMultiDeviceFixtu
     suite->closeRing();
 
     auto runOne = [&]() {
-        for (size_t i = 0; i < suite->nodeCount(); ++i) {
-            suite->node(i).shootout->startProposal();
-        }
+        suite->claimRingOn(0);
         for (size_t i = 0; i < suite->nodeCount(); ++i) {
             suite->node(i).shootout->confirmLocal();
             suite->deliverAllPackets();
@@ -952,7 +972,10 @@ inline void shootoutFourDeviceTwoTournamentsBackToBack(ChainDuelMultiDeviceFixtu
         for (int m = 0; m < 6; ++m) {
             int duelistIdx = -1;
             for (size_t i = 0; i < suite->nodeCount(); ++i) {
-                if (suite->node(i).shootout->isLocalDuelist()) { duelistIdx = (int)i; break; }
+                if (suite->node(i).shootout->isLocalDuelist()) {
+                    duelistIdx = (int)i;
+                    break;
+                }
             }
             if (duelistIdx < 0) break;
             suite->node(duelistIdx).shootout->reportLocalWin();
@@ -963,7 +986,8 @@ inline void shootoutFourDeviceTwoTournamentsBackToBack(ChainDuelMultiDeviceFixtu
             bool anyEnded = false;
             for (size_t i = 0; i < suite->nodeCount(); ++i) {
                 if (suite->node(i).shootout->getPhase() == ShootoutManager::Phase::ENDED) {
-                    anyEnded = true; break;
+                    anyEnded = true;
+                    break;
                 }
             }
             if (anyEnded) break;
@@ -989,12 +1013,15 @@ inline void shootoutFourDeviceTwoTournamentsBackToBack(ChainDuelMultiDeviceFixtu
     for (size_t i = 0; i < suite->nodeCount(); ++i) {
         ASSERT_TRUE(suite->node(i).cdm->isLoop())
             << "post-reset loop broken on node " << i;
+    }
+
+    // Run tournament 2. runOne re-claims the ring, which is what re-seeds the
+    // loop-member set that resetToIdle just dropped.
+    int matchesTwo = runOne();
+    for (size_t i = 0; i < suite->nodeCount(); ++i) {
         ASSERT_EQ(suite->node(i).shootout->getLoopMembers().size(), 4u)
             << "loop members wrong on node " << i;
     }
-
-    // Run tournament 2.
-    int matchesTwo = runOne();
     EXPECT_EQ(matchesTwo, 3) << "tournament 2 did not run 3 matches";
     for (size_t i = 0; i < suite->nodeCount(); ++i) {
         EXPECT_EQ(suite->node(i).shootout->getPhase(), ShootoutManager::Phase::ENDED)

--- a/test/test_core/chain-duel-multi-device-fixture.hpp
+++ b/test/test_core/chain-duel-multi-device-fixture.hpp
@@ -203,10 +203,8 @@ public:
         }
     }
 
-    /// Ring closure the way production delivers it: the RDC fires its head-only
-    /// ring-closed callback on one node, which claims coordinator and announces
-    /// the roster; every other node enters proposal on that broadcast, where the
-    /// Idle -> ShootoutProposal transition mounts the state.
+    /// Ring closure the way production delivers it: the head's RDC callback, the
+    /// roster broadcast, then each member's Idle -> ShootoutProposal mount.
     ///
     /// The head's roster is injected because this fixture drives the legacy
     /// serial handshake, which never latches the RDC ring that would serve one.

--- a/test/test_core/device-mock.hpp
+++ b/test/test_core/device-mock.hpp
@@ -246,6 +246,19 @@ private:
     bool isLoop_ = true;
 };
 
+// Stand-in RDC reporting a latched ring plus a head roster without driving the
+// HELLO stack. Only the chain surface ShootoutManager reads is overridden.
+class FakeRingRemoteDeviceCoordinator : public RemoteDeviceCoordinator {
+public:
+    /// The role this stand-in reports; RING by default.
+    ChainRole getChainRole() const override { return chainRole; }
+    /// The roster this stand-in serves, as a real head's RDC would.
+    std::vector<std::array<uint8_t, 6>> getChainMembers() const override { return chainMembers; }
+
+    ChainRole chainRole = ChainRole::RING;
+    std::vector<std::array<uint8_t, 6>> chainMembers;
+};
+
 // Fake QuickdrawWirelessManager that captures outbound packets instead of transmitting them.
 // Call deliverLastTo() to route the most-recently-captured packet to another manager's
 // processQuickdrawCommand(), exercising the real serialization/deserialization path.

--- a/test/test_core/quickdraw-tests.hpp
+++ b/test/test_core/quickdraw-tests.hpp
@@ -1330,8 +1330,7 @@ inline void duelReceivedResultDebouncesTransientDisconnect(StateCleanupTests* su
 // must be required instead.
 inline void countdownFreezesDisconnectDebounceDuringShootout(StateCleanupTests* suite) {
     ShootoutManager shootout(suite->player, suite->device.wirelessManager,
-                             &suite->device.fakeRemoteDeviceCoordinator,
-                             suite->chainDuelManager);
+                             &suite->device.fakeRemoteDeviceCoordinator);
     shootout.startProposal();
     ASSERT_TRUE(shootout.active());
     suite->ctx.shootoutManager = &shootout;

--- a/test/test_core/shootout-manager-tests.hpp
+++ b/test/test_core/shootout-manager-tests.hpp
@@ -234,6 +234,68 @@ inline void mergedRingCoordinatorStandsDownToLowerMac(ShootoutManagerTests* suit
     EXPECT_EQ(suite->shootout->getBracketPendingAckCount(), 0u);
 }
 
+// BRACKET is a broadcast, so an unrelated ring's tournament reaches us. Before
+// this guard the lower-MAC stand-down ran first and wiped a live tournament into
+// a state nothing recovers: no coordinator, no bracket, phase still
+// MATCH_IN_PROGRESS, and every restart path gated on isCoordinator().
+inline void foreignRingBracketLeavesLiveTournamentIntact(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x09, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> me = {0x09, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> mine = {0x0A, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+    ON_CALL(*suite->device.mockPeerComms, sendData(testing::_, testing::_, testing::_, testing::_))
+        .WillByDefault(testing::Return(1));
+
+    suite->shootout->setLoopMembersForTest({me, mine});
+    suite->shootout->onRingClosed();
+    suite->shootout->startProposal();
+    suite->shootout->confirmLocal();
+    suite->shootout->onConfirmReceived(mine.data());
+    ASSERT_TRUE(suite->shootout->isCoordinator());
+    ASSERT_EQ(suite->shootout->getBracket().size(), 2u);
+
+    // A stranger ring, lower MAC than us, sharing no member with our bracket.
+    std::array<uint8_t, 6> stranger = {0x01, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> strangerPeer = {0x02, 0, 0, 0, 0, 0};
+    suite->shootout->onBracketReceived(stranger.data(), {stranger, strangerPeer}, 7);
+
+    EXPECT_TRUE(suite->shootout->isCoordinator());
+    EXPECT_EQ(suite->shootout->getBracket().size(), 2u);
+    EXPECT_EQ(memcmp(suite->shootout->getCoordinatorMac().data(), selfMac, 6), 0);
+}
+
+// An abort from retry exhaustion drops the ring anchor with the cables still in
+// place, and the RDC latch is edge-triggered so it never fires again. The
+// coordinator has to notice the ring is still there and re-claim, or the whole
+// ring waits for someone to unplug.
+inline void abortedRingReclaimsWhileStillCabled(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x01, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+    ON_CALL(*suite->device.mockPeerComms, sendData(testing::_, testing::_, testing::_, testing::_))
+        .WillByDefault(testing::Return(1));
+
+    FakeRingRemoteDeviceCoordinator ringRdc;
+    ringRdc.chainMembers = {{0x02, 0, 0, 0, 0, 0}};
+    ShootoutManager ringShootout(&suite->player, suite->device.wirelessManager, &ringRdc);
+
+    ringShootout.onRingClosed();
+    ASSERT_TRUE(ringShootout.shouldEnterProposal());
+    ASSERT_TRUE(ringShootout.isCoordinator());
+
+    // Abort back to idle without touching a cable: the RDC latch stays set and
+    // is edge-triggered, so nothing re-fires it.
+    ringShootout.resetToIdle();
+    ASSERT_FALSE(ringShootout.shouldEnterProposal());
+    ASSERT_EQ(ringRdc.getChainRole(), ChainRole::RING);
+
+    ringShootout.sync();
+
+    EXPECT_TRUE(ringShootout.shouldEnterProposal());
+    EXPECT_TRUE(ringShootout.isCoordinator());
+}
+
 // The head's roster fills from announces that can still be in flight when the
 // ring closes. Claiming on a one-entry roster must not run a solo tournament;
 // the re-announce round picks the real members up and play proceeds.

--- a/test/test_core/shootout-manager-tests.hpp
+++ b/test/test_core/shootout-manager-tests.hpp
@@ -23,15 +23,12 @@ public:
         ON_CALL(*device.mockPeerComms, getMacAddress()).WillByDefault(testing::Return(localMac));
 
         rdc.initialize(device.wirelessManager, device.serialManager, &device);
-        cdm = new ChainDuelManager(&player, device.wirelessManager, &rdc);
-        shootout = new ShootoutManager(&player, device.wirelessManager, &rdc, cdm);
+        shootout = new ShootoutManager(&player, device.wirelessManager, &rdc);
     }
 
     void TearDown() override {
         delete shootout;
         shootout = nullptr;
-        delete cdm;
-        cdm = nullptr;
         SimpleTimer::setPlatformClock(nullptr);
         delete fakeClock;
     }
@@ -39,7 +36,6 @@ public:
     MockDevice device;
     RemoteDeviceCoordinator rdc;
     Player player{"TEST", Allegiance::RESISTANCE, true};
-    ChainDuelManager* cdm = nullptr;
     ShootoutManager* shootout = nullptr;
     FakePlatformClock* fakeClock = nullptr;
     uint8_t localMac[6] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00};
@@ -83,8 +79,11 @@ inline void confirmRebroadcastsEverySecondDuringProposal(ShootoutManagerTests* s
     EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::PROPOSAL);
 }
 
-inline void coordinatorIsLowestMacAmongConfirmed(ShootoutManagerTests* suite) {
-    uint8_t selfMac[6] = {0x01, 0, 0, 0, 0, 0};  // self is the lowest → coordinator
+// Coordinator is whoever the RDC handed the ring-closed event to, not whoever
+// holds the lowest MAC. Self here is the lowest of the three and still is not
+// coordinator until the claim, which is the point of the redesign.
+inline void coordinatorIsTheRingClosureClaimant(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x01, 0, 0, 0, 0, 0};
     ON_CALL(*suite->device.mockPeerComms, getMacAddress())
         .WillByDefault(testing::Return(selfMac));
     ON_CALL(*suite->device.mockPeerComms, sendData(testing::_, testing::_, testing::_, testing::_))
@@ -97,9 +96,223 @@ inline void coordinatorIsLowestMacAmongConfirmed(ShootoutManagerTests* suite) {
     suite->shootout->confirmLocal();                   // adds self (0x01)
     suite->shootout->onConfirmReceived(a.data());      // adds 0x05
     suite->shootout->onConfirmReceived(c.data());      // adds 0x03
-    auto coord = suite->shootout->getCoordinatorMac();
-    EXPECT_EQ(memcmp(coord.data(), b.data(), 6), 0);
+    EXPECT_FALSE(suite->shootout->isCoordinator())
+        << "lowest MAC must not elect itself";
+
+    // The same device once its RDC reports the ring closed on its own in-jack.
+    suite->shootout->resetToIdle();
+    suite->shootout->onRingClosed();
+    suite->shootout->startProposal();
     EXPECT_TRUE(suite->shootout->isCoordinator());
+    EXPECT_EQ(memcmp(suite->shootout->getCoordinatorMac().data(), b.data(), 6), 0);
+}
+
+// The head announces the roster it just claimed, and that broadcast is the only
+// thing that opens the proposal window on the other members.
+inline void ringClosedClaimAnnouncesRosterToMembers(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x01, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+    std::vector<std::array<uint8_t, 6>> members = {
+        {0x01, 0, 0, 0, 0, 0}, {0x02, 0, 0, 0, 0, 0}, {0x03, 0, 0, 0, 0, 0}};
+    suite->shootout->setLoopMembersForTest(members);
+
+    std::vector<uint8_t> frame;
+    std::array<uint8_t, 6> destination{};
+    ON_CALL(*suite->device.mockPeerComms,
+            sendData(testing::_, PktType::kShootoutCommand, testing::_, testing::_))
+        .WillByDefault(testing::Invoke(
+            [&frame, &destination](const uint8_t* dst, PktType, const uint8_t* data,
+                                   const size_t len) {
+                memcpy(destination.data(), dst, 6);
+                frame.assign(data, data + len);
+                return 1;
+            }));
+
+    EXPECT_FALSE(suite->shootout->shouldEnterProposal());
+    suite->shootout->onRingClosed();
+    EXPECT_TRUE(suite->shootout->shouldEnterProposal());
+
+    EXPECT_EQ(memcmp(destination.data(), MockDevice::BROADCAST_MAC, 6), 0);
+    ASSERT_EQ(frame.size(), 3u + 6u * members.size());
+    EXPECT_EQ(frame[0], static_cast<uint8_t>(ShootoutCmd::RING_CLOSED));
+    EXPECT_EQ(frame[2], members.size());
+    for (size_t i = 0; i < members.size(); i++) {
+        EXPECT_EQ(memcmp(&frame[3 + 6 * i], members[i].data(), 6), 0) << "member " << i;
+    }
+}
+
+// A member has no local ring signal to poll in the post-BEACON design: the
+// coordinator's broadcast is what puts it into proposal, and a roster it is
+// absent from belongs to a neighbouring ring.
+inline void ringClosedBroadcastPromotesOnlyItsOwnMembers(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x02, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> me = {0x02, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> coord = {0x01, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> other = {0x03, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+    ON_CALL(*suite->device.mockPeerComms, sendData(testing::_, testing::_, testing::_, testing::_))
+        .WillByDefault(testing::Return(1));
+
+    std::array<uint8_t, 6> alienCoord = {0xA1, 0, 0, 0, 0, 0};
+    suite->shootout->onRingClosedReceived(alienCoord.data(), {alienCoord, other});
+    EXPECT_FALSE(suite->shootout->shouldEnterProposal());
+    EXPECT_TRUE(suite->shootout->getLoopMembers().empty());
+
+    suite->shootout->onRingClosedReceived(coord.data(), {coord, me, other});
+    EXPECT_TRUE(suite->shootout->shouldEnterProposal());
+    EXPECT_FALSE(suite->shootout->isCoordinator());
+    EXPECT_EQ(memcmp(suite->shootout->getCoordinatorMac().data(), coord.data(), 6), 0);
+    EXPECT_EQ(suite->shootout->getLoopMembers().size(), 3u);
+
+    // The member's own CONFIRM now has a ring to reach; an empty roster would
+    // have suppressed it at the broadcast guard.
+    suite->shootout->startProposal();
+    EXPECT_CALL(*suite->device.mockPeerComms,
+                sendData(testing::_, PktType::kShootoutCommand, testing::_, testing::_))
+        .Times(testing::AtLeast(1))
+        .WillRepeatedly(testing::Return(1));
+    suite->shootout->confirmLocal();
+}
+
+// The coordinator's roster is the RDC's head-only chain-member set plus itself:
+// getChainMembers() enumerates who announced to the head, never the head.
+inline void ringHeadLoopMembersComeFromRdcRoster(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x01, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+    ON_CALL(*suite->device.mockPeerComms, sendData(testing::_, testing::_, testing::_, testing::_))
+        .WillByDefault(testing::Return(1));
+
+    FakeRingRemoteDeviceCoordinator ringRdc;
+    ringRdc.chainMembers = {{0x02, 0, 0, 0, 0, 0}, {0x03, 0, 0, 0, 0, 0}};
+    ShootoutManager ringShootout(&suite->player, suite->device.wirelessManager, &ringRdc);
+
+    std::vector<std::array<uint8_t, 6>> members = ringShootout.getLoopMembers();
+    ASSERT_EQ(members.size(), 3u);
+    EXPECT_EQ(memcmp(members[2].data(), selfMac, 6), 0);
+
+    // A device the RDC does not treat as the ring's roster authority has nothing
+    // to read and falls back to whatever the coordinator broadcast (nothing yet).
+    ringRdc.chainRole = ChainRole::CHILD;
+    EXPECT_TRUE(ringShootout.getLoopMembers().empty());
+}
+
+// Two rings that each closed and claimed a head, then got cabled together. The
+// higher-MAC head must drop its own bracket, not just the anchor, or both sides
+// keep running separate tournaments over one ring.
+inline void mergedRingCoordinatorStandsDownToLowerMac(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x09, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> me = {0x09, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> mine = {0x0A, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> rival = {0x01, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+    ON_CALL(*suite->device.mockPeerComms, sendData(testing::_, testing::_, testing::_, testing::_))
+        .WillByDefault(testing::Return(1));
+
+    suite->shootout->setLoopMembersForTest({me, mine});
+    suite->shootout->onRingClosed();
+    suite->shootout->startProposal();
+    suite->shootout->confirmLocal();
+    suite->shootout->onConfirmReceived(mine.data());
+    ASSERT_TRUE(suite->shootout->isCoordinator());
+    ASSERT_EQ(suite->shootout->getBracket().size(), 2u);
+
+    // A higher-MAC rival coordinator loses; ours survives untouched.
+    std::array<uint8_t, 6> higher = {0xF0, 0, 0, 0, 0, 0};
+    suite->shootout->onBracketReceived(higher.data(), {higher, me}, 4);
+    EXPECT_TRUE(suite->shootout->isCoordinator());
+    EXPECT_EQ(suite->shootout->getBracket().size(), 2u);
+
+    // A lower-MAC one wins: we demote and adopt its bracket.
+    suite->shootout->onBracketReceived(rival.data(), {rival, me, mine}, 5);
+    EXPECT_FALSE(suite->shootout->isCoordinator());
+    EXPECT_EQ(memcmp(suite->shootout->getCoordinatorMac().data(), rival.data(), 6), 0);
+    EXPECT_EQ(suite->shootout->getBracket().size(), 3u);
+    EXPECT_EQ(suite->shootout->getBracketPendingAckCount(), 0u);
+}
+
+// The head's roster fills from announces that can still be in flight when the
+// ring closes. Claiming on a one-entry roster must not run a solo tournament;
+// the re-announce round picks the real members up and play proceeds.
+inline void laggingRosterDoesNotRunSoloTournament(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x01, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> me = {0x01, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> peer = {0x02, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+    std::vector<uint8_t> lastRingClosed;
+    ON_CALL(*suite->device.mockPeerComms,
+            sendData(testing::_, PktType::kShootoutCommand, testing::_, testing::_))
+        .WillByDefault(testing::Invoke(
+            [&lastRingClosed](const uint8_t*, PktType, const uint8_t* data, const size_t len) {
+                if (data[0] == static_cast<uint8_t>(ShootoutCmd::RING_CLOSED)) {
+                    lastRingClosed.assign(data, data + len);
+                }
+                return 1;
+            }));
+
+    suite->shootout->setLoopMembersForTest({me});
+    suite->shootout->onRingClosed();
+    suite->shootout->startProposal();
+    suite->shootout->confirmLocal();
+    EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::PROPOSAL);
+    EXPECT_TRUE(suite->shootout->getBracket().empty());
+
+    // The absent member's announce lands; the next re-announce round picks it up
+    // and the frame it sends now names that member, which is what lets it in.
+    suite->shootout->setLoopMembersForTest({me, peer});
+    suite->fakeClock->advance(ShootoutManager::kConfirmRebroadcastMs + 100);
+    suite->shootout->sync();
+    ASSERT_EQ(lastRingClosed.size(), 3u + 6u * 2u);
+    EXPECT_EQ(memcmp(&lastRingClosed[9], peer.data(), 6), 0);
+
+    suite->shootout->onConfirmReceived(peer.data());
+    EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::BRACKET_REVEAL);
+    EXPECT_EQ(suite->shootout->getBracket().size(), 2u);
+}
+
+// RING_CLOSED carries no ack, so a member that missed the frame would sit in
+// idle forever while the coordinator blocks on its confirm. The coordinator
+// re-announces on the same 1Hz cadence as CONFIRM until the roster is complete.
+inline void ringClosedReannouncesWhileMembersUnconfirmed(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x01, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> me = {0x01, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> peer = {0x02, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+
+    int ringClosedFrames = 0;
+    ON_CALL(*suite->device.mockPeerComms,
+            sendData(testing::_, PktType::kShootoutCommand, testing::_, testing::_))
+        .WillByDefault(testing::Invoke(
+            [&ringClosedFrames](const uint8_t*, PktType, const uint8_t* data, const size_t) {
+                if (data[0] == static_cast<uint8_t>(ShootoutCmd::RING_CLOSED)) ringClosedFrames++;
+                return 1;
+            }));
+
+    suite->shootout->setLoopMembersForTest({me, peer});
+    suite->shootout->onRingClosed();
+    suite->shootout->startProposal();
+    ASSERT_EQ(ringClosedFrames, 1);
+
+    for (int i = 0; i < 30; i++) {
+        suite->fakeClock->advance(100);
+        suite->shootout->sync();
+    }
+    EXPECT_GT(ringClosedFrames, 1);
+
+    // Once everyone has confirmed there is nobody left to reach.
+    suite->shootout->confirmLocal();
+    suite->shootout->onConfirmReceived(peer.data());
+    int afterConfirmed = ringClosedFrames;
+    for (int i = 0; i < 30; i++) {
+        suite->fakeClock->advance(100);
+        suite->shootout->sync();
+    }
+    EXPECT_EQ(ringClosedFrames, afterConfirmed);
 }
 
 inline void bracketSizeAndByeMatchMemberCount(ShootoutManagerTests* suite) {
@@ -113,6 +326,7 @@ inline void bracketSizeAndByeMatchMemberCount(ShootoutManagerTests* suite) {
         for (uint8_t i = 1; i <= memberCount; i++) members.push_back({i, 0, 0, 0, 0, 0});
         suite->shootout->setLoopMembersForTest(members);
         suite->shootout->resetToIdle();
+        suite->shootout->onRingClosed();
         suite->shootout->startProposal();
         suite->shootout->confirmLocal();
         for (auto& m : members) suite->shootout->onConfirmReceived(m.data());
@@ -132,6 +346,7 @@ inline void receivingAllConfirmsAdvancesToBracketReveal(ShootoutManagerTests* su
     std::array<uint8_t, 6> m2 = {0x02, 0, 0, 0, 0, 0};
     std::array<uint8_t, 6> m3 = {0x03, 0, 0, 0, 0, 0};
     suite->shootout->setLoopMembersForTest({m1, m2, m3});
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     suite->shootout->confirmLocal();
     suite->shootout->onConfirmReceived(m2.data());
@@ -162,7 +377,9 @@ inline void coordinatorBroadcastsBracketOnAdvance(ShootoutManagerTests* suite) {
                 return 1;
             }));
 
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
+    destinations.clear();  // drop the claim's own RING_CLOSED frame
     for (auto& m : members) suite->shootout->onConfirmReceived(m.data());
     suite->shootout->confirmLocal();
     EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::BRACKET_REVEAL);
@@ -182,6 +399,7 @@ inline void bracketAckClearsPendingForThatPeer(ShootoutManagerTests* suite) {
         {0x01, 0, 0, 0, 0, 0}, {0x02, 0, 0, 0, 0, 0}, {0x03, 0, 0, 0, 0, 0}
     };
     suite->shootout->setLoopMembersForTest(members);
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     for (auto& m : members) suite->shootout->onConfirmReceived(m.data());
     suite->shootout->confirmLocal();
@@ -204,6 +422,7 @@ inline void bracketRetriesThreeTimesThenAborts(ShootoutManagerTests* suite) {
         {0x01, 0, 0, 0, 0, 0}, {0x02, 0, 0, 0, 0, 0}
     };
     suite->shootout->setLoopMembersForTest(members);
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     for (auto& m : members) suite->shootout->onConfirmReceived(m.data());
     suite->shootout->confirmLocal();
@@ -226,6 +445,7 @@ inline void matchStartGatedOnAllBracketAcks(ShootoutManagerTests* suite) {
     };
     suite->shootout->setLoopMembersForTest(members);
 
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     for (auto& m : members) suite->shootout->onConfirmReceived(m.data());
     suite->shootout->confirmLocal();
@@ -277,7 +497,7 @@ inline void nonCoordinatorReceivingMatchStartIdentifiesRole(ShootoutManagerTests
     suite->shootout->onConfirmReceived(me.data());
     suite->shootout->onConfirmReceived(coord.data());
     suite->shootout->onConfirmReceived(other.data());
-    suite->shootout->onBracketReceived({me, coord, other}, 1);
+    suite->shootout->onBracketReceived(coord.data(), {me, coord, other}, 1);
     EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::BRACKET_REVEAL);
 
     // Self in the duelist pair -> isLocalDuelist + opponentMac populated.
@@ -305,7 +525,7 @@ inline void winnerBroadcastsMatchResultAndAdvancesLocally(ShootoutManagerTests* 
     suite->shootout->onConfirmReceived(coord.data());
     suite->shootout->onConfirmReceived(me.data());
     suite->shootout->onConfirmReceived(opMac.data());
-    suite->shootout->onBracketReceived({me, opMac, coord}, 1);
+    suite->shootout->onBracketReceived(coord.data(), {me, opMac, coord}, 1);
     suite->shootout->onMatchStartReceived(me.data(), opMac.data(), 0, 2);
 
     suite->shootout->reportLocalWin();
@@ -329,7 +549,7 @@ inline void matchResultReceivedAdvancesLocalBracket(ShootoutManagerTests* suite)
     for (auto& m : std::vector<std::array<uint8_t,6>>{coord, aMac, bMac, me}) {
         suite->shootout->onConfirmReceived(m.data());
     }
-    suite->shootout->onBracketReceived({aMac, bMac, coord, me}, 1);
+    suite->shootout->onBracketReceived(coord.data(), {aMac, bMac, coord, me}, 1);
     suite->shootout->onMatchStartReceived(aMac.data(), bMac.data(), 0, 2);
     suite->shootout->onMatchResultReceived(aMac.data(), bMac.data(), 0, 3, aMac.data());
     EXPECT_TRUE(suite->shootout->isEliminated(bMac.data()));
@@ -345,6 +565,7 @@ inline void drawWatchdogReplaysMatchStart(ShootoutManagerTests* suite) {
     ON_CALL(*suite->device.mockPeerComms, sendData(testing::_, testing::_, testing::_, testing::_))
         .WillByDefault(testing::Return(1));
     suite->shootout->setLoopMembersForTest({me, opMac});
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     suite->shootout->onConfirmReceived(me.data());
     suite->shootout->onConfirmReceived(opMac.data());
@@ -378,7 +599,7 @@ inline void peerLostCoordinatorAborts(ShootoutManagerTests* suite) {
     suite->shootout->onConfirmReceived(coord.data());
     suite->shootout->onConfirmReceived(me.data());
     suite->shootout->onConfirmReceived(other.data());
-    suite->shootout->onBracketReceived({me, other, coord}, 1);
+    suite->shootout->onBracketReceived(coord.data(), {me, other, coord}, 1);
     suite->shootout->onMatchStartReceived(me.data(), other.data(), 0, 2);
     suite->shootout->onPeerLostReceived(coord.data());
     EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::ABORTED);
@@ -398,7 +619,7 @@ inline void peerLostActiveDuelistAborts(ShootoutManagerTests* suite) {
     suite->shootout->onConfirmReceived(coord.data());
     suite->shootout->onConfirmReceived(me.data());
     suite->shootout->onConfirmReceived(other.data());
-    suite->shootout->onBracketReceived({me, other, coord}, 1);
+    suite->shootout->onBracketReceived(coord.data(), {me, other, coord}, 1);
     suite->shootout->onMatchStartReceived(me.data(), other.data(), 0, 2);
     suite->shootout->onPeerLostReceived(other.data());
     EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::ABORTED);
@@ -415,6 +636,7 @@ inline void peerLostSpectatorAborts(ShootoutManagerTests* suite) {
     ON_CALL(*suite->device.mockPeerComms, sendData(testing::_, testing::_, testing::_, testing::_))
         .WillByDefault(testing::Return(1));
     suite->shootout->setLoopMembersForTest({me, a, b, c});
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     for (auto& m : std::vector<std::array<uint8_t,6>>{me, a, b, c}) {
         suite->shootout->onConfirmReceived(m.data());
@@ -457,6 +679,7 @@ inline void finalMatchResultTriggersTournamentEnd(ShootoutManagerTests* suite) {
     ON_CALL(*suite->device.mockPeerComms, sendData(testing::_, testing::_, testing::_, testing::_))
         .WillByDefault(testing::Return(1));
     suite->shootout->setLoopMembersForTest({me, opMac});
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     suite->shootout->onConfirmReceived(me.data());
     suite->shootout->onConfirmReceived(opMac.data());
@@ -489,6 +712,7 @@ inline void startProposalClearsAllPriorTournamentState(ShootoutManagerTests* sui
 
     // Tournament 1
     suite->shootout->setLoopMembersForTest({me, opMac});
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     suite->shootout->onConfirmReceived(me.data());
     suite->shootout->onConfirmReceived(opMac.data());
@@ -548,6 +772,7 @@ inline void duplicateMatchResultDoesNotDoubleAdvance(ShootoutManagerTests* suite
         sendData(testing::_, testing::_, testing::_, testing::_))
         .WillByDefault(testing::Return(1));
     suite->shootout->setLoopMembersForTest({me, b, c, d});
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     for (auto& m : {me, b, c, d}) suite->shootout->onConfirmReceived(m.data());
     uint8_t bSeq = suite->shootout->getLastBracketSeqId();
@@ -607,6 +832,7 @@ inline void tournamentEndRetriesUntilAcked(ShootoutManagerTests* suite) {
             }));
 
     suite->shootout->setLoopMembersForTest({me, opMac});
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     suite->shootout->onConfirmReceived(me.data());
     suite->shootout->onConfirmReceived(opMac.data());
@@ -659,6 +885,7 @@ inline void matchResultRetriesUntilAcked(ShootoutManagerTests* suite) {
             }));
 
     suite->shootout->setLoopMembersForTest({me, opMac, spec});
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     suite->shootout->onConfirmReceived(me.data());
     suite->shootout->onConfirmReceived(opMac.data());
@@ -724,7 +951,7 @@ inline void isHunterRestoredAfterTournament(ShootoutManagerTests* suite) {
     suite->shootout->onConfirmReceived(me.data());
     suite->shootout->onConfirmReceived(opMac.data());
     suite->shootout->onConfirmReceived(third.data());
-    suite->shootout->onBracketReceived({me, opMac, third}, 1);
+    suite->shootout->onBracketReceived(opMac.data(), {me, opMac, third}, 1);
     suite->shootout->onMatchStartReceived(me.data(), opMac.data(), 0, 2);
     suite->player.setIsHunter(!originalIsHunter);
     suite->shootout->onPeerLostReceived(opMac.data());
@@ -746,6 +973,7 @@ inline void localRDCDisconnectIsIdempotent(ShootoutManagerTests* suite) {
         .WillByDefault(testing::Return(selfMac));
 
     suite->shootout->setLoopMembersForTest({me, a, b, c});
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     for (auto& m : std::vector<std::array<uint8_t,6>>{me, a, b, c}) {
         suite->shootout->onConfirmReceived(m.data());
@@ -905,7 +1133,9 @@ inline void bracketFanOutIsOneFrameBeyondPeerTable(ShootoutManagerTests* suite) 
                 return 1;
             }));
 
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
+    destinations.clear();  // drop the claim's own RING_CLOSED frame
     for (auto& m : members)
         suite->shootout->onConfirmReceived(m.data());
 
@@ -929,6 +1159,7 @@ inline void bracketRetryIsOneFramePerRound(ShootoutManagerTests* suite) {
             sendData(testing::_, testing::_, testing::_, testing::_))
         .WillByDefault(testing::Return(1));
 
+    suite->shootout->onRingClosed();
     suite->shootout->startProposal();
     for (auto& m : members)
         suite->shootout->onConfirmReceived(m.data());
@@ -968,7 +1199,9 @@ inline void foreignBracketIsNeitherAdoptedNorAcked(ShootoutManagerTests* suite) 
                 sendData(testing::_, PktType::kShootoutCommandAck, testing::_, testing::_))
         .Times(0);
 
-    suite->shootout->onBracketReceived({{0x01, 0, 0, 0, 0, 0},
+    std::array<uint8_t, 6> alienCoord = {0x01, 0, 0, 0, 0, 0};
+    suite->shootout->onBracketReceived(alienCoord.data(),
+                                       {alienCoord,
                                         {0x02, 0, 0, 0, 0, 0},
                                         {0x03, 0, 0, 0, 0, 0}},
                                        1);
@@ -996,7 +1229,7 @@ inline void strayRingCommandsLeaveTournamentUntouched(ShootoutManagerTests* suit
     suite->shootout->startProposal();
     for (auto& m : {coord, me, other})
         suite->shootout->onConfirmReceived(m.data());
-    suite->shootout->onBracketReceived({me, other, coord}, 1);
+    suite->shootout->onBracketReceived(coord.data(), {me, other, coord}, 1);
     suite->shootout->onMatchStartReceived(me.data(), other.data(), 0, 2);
     ASSERT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::MATCH_IN_PROGRESS);
     ASSERT_EQ(suite->shootout->getCurrentMatchIndex(), 0);

--- a/test/test_core/shootout-manager-tests.hpp
+++ b/test/test_core/shootout-manager-tests.hpp
@@ -80,8 +80,8 @@ inline void confirmRebroadcastsEverySecondDuringProposal(ShootoutManagerTests* s
 }
 
 // Coordinator is whoever the RDC handed the ring-closed event to, not whoever
-// holds the lowest MAC. Self here is the lowest of the three and still is not
-// coordinator until the claim, which is the point of the redesign.
+// holds the lowest MAC: self here is the lowest of the three and still is not
+// coordinator until the claim.
 inline void coordinatorIsTheRingClosureClaimant(ShootoutManagerTests* suite) {
     uint8_t selfMac[6] = {0x01, 0, 0, 0, 0, 0};
     ON_CALL(*suite->device.mockPeerComms, getMacAddress())
@@ -142,9 +142,9 @@ inline void ringClosedClaimAnnouncesRosterToMembers(ShootoutManagerTests* suite)
     }
 }
 
-// A member has no local ring signal to poll in the post-BEACON design: the
-// coordinator's broadcast is what puts it into proposal, and a roster it is
-// absent from belongs to a neighbouring ring.
+// A member has no local ring signal to poll: the coordinator's broadcast is
+// what puts it into proposal, and a roster it is absent from belongs to a
+// neighbouring ring.
 inline void ringClosedBroadcastPromotesOnlyItsOwnMembers(ShootoutManagerTests* suite) {
     uint8_t selfMac[6] = {0x02, 0, 0, 0, 0, 0};
     std::array<uint8_t, 6> me = {0x02, 0, 0, 0, 0, 0};
@@ -261,8 +261,8 @@ inline void laggingRosterDoesNotRunSoloTournament(ShootoutManagerTests* suite) {
     EXPECT_EQ(suite->shootout->getPhase(), ShootoutManager::Phase::PROPOSAL);
     EXPECT_TRUE(suite->shootout->getBracket().empty());
 
-    // The absent member's announce lands; the next re-announce round picks it up
-    // and the frame it sends now names that member, which is what lets it in.
+    // The absent member's announce lands, and the next re-announce round names it
+    // in the frame.
     suite->shootout->setLoopMembersForTest({me, peer});
     suite->fakeClock->advance(ShootoutManager::kConfirmRebroadcastMs + 100);
     suite->shootout->sync();

--- a/test/test_core/shootout-manager-tests.hpp
+++ b/test/test_core/shootout-manager-tests.hpp
@@ -263,6 +263,15 @@ inline void foreignRingBracketLeavesLiveTournamentIntact(ShootoutManagerTests* s
     EXPECT_TRUE(suite->shootout->isCoordinator());
     EXPECT_EQ(suite->shootout->getBracket().size(), 2u);
     EXPECT_EQ(memcmp(suite->shootout->getCoordinatorMac().data(), selfMac, 6), 0);
+
+    // The harder case: a lower-MAC stranger whose bracket claims one of ours but
+    // not us. Standing down to it drops our bracket and adopts nothing, which is
+    // worse than ignoring it — there is no coordinator left to restart anything.
+    suite->shootout->onBracketReceived(stranger.data(), {stranger, strangerPeer, mine}, 8);
+
+    EXPECT_TRUE(suite->shootout->isCoordinator());
+    EXPECT_EQ(suite->shootout->getBracket().size(), 2u);
+    EXPECT_EQ(memcmp(suite->shootout->getCoordinatorMac().data(), selfMac, 6), 0);
 }
 
 // An abort from retry exhaustion drops the ring anchor with the cables still in
@@ -284,16 +293,47 @@ inline void abortedRingReclaimsWhileStillCabled(ShootoutManagerTests* suite) {
     ASSERT_TRUE(ringShootout.shouldEnterProposal());
     ASSERT_TRUE(ringShootout.isCoordinator());
 
-    // Abort back to idle without touching a cable: the RDC latch stays set and
-    // is edge-triggered, so nothing re-fires it.
+    // Abort back to idle without touching a cable. The RDC latch stays set and is
+    // edge-triggered, so it will never announce this ring again.
     ringShootout.resetToIdle();
-    ASSERT_FALSE(ringShootout.shouldEnterProposal());
+    ASSERT_FALSE(ringShootout.isCoordinator());
     ASSERT_EQ(ringRdc.getChainRole(), ChainRole::RING);
 
-    ringShootout.sync();
+    // Idle polls this predicate every tick and mounts the proposal on it. Both
+    // halves have to work, so drive those rather than the manager's sync().
+    ASSERT_TRUE(ringShootout.shouldEnterProposal());
+    ringShootout.startProposal();
 
-    EXPECT_TRUE(ringShootout.shouldEnterProposal());
     EXPECT_TRUE(ringShootout.isCoordinator());
+    EXPECT_EQ(ringShootout.getPhase(), ShootoutManager::Phase::PROPOSAL);
+}
+
+// Both heads of a merging pair latch and both announce. Adopting whichever frame
+// lands last leaves A following B while B follows A, so nobody builds a bracket
+// and every member parks in BracketReveal with the cables still in.
+inline void mergedRingClaimantsSettleOnLowerMac(ShootoutManagerTests* suite) {
+    uint8_t selfMac[6] = {0x09, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> me = {0x09, 0, 0, 0, 0, 0};
+    std::array<uint8_t, 6> mine = {0x0A, 0, 0, 0, 0, 0};
+    ON_CALL(*suite->device.mockPeerComms, getMacAddress())
+        .WillByDefault(testing::Return(selfMac));
+    ON_CALL(*suite->device.mockPeerComms, sendData(testing::_, testing::_, testing::_, testing::_))
+        .WillByDefault(testing::Return(1));
+
+    suite->shootout->setLoopMembersForTest({me, mine});
+    suite->shootout->onRingClosed();
+    ASSERT_TRUE(suite->shootout->isCoordinator());
+
+    // A higher-MAC rival head announces the merged ring; ours stands.
+    std::array<uint8_t, 6> higher = {0xF0, 0, 0, 0, 0, 0};
+    suite->shootout->onRingClosedReceived(higher.data(), {higher, me, mine});
+    EXPECT_TRUE(suite->shootout->isCoordinator());
+
+    // A lower-MAC one wins, and we follow it.
+    std::array<uint8_t, 6> lower = {0x01, 0, 0, 0, 0, 0};
+    suite->shootout->onRingClosedReceived(lower.data(), {lower, me, mine});
+    EXPECT_FALSE(suite->shootout->isCoordinator());
+    EXPECT_EQ(memcmp(suite->shootout->getCoordinatorMac().data(), lower.data(), 6), 0);
 }
 
 // The head's roster fills from announces that can still be in flight when the

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1627,6 +1627,7 @@ TEST_F(ShootoutManagerTests, ringHeadLoopMembersComeFromRdcRoster) { ringHeadLoo
 TEST_F(ShootoutManagerTests, mergedRingCoordinatorStandsDownToLowerMac) { mergedRingCoordinatorStandsDownToLowerMac(this); }
 TEST_F(ShootoutManagerTests, foreignRingBracketLeavesLiveTournamentIntact) { foreignRingBracketLeavesLiveTournamentIntact(this); }
 TEST_F(ShootoutManagerTests, abortedRingReclaimsWhileStillCabled) { abortedRingReclaimsWhileStillCabled(this); }
+TEST_F(ShootoutManagerTests, mergedRingClaimantsSettleOnLowerMac) { mergedRingClaimantsSettleOnLowerMac(this); }
 TEST_F(ShootoutManagerTests, ringClosedReannouncesWhileMembersUnconfirmed) { ringClosedReannouncesWhileMembersUnconfirmed(this); }
 TEST_F(ShootoutManagerTests, laggingRosterDoesNotRunSoloTournament) { laggingRosterDoesNotRunSoloTournament(this); }
 TEST_F(ShootoutManagerTests, bracketSizeAndByeMatchMemberCount) { bracketSizeAndByeMatchMemberCount(this); }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1625,6 +1625,8 @@ TEST_F(ShootoutManagerTests, ringClosedClaimAnnouncesRosterToMembers) { ringClos
 TEST_F(ShootoutManagerTests, ringClosedBroadcastPromotesOnlyItsOwnMembers) { ringClosedBroadcastPromotesOnlyItsOwnMembers(this); }
 TEST_F(ShootoutManagerTests, ringHeadLoopMembersComeFromRdcRoster) { ringHeadLoopMembersComeFromRdcRoster(this); }
 TEST_F(ShootoutManagerTests, mergedRingCoordinatorStandsDownToLowerMac) { mergedRingCoordinatorStandsDownToLowerMac(this); }
+TEST_F(ShootoutManagerTests, foreignRingBracketLeavesLiveTournamentIntact) { foreignRingBracketLeavesLiveTournamentIntact(this); }
+TEST_F(ShootoutManagerTests, abortedRingReclaimsWhileStillCabled) { abortedRingReclaimsWhileStillCabled(this); }
 TEST_F(ShootoutManagerTests, ringClosedReannouncesWhileMembersUnconfirmed) { ringClosedReannouncesWhileMembersUnconfirmed(this); }
 TEST_F(ShootoutManagerTests, laggingRosterDoesNotRunSoloTournament) { laggingRosterDoesNotRunSoloTournament(this); }
 TEST_F(ShootoutManagerTests, bracketSizeAndByeMatchMemberCount) { bracketSizeAndByeMatchMemberCount(this); }

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -1620,7 +1620,13 @@ TEST_F(ChainDuelMultiDeviceFixture, shootoutFourDeviceTwoTournamentsBackToBack) 
 // SHOOTOUT MANAGER TESTS
 // ============================================
 
-TEST_F(ShootoutManagerTests, coordinatorIsLowestMacAmongConfirmed) { coordinatorIsLowestMacAmongConfirmed(this); }
+TEST_F(ShootoutManagerTests, coordinatorIsTheRingClosureClaimant) { coordinatorIsTheRingClosureClaimant(this); }
+TEST_F(ShootoutManagerTests, ringClosedClaimAnnouncesRosterToMembers) { ringClosedClaimAnnouncesRosterToMembers(this); }
+TEST_F(ShootoutManagerTests, ringClosedBroadcastPromotesOnlyItsOwnMembers) { ringClosedBroadcastPromotesOnlyItsOwnMembers(this); }
+TEST_F(ShootoutManagerTests, ringHeadLoopMembersComeFromRdcRoster) { ringHeadLoopMembersComeFromRdcRoster(this); }
+TEST_F(ShootoutManagerTests, mergedRingCoordinatorStandsDownToLowerMac) { mergedRingCoordinatorStandsDownToLowerMac(this); }
+TEST_F(ShootoutManagerTests, ringClosedReannouncesWhileMembersUnconfirmed) { ringClosedReannouncesWhileMembersUnconfirmed(this); }
+TEST_F(ShootoutManagerTests, laggingRosterDoesNotRunSoloTournament) { laggingRosterDoesNotRunSoloTournament(this); }
 TEST_F(ShootoutManagerTests, bracketSizeAndByeMatchMemberCount) { bracketSizeAndByeMatchMemberCount(this); }
 TEST_F(ShootoutManagerTests, localConfirmIsRecordedAndBroadcast) { localConfirmIsRecordedAndBroadcast(this); }
 TEST_F(ShootoutManagerTests, receivingAllConfirmsAdvancesToBracketReveal) { receivingAllConfirmsAdvancesToBracketReveal(this); }


### PR DESCRIPTION
Closes #169.

The coordinator is now the structural head: `ShootoutManager` subscribes to `RDC::setOnRingClosed` via Quickdraw's constructor and claims on that callback with no election. `getCoordinatorMac()` is purely the claim — the `lowestMacIn(confirmedSet)` fallback and `lowestMacIn()` itself are gone. `buildLoopMemberSet` reads `rdc->getChainMembers()`, and the `ChainDuelManager*` dependency is gone (`ChainDuelManager::isLoop()` itself is untouched).

## Where to look

**RING_CLOSED carries the member list rather than being a bare signal.** `getChainMembers()` is head-only and BEACON is gone, so a follower has no other source for the ring roster — and without one, `sendLocalConfirm`'s broadcast guard suppresses every follower CONFIRM. The payload reuses the BRACKET shape, carries seqId 0 with no ack, and relies instead on a coordinator-side re-announce on the existing CONFIRM cadence that re-reads the roster each round, so a ConnectionAnnounce still in flight at closure still gets its member in.

**Deleting the min-MAC fallback turned the old `if (isCoordinator()) return;` at the top of `onBracketReceived` into a hazard**, since it would have split-brained two merged rings. It became a real lower-MAC stand-down that also drops the self-built bracket, and `onBracketReceived` gained a `fromMac` parameter to anchor on the actual sender.

## Two defects found in review and fixed here

**A foreign ring's bracket wiped a live tournament, unrecoverably.** BRACKET is a broadcast, so a tournament two rings away lands in `onBracketReceived`. The stand-down block ran *before* the roster-membership check, so a lower-MAC stranger cleared `coordinatorMac`, `bracket`, `currentRound`, `eliminated`, both pending-ack sets and `currentMatchIndex` — and then the membership check bailed. Nothing recovers that: phase stays `MATCH_IN_PROGRESS`, `isCoordinator()` is false, and `maybeStartNextMatch`, the match-start watchdog and `onRingClosed` are all gated against it.

Fixed by requiring the bracket to concern us at all before anything is touched: it must either name us or share a member with our own bracket. Overlap is what distinguishes a merge from a stranger — merged rings share the members whose cables joined them — so the tiebreaker still fires where it is meant to, which a plain membership hoist would not have preserved.

**The ring-closed latch had no re-arm.** `ringClosedCallback()` fires only on the RDC's `!ringLatched -> ringLatched` edge, while an abort from bracket-ack exhaustion or an inbound ABORT clears `ringMembers` with the cables untouched. `shouldEnterProposal()` was then false forever and the coordinator's re-announce is gated on `phase == PROPOSAL && isCoordinator()`, so the whole ring sat idle until somebody physically unplugged. `sync()` now re-claims when the phase is IDLE, the roster is empty and the RDC still reports `ChainRole::RING`. That fires on exactly one device — the RDC only latches RING where the device's own MAC came back around — and the members follow its re-announce.

Both are covered by new tests, each falsified by reverting exactly its own mechanism and confirming only that test fails.

## Behaviour worth weighing

`resetToIdle()` split into a tournament-state wipe plus the ring anchor, and `startProposal()` only does the former, because the closure that drove the mount set that anchor moments earlier. `allMembersConfirmed()` now needs two members, so a roster that has not converged cannot run a one-device tournament that declares itself the winner.

## Not done

`ChainDuelManager::isSupporter()` and `isChampion()` still call `isLoop()`, which is unchanged and still correct on this base. That matters for #160: deleting the daisy-chain announcements collapses `getPortState` to one MAC per jack, and `isLoop()` intersects the two jacks' peer sets, so it can only be true for a two-device ring. This PR removes the Idle gate's dependency on it but not the other two. #160 will need `isLoop()` re-pointed at the RDC ring latch.

Seven test bodies became follower cases needing only the new `fromMac`; fifteen became explicit coordinator claims; `coordinatorIsLowestMacAmongConfirmed` was rewritten and renamed to assert the lowest MAC does *not* elect itself. No test was weakened or deleted. Not hardware validated. `Closes #169` will not fire — the base is not the default branch.
